### PR TITLE
Fix: Docs Build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "is-absolute-url": "^2.1.0",
     "mdx-docs": "^1.0.0-9",
     "pcln-design-system": "^2.3.0-2",
+    "pcln-icons": "^2.0.9",
     "pcln-modal": "^2.0.4",
     "pcln-slider": "2.0.1",
     "prop-types": "^15.6.2",

--- a/docs/pages/iconography.js
+++ b/docs/pages/iconography.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Flex, Heading, Text, Icon, BlockLink } from 'pcln-design-system'
-import icons from 'pcln-design-system/icons.json'
+import * as icons from 'pcln-icons/lib/index'
 import { PageTitle, Description, Code } from '../src/components'
 
 const iconNames = Object.keys(icons)


### PR DESCRIPTION
Fixing the docs using the old icons from core, to use pcln-icons instead.