### PR TITLE
Fix broken Popover by changing innerRefs to refs

### DIFF
--- a/packages/popover/src/Arrow.js
+++ b/packages/popover/src/Arrow.js
@@ -12,7 +12,7 @@ const PopoverArrow = ({
 }) => (
   <Arrow
     className={className}
-    innerRef={arrowProps.ref}
+    ref={arrowProps.ref}
     style={arrowProps.style}
     data-placement={placement}
     theme={theme}

--- a/packages/popover/src/Arrow.js
+++ b/packages/popover/src/Arrow.js
@@ -12,6 +12,7 @@ const PopoverArrow = ({
 }) => (
   <Arrow
     className={className}
+    innerRef={arrowProps.ref}
     ref={arrowProps.ref}
     style={arrowProps.style}
     data-placement={placement}

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -59,11 +59,13 @@ class Popover extends Component {
         <Reference>
           {({ ref }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
-            <InlineContainer ref={ref}>
+            // Styled-Components v4 uses regular refs, keep innerRef for v3 peer dependency
+            <InlineContainer innerRef={ref} ref={ref}>
               {// Clone element to pass down toggle event so it can be used directly from children as needed
               React.cloneElement(this.props.children, {
                 'aria-label': 'Click to open popover with more information',
                 onClick: evt => this.handleToggle(evt, isPopoverOpen),
+                innerRef: this.triggerRef,
                 ref: this.triggerRef
               })}
             </InlineContainer>

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -59,13 +59,12 @@ class Popover extends Component {
         <Reference>
           {({ ref }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
-            <InlineContainer innerRef={ref}>
+            <InlineContainer ref={ref}>
               {// Clone element to pass down toggle event so it can be used directly from children as needed
               React.cloneElement(this.props.children, {
                 'aria-label': 'Click to open popover with more information',
                 onClick: evt => this.handleToggle(evt, isPopoverOpen),
-                innerRef: this.triggerRef, // Need to use inner ref for DS core components using styled components v4
-                ref: this.triggerRef // Additionally need to add ref, in case native element is used as trigger
+                ref: this.triggerRef
               })}
             </InlineContainer>
           )}

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -59,7 +59,6 @@ class Popover extends Component {
         <Reference>
           {({ ref }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
-            // Styled-Components v4 uses regular refs, keep innerRef for v3 peer dependency
             <InlineContainer innerRef={ref} ref={ref}>
               {// Clone element to pass down toggle event so it can be used directly from children as needed
               React.cloneElement(this.props.children, {

--- a/packages/popover/src/PopoverContent.js
+++ b/packages/popover/src/PopoverContent.js
@@ -68,7 +68,6 @@ class PopoverContent extends Component {
         >
           {({ placement, ref, style, arrowProps }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
-            // Styled-Components v4 uses regular refs, keep innerRef for v3 peer dependency
             <PopperGuide
               className={this.props.className}
               innerRef={ref}

--- a/packages/popover/src/PopoverContent.js
+++ b/packages/popover/src/PopoverContent.js
@@ -69,12 +69,8 @@ class PopoverContent extends Component {
           {({ placement, ref, style, arrowProps }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
             <PopperGuide
-              /*
-               * NOTE: InnerRef has been depracted in V4 of styled components. Make sure to change this prop once we upgrade to styled components v4
-               * https://www.styled-components.com/docs/api#deprecated-innerref-prop
-               */
               className={this.props.className}
-              innerRef={ref}
+              ref={ref}
               style={style}
               data-placement={placement}
               aria-label={this.props.ariaLabel}
@@ -83,7 +79,7 @@ class PopoverContent extends Component {
               aria-describedby={`dialog-description-${this.props.idx}`}
             >
               <ContentContainer
-                innerRef={this.props.contentRef}
+                ref={this.props.contentRef}
                 {...styleProps}
                 tabIndex="-1"
               >

--- a/packages/popover/src/PopoverContent.js
+++ b/packages/popover/src/PopoverContent.js
@@ -68,8 +68,10 @@ class PopoverContent extends Component {
         >
           {({ placement, ref, style, arrowProps }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
+            // Styled-Components v4 uses regular refs, keep innerRef for v3 peer dependency
             <PopperGuide
               className={this.props.className}
+              innerRef={ref}
               ref={ref}
               style={style}
               data-placement={placement}
@@ -79,6 +81,7 @@ class PopoverContent extends Component {
               aria-describedby={`dialog-description-${this.props.idx}`}
             >
               <ContentContainer
+                innerRef={this.props.contentRef}
                 ref={this.props.contentRef}
                 {...styleProps}
                 tabIndex="-1"

--- a/packages/popover/test/__snapshots__/Popover.js.snap
+++ b/packages/popover/test/__snapshots__/Popover.js.snap
@@ -132,8 +132,9 @@ exports[`Popover UI Positioning Bottom 1`] = `
   aria-describedby="dialog-description-1"
   aria-label="Top PopOver"
   class="c0"
+  data-placement="bottom"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+  style="position: fixed; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
   width="400"
 >
   <section
@@ -160,7 +161,7 @@ exports[`Popover UI Positioning Bottom 1`] = `
   <span
     aria-hidden="true"
     class="c2"
-    data-placement="top"
+    data-placement="bottom"
   />
 </div>
 `;
@@ -254,8 +255,9 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   aria-describedby="dialog-description-1"
   aria-label="Top PopOver"
   class="c0"
+  data-placement="bottom-end"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+  style="position: fixed; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
   width="400"
 >
   <section
@@ -282,7 +284,7 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   <span
     aria-hidden="true"
     class="c2"
-    data-placement="top"
+    data-placement="bottom-end"
   />
 </div>
 `;
@@ -376,8 +378,9 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   aria-describedby="dialog-description-1"
   aria-label="Top PopOver"
   class="c0"
+  data-placement="bottom-start"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 0; pointer-events: none;"
+  style="position: fixed; top: 0px; left: 0px; transform: translate3d(NaNpx, NaNpx, 0); will-change: transform;"
   width="400"
 >
   <section
@@ -404,7 +407,7 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   <span
     aria-hidden="true"
     class="c2"
-    data-placement="top"
+    data-placement="bottom-start"
   />
 </div>
 `;


### PR DESCRIPTION
Closes https://github.com/pricelinelabs/design-system/issues/631

Tests pass, Popover works as expected. See my comment on that issue for more details. Particularly of note: I was never able to reproduce the scroll reset bug.