### PR TITLE
apply rollup to all packages except icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ known_hosts
 id_rs*
 *ssh*
 packages/**/package-lock.json
+
+packages/**/rollup.bundleAnalysis.json
+packages/**/stats.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -8149,6 +8149,12 @@
 			"integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg==",
 			"dev": true
 		},
+		"escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+			"dev": true
+		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -8906,7 +8912,8 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -8930,13 +8937,15 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -8953,19 +8962,22 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -9096,7 +9108,8 @@
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -9110,6 +9123,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9126,6 +9140,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -9134,13 +9149,15 @@
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -9161,6 +9178,7 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -9249,7 +9267,8 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -9263,6 +9282,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -9358,7 +9378,8 @@
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -9400,6 +9421,7 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9421,6 +9443,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9469,13 +9492,15 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -17126,6 +17151,15 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
+		"open": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+			"integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+			"dev": true,
+			"requires": {
+				"is-wsl": "^1.1.0"
+			}
+		},
 		"opn": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -18118,6 +18152,15 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"pupa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+			"dev": true,
+			"requires": {
+				"escape-goat": "^2.0.0"
+			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -19237,6 +19280,12 @@
 				}
 			}
 		},
+		"rollup-plugin-analyzer": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-3.2.2.tgz",
+			"integrity": "sha512-rRNOaykvnniNmByeaYuhrnMSwAmYduvGy1q2rBchRjGL/bEtEVr2WogKMQ0po8QbnwcsYaiQacYFxsvGTnw6Iw==",
+			"dev": true
+		},
 		"rollup-plugin-babel": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",
@@ -19397,6 +19446,45 @@
 				"is-module": "^1.0.0",
 				"resolve": "^1.11.1",
 				"rollup-pluginutils": "^2.8.1"
+			}
+		},
+		"rollup-plugin-peer-deps-external": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.0.tgz",
+			"integrity": "sha512-BmJMHUWQcvjS2dQMwJ7dzvdbwpRChnq4AYk2sTU/4aySt9Kumk8y8W3HhTHss31wxzKb0AC/wsiX1AqDcOBIEA==",
+			"dev": true
+		},
+		"rollup-plugin-terser": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
+			"integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"jest-worker": "^24.6.0",
+				"rollup-pluginutils": "^2.8.1",
+				"serialize-javascript": "^1.7.0",
+				"terser": "^4.1.0"
+			}
+		},
+		"rollup-plugin-visualizer": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-2.7.2.tgz",
+			"integrity": "sha512-aJ9GA2mGblEttMmyA2bO8Ce40/VAH3tFYhiXaEJKuJTY6eaU5q744wgE6H8YzM2mc1uLQeejn6A00ldjUSLhyA==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1",
+				"open": "^6.0.0",
+				"pupa": "^2.0.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
 			}
 		},
 		"rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "prepare": "lerna bootstrap --hoist",
+    "bundle:audit": "AUDIT_BUNDLE=true npm run prepare",
     "clean": "lerna run clean",
     "changed": "lerna changed",
     "diff": "lerna diff",
@@ -41,12 +42,16 @@
     "react-dom": "^16.10.2",
     "react-draggable-playground": "^1.0.0",
     "rollup": "^1.23.1",
+    "rollup-plugin-analyzer": "^3.2.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-babel-runtime-external": "^2.0.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-filesize": "^6.0.1",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-peer-deps-external": "^2.2.0",
+    "rollup-plugin-terser": "^5.1.2",
+    "rollup-plugin-visualizer": "^2.7.2",
     "styled-components": "^4.4.0"
   },
   "jest": {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -2,7 +2,8 @@
   "name": "pcln-autocomplete",
   "version": "2.0.5",
   "description": "React autocomplete component built with Downshift",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "scripts": {
     "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -4,7 +4,7 @@
   "description": "React autocomplete component built with Downshift",
   "main": "dist/index.js",
   "scripts": {
-    "prepare": "babel src -d dist",
+    "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist",
     "test": "jest"
   },
@@ -21,7 +21,7 @@
     "@babel/core": "^7.6.4",
     "@reach/component-component": "^0.1.1",
     "cat-names": "^2.0.0",
-    "pcln-design-system": "^2.5.1",
+    "pcln-design-system": "^2.6.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-test-renderer": "^16.10.2",
@@ -29,7 +29,7 @@
     "us": "^2.0.0"
   },
   "peerDependencies": {
-    "pcln-design-system": ">=2.0.0"
+    "pcln-design-system": ">=2.x"
   },
   "jest": {
     "setupFilesAfterEnv": ["../../test-setup.js"],

--- a/packages/autocomplete/rollup.config.js
+++ b/packages/autocomplete/rollup.config.js
@@ -1,3 +1,4 @@
 const rollupConfig = require('../../rollup.config')
+rollupConfig.external.push('react-is')
 
 module.exports = rollupConfig

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "scripts": {
-    "prepare": "npx rollup --config",
+    "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist",
     "test": "jest"
   },
@@ -42,12 +42,8 @@
     "stylis": "^3.4.9"
   },
   "jest": {
-    "setupFilesAfterEnv": [
-      "../../test-setup.js"
-    ],
-    "testMatch": [
-      "<rootDir>/test/**/*.js"
-    ]
+    "setupFilesAfterEnv": ["../../test-setup.js"],
+    "testMatch": ["<rootDir>/test/**/*.js"]
   },
   "dependencies": {
     "deepmerge": "^4.0.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.esm.js",
   "scripts": {
     "test": "jest",
-    "prepare": "rollup --config",
+    "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist"
   },
   "author": "Priceline",
@@ -17,15 +17,15 @@
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {
-    "pcln-design-system": ">=1.0.0 || >=2.0.0",
+    "pcln-design-system": ">=2.0.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
-    "styled-components": ">=3.x || >= 4.x",
+    "styled-components": ">=3.x <5",
     "styled-system": "^3.2.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-    "pcln-design-system": "^2.5.1",
+    "pcln-design-system": "^2.6.2",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",

--- a/packages/popover/babel.config.js
+++ b/packages/popover/babel.config.js
@@ -1,7 +1,3 @@
-module.exports = {
-  presets: ['@babel/env', '@babel/react'],
-  plugins: [
-    '@babel/plugin-transform-runtime',
-    '@babel/plugin-proposal-class-properties'
-  ]
-}
+const rootBabelConfig = require('../../babel.config')
+
+module.exports = rootBabelConfig

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,38 +5,30 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "scripts": {
-    "prepare": "babel src -d dist",
+    "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist",
     "test": "jest"
   },
   "author": "Priceline",
   "license": "MIT",
   "jest": {
-    "coverageReporters": [
-      "lcov",
-      "html"
-    ],
-    "setupFilesAfterEnv": [
-      "../../test-setup.js"
-    ],
-    "testMatch": [
-      "<rootDir>/test/**/*.js"
-    ]
+    "coverageReporters": ["lcov", "html"],
+    "setupFilesAfterEnv": ["../../test-setup.js"],
+    "testMatch": ["<rootDir>/test/**/*.js"]
   },
   "dependencies": {
     "react-popper": "^1.3.3"
   },
   "peerDependencies": {
-    "pcln-design-system": ">=1.x || >=2.x",
-    "styled-components": ">=3.x || >= 4.x",
+    "pcln-design-system": ">=2.x",
+    "styled-components": ">=3.x <5",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-runtime": "^7.6.2",
     "@reach/component-component": "^0.1.1",
     "jest": "^24.9.0",
-    "pcln-design-system": "^2.0.4",
+    "pcln-design-system": "^2.6.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-test-renderer": "^16.10.2",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,20 +5,15 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "scripts": {
-    "prepare": "rollup --config",
+    "prepare": "rollup -c",
     "clean": "rm -rf node_modules dist",
     "test": "jest"
   },
   "author": "Priceline",
   "license": "MIT",
   "jest": {
-    "coverageReporters": [
-      "lcov",
-      "html"
-    ],
-    "testMatch": [
-      "<rootDir>/test/**/*.js"
-    ]
+    "coverageReporters": ["lcov", "html"],
+    "testMatch": ["<rootDir>/test/**/*.js"]
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -30,8 +25,8 @@
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "pcln-design-system": ">=1.x || >=2.x",
-    "styled-components": ">=3.x || >= 4.x",
+    "pcln-design-system": ">=2.x",
+    "styled-components": ">=3.x <5x",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,65 @@
-const resolve = require('rollup-plugin-node-resolve')
+const fs = require('fs')
+
 const babel = require('rollup-plugin-babel')
+const peerExternal = require('rollup-plugin-peer-deps-external')
 const commonjs = require('rollup-plugin-commonjs')
 const json = require('rollup-plugin-json')
+const resolve = require('rollup-plugin-node-resolve')
 const fileSize = require('rollup-plugin-filesize')
+const { terser } = require('rollup-plugin-terser')
+const analyze = require('rollup-plugin-analyzer')
+const visualize = require('rollup-plugin-visualizer')
 
+const isAudit = process.env.AUDIT_BUNDLE === 'true'
+
+const generatePlugins = () => {
+  const plugins = [
+    babel({
+      exclude: 'node_modules/**'
+    }),
+    peerExternal(),
+    commonjs({
+      namedExports: {
+        'node_modules/deepmerge/index.js': ['deepmerge'],
+        'node_modules/classnames/index.js': ['classNames'],
+        'node_modules/shallowequal/index.js': ['shallowEqual']
+      }
+    }),
+    json(),
+    resolve(),
+    fileSize(),
+    terser()
+  ]
+
+  if (isAudit) {
+    plugins.push(
+      analyze({
+        showExports: true,
+        summaryOnly: true,
+        filter: module => {
+          const zeroBytes = module.size === 0
+
+          return !zeroBytes
+        },
+        onAnalysis: analysis => {
+          fs.writeFileSync(
+            'rollup.bundleAnalysis.json',
+            JSON.stringify(analysis, null, 4)
+          )
+        }
+      }),
+      visualize({
+        // template: 'sunburst'
+        // template: 'treemap'
+        // template: 'circlepacking'
+        // template: 'network',
+        open: true
+      })
+    )
+  }
+
+  return plugins
+}
 module.exports = {
   input: 'src/index.js',
   output: [
@@ -16,21 +72,7 @@ module.exports = {
       format: 'esm'
     }
   ],
-  plugins: [
-    babel({
-      exclude: 'node_modules/**'
-    }),
-    commonjs({
-      namedExports: {
-        'node_modules/deepmerge/index.js': ['deepmerge'],
-        'node_modules/classnames/index.js': ['classNames'],
-        'node_modules/shallowequal/index.js': ['shallowEqual']
-      }
-    }),
-    json(),
-    resolve(),
-    fileSize()
-  ],
+  plugins: generatePlugins(),
   external: [
     'styled-components',
     'react',


### PR DESCRIPTION
Apply rollup to packages that don't use it yet (coming in an additional PR)
Add `npm run bundle:audit` command