### PR TITLE
Swap Input and TextArea to use border over box-shadow (#529)

### DIFF
--- a/MIGRATING_to_v3.md
+++ b/MIGRATING_to_v3.md
@@ -49,3 +49,4 @@ import { ThumbsUp } from 'pcln-icons
 - Link now uses dark shade of `color` prop on hover
 - Banner now supports a node as its `header` prop in addition to strings
 - Popover now supports trapping focus inside of the popup via `trapFocus` prop
+- Input and TextArea now use `borders` instead of `box-shadow`, to prevent misalignments with other components like Select

--- a/packages/autocomplete/test/__snapshots__/index.js.snap
+++ b/packages/autocomplete/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`Autocomplete renders 1`] = `
 .c2 {
   margin-top: 4px;
   background-color: #fff;
+  box-shadow: 0 0 2px 0 rgba(0,0,0,.08),0 4px 16px 0 rgba(0,0,0,.16);
   border: 0;
   border-radius: 2px;
 }

--- a/packages/autocomplete/test/__snapshots__/index.js.snap
+++ b/packages/autocomplete/test/__snapshots__/index.js.snap
@@ -4,7 +4,6 @@ exports[`Autocomplete renders 1`] = `
 .c2 {
   margin-top: 4px;
   background-color: #fff;
-  box-shadow: 0 0 2px 0 rgba(0,0,0,.08),0 4px 16px 0 rgba(0,0,0,.16);
   border: 0;
   border-radius: 2px;
 }
@@ -19,15 +18,15 @@ exports[`Autocomplete renders 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 

--- a/packages/core/src/Input.js
+++ b/packages/core/src/Input.js
@@ -16,8 +16,9 @@ const Input = styled.input`
   color: inherit;
   background-color: transparent;
   border-radius: ${themeGet('radius')};
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: ${getPaletteColor('border.base')};
 
   padding-top: 14px;
   padding-bottom: 14px;

--- a/packages/core/src/Select.js
+++ b/packages/core/src/Select.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { space, fontSize, themeGet } from 'styled-system'
 import { ChevronDown } from 'pcln-icons'
-import { getPaletteColor, deprecatedColorValue } from './utils'
+import { borders, getPaletteColor, deprecatedColorValue } from './utils'
 import Flex from './Flex'
 
 const ClickableIcon = styled(ChevronDown)`
@@ -20,11 +20,8 @@ const SelectBase = styled.select`
   border-width: 1px;
   border-style: solid;
   border-color: ${getPaletteColor('border.base')};
-  ${space} ${fontSize} &:focus {
-    outline: none;
-    border-color: ${getPaletteColor('base')};
-    box-shadow: 0 0 0 1px ${getPaletteColor('base')};
-  }
+
+  ${borders} ${space} ${fontSize}
   ::-ms-expand {
     display: none;
   }
@@ -41,7 +38,8 @@ SelectBase.defaultProps = {
 SelectBase.propTypes = {
   ...space.propTypes,
   ...fontSize.propTypes,
-  color: deprecatedColorValue()
+  color: deprecatedColorValue(),
+  ...borders.propTypes
 }
 
 const Select = styled(props => (

--- a/packages/core/src/TextArea.js
+++ b/packages/core/src/TextArea.js
@@ -17,7 +17,7 @@ const TextArea = styled.textarea`
   color: inherit;
   background-color: transparent;
   border-radius: ${themeGet('radius')};
-  border-width: 0;
+  border-width: 1;
   border-style: solid;
 
   padding-top: 14px;

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -261,9 +261,9 @@ export const borders = props => {
   const focusColor = props.color
     ? borderColor
     : getPaletteColor('primary.base')(props)
+
   return {
     'border-color': borderColor,
-    'box-shadow': `0 0 0 1px ${borderColor}`,
     ':focus': {
       outline: 0,
       'border-color': focusColor,

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -18,15 +18,15 @@ exports[`FormField renders 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -155,15 +155,15 @@ exports[`FormField renders with Icon 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -318,15 +318,15 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -499,6 +499,7 @@ exports[`FormField renders with Select  1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #c0cad5;
+  border-color: #007aff;
   margin: 0px;
   padding-left: 12px;
   padding-right: 32px;
@@ -508,9 +509,9 @@ exports[`FormField renders with Select  1`] = `
 }
 
 .c2:focus {
-  outline: none;
+  outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 .c2::-ms-expand {
@@ -629,6 +630,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #c0cad5;
+  border-color: #007aff;
   margin: 0px;
   padding-left: 12px;
   padding-right: 32px;
@@ -638,9 +640,9 @@ exports[`FormField renders with Select and Icon 1`] = `
 }
 
 .c4:focus {
-  outline: none;
+  outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 .c4::-ms-expand {

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -28,15 +28,15 @@ exports[`IconField renders 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -178,15 +178,15 @@ exports[`IconField renders icon button 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -329,15 +329,15 @@ exports[`IconField renders icon, input and icon button together 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 

--- a/packages/core/test/__snapshots__/Input.js.snap
+++ b/packages/core/test/__snapshots__/Input.js.snap
@@ -11,15 +11,15 @@ exports[`Input it renders 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 16px;
 }
 
@@ -79,15 +79,15 @@ exports[`Input it renders an input element with a really large padding and margi
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   margin: 32px;
   padding: 32px;
   font-size: 16px;
@@ -149,15 +149,15 @@ exports[`Input it renders an input element with a red border with a color prop i
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c00;
-  box-shadow: 0 0 0 1px #c00;
   font-size: 16px;
 }
 
@@ -218,15 +218,15 @@ exports[`Input it renders an input element with large text 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0px;
+  border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
   padding-top: 14px;
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   font-size: 24px;
 }
 

--- a/packages/core/test/__snapshots__/Select.js.snap
+++ b/packages/core/test/__snapshots__/Select.js.snap
@@ -39,6 +39,7 @@ exports[`Select renders 1`] = `
   border-width: 1px;
   border-style: solid;
   border-color: #c0cad5;
+  border-color: #007aff;
   margin: 0px;
   padding-left: 12px;
   padding-right: 32px;
@@ -48,9 +49,9 @@ exports[`Select renders 1`] = `
 }
 
 .c1:focus {
-  outline: none;
+  outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 .c1::-ms-expand {

--- a/packages/core/test/__snapshots__/TextArea.js.snap
+++ b/packages/core/test/__snapshots__/TextArea.js.snap
@@ -12,7 +12,7 @@ exports[`TextArea it renders 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0;
+  border-width: 1;
   border-style: solid;
   padding-top: 14px;
   padding-bottom: 14px;
@@ -20,7 +20,6 @@ exports[`TextArea it renders 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
 }
 
 .c0::-webkit-input-placeholder {
@@ -67,7 +66,7 @@ exports[`TextArea it renders an input element with a really large padding and ma
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0;
+  border-width: 1;
   border-style: solid;
   padding-top: 14px;
   padding-bottom: 14px;
@@ -75,7 +74,6 @@ exports[`TextArea it renders an input element with a really large padding and ma
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
   margin: 32px;
   padding: 32px;
 }
@@ -124,7 +122,7 @@ exports[`TextArea it renders an input element with a red border with a color pro
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0;
+  border-width: 1;
   border-style: solid;
   padding-top: 14px;
   padding-bottom: 14px;
@@ -132,7 +130,6 @@ exports[`TextArea it renders an input element with a red border with a color pro
   padding-right: 12px;
   margin: 0;
   border-color: #c00;
-  box-shadow: 0 0 0 1px #c00;
 }
 
 .c0::-webkit-input-placeholder {
@@ -180,7 +177,7 @@ exports[`TextArea it renders an input element with large text 1`] = `
   color: inherit;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 0;
+  border-width: 1;
   border-style: solid;
   padding-top: 14px;
   padding-bottom: 14px;
@@ -188,7 +185,6 @@ exports[`TextArea it renders an input element with large text 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #c0cad5;
-  box-shadow: 0 0 0 1px #c0cad5;
 }
 
 .c0::-webkit-input-placeholder {


### PR DESCRIPTION
Input, TextArea, and Select will now each use `utils/borders` for `borders`, removing inconsistent use of `box-shadow`.

Related to https://github.com/priceline/design-system/issues/529