### PR TITLE
(#650) Mark bg prop as deprecated

### DIFF
--- a/MIGRATING_to_v3.md
+++ b/MIGRATING_to_v3.md
@@ -21,6 +21,7 @@
   - Use `<Button color='secondary'>...</Button` or `<Button color='error'>...</Button>` instead
 - OutlineButton `<OutlineButton />` has been removed
   - Use `<Button variation='outline'>...</Button>` instead
+- `bg` prop has been marked as deprecated in favor of `color`
 - Icon `<Icon name="iconName" />` has been removed
 - IconButton
   - `name`, `size` and `color` props are removed

--- a/packages/autocomplete/src/index.js
+++ b/packages/autocomplete/src/index.js
@@ -10,6 +10,8 @@ import {
 } from 'pcln-design-system'
 import { themeGet } from 'styled-system'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 export const AutocompleteContext = React.createContext()
 
 export const withAutocomplete = (Component, mapProps) =>
@@ -46,6 +48,10 @@ MenuCard.defaultProps = {
   borderWidth: 0,
   boxShadowSize: 'lg',
   mt: 1
+}
+
+MenuCard.propTypes = {
+  bg: deprecatedPropType('color')
 }
 
 const MenuRoot = React.forwardRef((props, ref) => (

--- a/packages/core/src/Badge.js
+++ b/packages/core/src/Badge.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
 import { themeGet, space } from 'styled-system'
-import { applyVariations, color, deprecatedColorValue } from './utils'
+import {
+  applyVariations,
+  color,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const type = props => {
   const badgeColors = {
@@ -64,7 +69,7 @@ Badge.displayName = 'Badge'
 Badge.propTypes = {
   ...space.propTypes,
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue()
+  bg: deprecatedPropType('color')
 }
 
 Badge.defaultProps = {

--- a/packages/core/src/Banner.js
+++ b/packages/core/src/Banner.js
@@ -5,13 +5,18 @@ import Text from './Text'
 import CloseButton from './CloseButton'
 import PropTypes from 'prop-types'
 import styled, { withTheme } from 'styled-components'
-import { applyVariations, hasPaletteColor, deprecatedColorValue } from './utils'
 import {
   Attention as AttentionIcon,
   Information as InformationIcon,
   Success as SuccessIcon,
   Warning as WarningIcon
 } from 'pcln-icons'
+import {
+  applyVariations,
+  hasPaletteColor,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const bannerColors = {
   green: {
@@ -110,7 +115,7 @@ Banner.propTypes = {
   text: PropTypes.node,
   textAlign: PropTypes.string,
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue()
+  bg: deprecatedPropType('color')
 }
 
 Banner.defaultProps = {

--- a/packages/core/src/Box.js
+++ b/packages/core/src/Box.js
@@ -1,6 +1,11 @@
 import styled from 'styled-components'
 import { space, width, textAlign } from 'styled-system'
-import { applyVariations, color, deprecatedColorValue } from './utils'
+import {
+  applyVariations,
+  color,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const Box = styled.div`
   ${space} ${width} ${textAlign}
@@ -14,7 +19,7 @@ Box.propTypes = {
   ...space.propTypes,
   ...width.propTypes,
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue(),
+  bg: deprecatedPropType('color'),
   ...textAlign.propTypes
 }
 

--- a/packages/core/src/Flag.js
+++ b/packages/core/src/Flag.js
@@ -9,7 +9,8 @@ import {
   getPaletteColor,
   hasPaletteColor,
   color,
-  deprecatedColorValue
+  deprecatedColorValue,
+  deprecatedPropType
 } from './utils'
 
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
@@ -100,7 +101,7 @@ const Flag = ({ color, bg, children, width, ...props }) => (
 
 Flag.propTypes = {
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue()
+  bg: deprecatedPropType('color')
 }
 
 Flag.defaultProps = {

--- a/packages/core/src/Flex.js
+++ b/packages/core/src/Flex.js
@@ -32,7 +32,7 @@ Flex.propTypes = {
   ...space.propTypes,
   ...width.propTypes,
   color: deprecatedColorValue(),
-  bg: deprecatedPropType(),
+  bg: deprecatedPropType('color'),
   ...alignItems.propTypes,
   ...justifyContent.propTypes,
   ...flexWrap.propTypes,

--- a/packages/core/src/RatingBadge.js
+++ b/packages/core/src/RatingBadge.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { fontWeight, borderRadius } from 'styled-system'
 import Box from './Box'
-import { applyVariations } from './utils'
+import { applyVariations, deprecatedPropType } from './utils'
 
 const RatingBadge = styled(Box)`
   display: inline-block;
@@ -20,7 +20,8 @@ RatingBadge.defaultProps = {
 
 RatingBadge.propTypes = {
   ...fontWeight.propTypes,
-  ...borderRadius.propTypes
+  ...borderRadius.propTypes,
+  bg: deprecatedPropType('color')
 }
 
 export default RatingBadge

--- a/packages/core/src/Stamp.js
+++ b/packages/core/src/Stamp.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
 import { themeGet, space, fontSize } from 'styled-system'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from './utils'
+import {
+  applyVariations,
+  getPaletteColor,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const Stamp = styled.div`
   display: inline-flex;
@@ -31,7 +36,7 @@ Stamp.propTypes = {
   ...space.propTypes,
   ...fontSize.propTypes,
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue(),
+  bg: deprecatedPropType('color'),
   borderColor: deprecatedColorValue()
 }
 

--- a/packages/core/src/ToggleBadge.js
+++ b/packages/core/src/ToggleBadge.js
@@ -2,7 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { space, fontSize } from 'styled-system'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from './utils'
+import {
+  applyVariations,
+  getPaletteColor,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const ToggleBadge = styled.button`
   border-radius: ${props => props.theme.radius};
@@ -31,7 +36,7 @@ ToggleBadge.propTypes = {
   ...space.propTypes,
   ...fontSize.propTypes,
   color: deprecatedColorValue(),
-  bg: deprecatedColorValue()
+  bg: deprecatedPropType('color')
 }
 
 ToggleBadge.defaultProps = {

--- a/packages/core/src/Tooltip.js
+++ b/packages/core/src/Tooltip.js
@@ -2,7 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Box from './Box'
 import styled, { withTheme } from 'styled-components'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from './utils'
+import {
+  applyVariations,
+  getPaletteColor,
+  deprecatedColorValue,
+  deprecatedPropType
+} from './utils'
 
 const arrowShadow = props => {
   return props.top
@@ -92,7 +97,7 @@ const TooltipContent = styled(Box)`
 
 const propTypes = {
   children: PropTypes.any.isRequired,
-  bg: deprecatedColorValue(),
+  bg: deprecatedPropType('color'),
   color: deprecatedColorValue(),
   bottom: PropTypes.bool,
   top: PropTypes.bool,

--- a/packages/core/storybook/Flex.js
+++ b/packages/core/storybook/Flex.js
@@ -43,3 +43,13 @@ storiesOf('Flex', module)
       </Box>
     </Flex>
   ))
+  .add('deprecated bg shim', () => (
+    <Flex bg="blue">
+      <Box width={1 / 2} p={3} color="white" bg="blue">
+        Flex
+      </Box>
+      <Box width={1 / 2} p={1} color="white" bg="green">
+        Box
+      </Box>
+    </Flex>
+  ))

--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -6,6 +6,8 @@ import { color, width, height } from 'styled-system'
 import { DialogOverlay, DialogContent } from '@reach/dialog'
 import { Box, CloseButton, Flex } from 'pcln-design-system'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 const OVERLAY_ANIMATION = transitionState => `
   opacity: 0;
   transition: opacity .5s cubic-bezier(0.50, 0.00, 0.25, 1.00);
@@ -216,7 +218,7 @@ Modal.propTypes = {
   disableCloseButton: PropTypes.bool,
   enableOverflow: PropTypes.bool,
   onClose: PropTypes.func,
-  bg: PropTypes.string,
+  bg: deprecatedPropType('color'),
   zIndex: PropTypes.number,
   title: PropTypes.string,
   headerBg: PropTypes.string,

--- a/packages/modal/src/ModalHeader.js
+++ b/packages/modal/src/ModalHeader.js
@@ -3,6 +3,8 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Flex, CloseButton, Text } from 'pcln-design-system'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 const HeaderWrapper = styled(Flex)`
   height: 40px;
 `
@@ -32,7 +34,7 @@ const ModalHeader = ({ bg, color, onClose, title }) => (
 ModalHeader.displayName = ModalHeader
 
 ModalHeader.propTypes = {
-  bg: PropTypes.string,
+  bg: deprecatedPropType('color'),
   onClose: PropTypes.func,
   color: PropTypes.string,
   title: PropTypes.string

--- a/packages/modal/src/SmallModalHeader.js
+++ b/packages/modal/src/SmallModalHeader.js
@@ -3,6 +3,8 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Box } from 'pcln-design-system'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 const HeaderBar = styled(Box)`
   height: 8px;
 `
@@ -12,7 +14,7 @@ const SmallModalHeader = ({ bg }) => <HeaderBar bg={bg} />
 SmallModalHeader.displayName = SmallModalHeader
 
 SmallModalHeader.propTypes = {
-  bg: PropTypes.string
+  bg: deprecatedPropType('color')
 }
 
 SmallModalHeader.defaultProps = {

--- a/packages/popover/src/Arrow.js
+++ b/packages/popover/src/Arrow.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { theme } from 'pcln-design-system'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 const PopoverArrow = ({
   arrowProps,
   placement,
@@ -94,7 +96,7 @@ PopoverArrow.propTypes = {
     style: PropTypes.object
   }).isRequired,
   className: PropTypes.string,
-  bg: PropTypes.string,
+  bg: deprecatedPropType('color'),
   borderColor: PropTypes.string,
   placement: PropTypes.string
 }

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 import { Manager, Reference } from 'react-popper'
 import PopoverContent from './PopoverContent'
 
+import { deprecatedPropType } from '../../core/src/utils'
+
 class Popover extends Component {
   constructor(props) {
     super(props)
@@ -92,7 +94,7 @@ Popover.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
   p: PropTypes.number,
-  bg: PropTypes.string,
+  bg: deprecatedPropType('color'),
   borderColor: PropTypes.string,
   placement: PropTypes.string,
   zIndex: PropTypes.number,

--- a/packages/popover/src/PopoverContent.js
+++ b/packages/popover/src/PopoverContent.js
@@ -5,9 +5,11 @@ import styled from 'styled-components'
 import { Popper } from 'react-popper'
 import { Box, theme } from 'pcln-design-system'
 import FocusLock from 'react-focus-lock'
+
 import DEFAULTS_MODIFIERS from './helpers/defaultModifiers'
 import Overlay from './Overlay'
 import PopoverArrow from './Arrow'
+import { deprecatedPropType } from '../../core/src/utils'
 
 class PopoverContent extends Component {
   componentDidMount() {
@@ -151,7 +153,7 @@ PopoverContent.propTypes = {
   className: PropTypes.string,
   theme: PropTypes.object,
   p: PropTypes.number,
-  bg: PropTypes.string,
+  bg: deprecatedPropType('color'),
   borderColor: PropTypes.string,
   placement: PropTypes.string,
   zIndex: PropTypes.number,


### PR DESCRIPTION
Marking the `bg` prop as deprecated in favor of `color`.

Addresses https://github.com/priceline/design-system/issues/650