### PR TITLE
Link - set rel noopener when target is blank

### DIFF
--- a/packages/core/src/Link.js
+++ b/packages/core/src/Link.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from './utils'
 
-const Link = styled.a`
+const Link = styled.a.attrs(props => ({
+  rel: props.target === '_blank' ? 'noopener' : null
+}))`
   cursor: pointer;
   text-decoration: none;
   color: ${getPaletteColor('base')};

--- a/packages/core/test/Link.js
+++ b/packages/core/test/Link.js
@@ -6,4 +6,21 @@ describe('Link', () => {
     const json = rendererCreateWithTheme(<Link>Dummy</Link>).toJSON()
     expect(json).toMatchSnapshot()
   })
+
+  test('adds a safe rel when target is blank', () => {
+    const json = rendererCreateWithTheme(
+      <Link target="_blank">Dummy</Link>
+    ).toJSON()
+
+    expect(json).toMatchSnapshot()
+    expect(json.props.target).toEqual('_blank')
+    expect(json.props.rel).toEqual('noopener')
+  })
+
+  test('does not add a safe rel when target is not blank', () => {
+    const json = rendererCreateWithTheme(<Link>Dummy</Link>).toJSON()
+
+    expect(json).toMatchSnapshot()
+    expect(json.props.rel).toBe(null)
+  })
 })

--- a/packages/core/test/__snapshots__/BlockLink.js.snap
+++ b/packages/core/test/__snapshots__/BlockLink.js.snap
@@ -20,6 +20,7 @@ exports[`BlockLink renders 1`] = `
 <a
   className="c0"
   color="primary"
+  rel={null}
 >
   raw text
 </a>

--- a/packages/core/test/__snapshots__/Breadcrumbs.js.snap
+++ b/packages/core/test/__snapshots__/Breadcrumbs.js.snap
@@ -58,6 +58,7 @@ exports[`Breadcrumbs renders basic 1`] = `
       className="c2"
       color="text.light"
       href="https://www.priceline.com"
+      rel={null}
     >
       Home
     </a>
@@ -75,6 +76,7 @@ exports[`Breadcrumbs renders basic 1`] = `
       className="c2"
       color="text.light"
       href="https://www.priceline.com/flights/"
+      rel={null}
     >
       Flights
     </a>
@@ -92,6 +94,7 @@ exports[`Breadcrumbs renders basic 1`] = `
       className="c4"
       color="text.dark"
       href="https://www.priceline.com/flights/"
+      rel={null}
     >
       Seat Selection
     </a>
@@ -201,6 +204,7 @@ exports[`Breadcrumbs renders with icons 1`] = `
       className="c4"
       color="text.light"
       href="https://www.priceline.com"
+      rel={null}
     >
       Home
     </a>
@@ -234,6 +238,7 @@ exports[`Breadcrumbs renders with icons 1`] = `
       className="c4"
       color="text.light"
       href="https://www.priceline.com/flights/"
+      rel={null}
     >
       Flights
     </a>
@@ -267,6 +272,7 @@ exports[`Breadcrumbs renders with icons 1`] = `
       className="c9"
       color="text.dark"
       href="https://www.priceline.com/flights/"
+      rel={null}
     >
       Seat Selection
     </a>

--- a/packages/core/test/__snapshots__/Link.js.snap
+++ b/packages/core/test/__snapshots__/Link.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Link adds a safe rel when target is blank 1`] = `
+.c0 {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007aff;
+}
+
+.c0:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<a
+  className="c0"
+  color="primary"
+  rel="noopener"
+  target="_blank"
+>
+  Dummy
+</a>
+`;
+
+exports[`Link does not add a safe rel when target is not blank 1`] = `
+.c0 {
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #007aff;
+}
+
+.c0:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<a
+  className="c0"
+  color="primary"
+  rel={null}
+>
+  Dummy
+</a>
+`;
+
 exports[`Link renders 1`] = `
 .c0 {
   cursor: pointer;
@@ -16,6 +61,7 @@ exports[`Link renders 1`] = `
 <a
   className="c0"
   color="primary"
+  rel={null}
 >
   Dummy
 </a>


### PR DESCRIPTION
Wanted to make it easier to ensure safe cross-origin navigation using the Link component.

- Added conditional `rel` value `noopener` when `target='_blank'`
- Added new test to assert value is added
- Update snapshots

Sources for reading more about this topic and specific attribute value:
- https://mathiasbynens.github.io/rel-noopener/
- https://developers.google.com/web/tools/lighthouse/audits/noopener