### PR TITLE
fix(label-width): prevent label width overflow

### DIFF
--- a/packages/core/src/FormField.js
+++ b/packages/core/src/FormField.js
@@ -32,12 +32,14 @@ const FormField = props => {
     return child
   })
 
+  const ml = iconBefore ? '40px' : '12px'
+
   const styledLabel =
     label &&
     React.cloneElement(label, {
       htmlFor: label.props.htmlFor || id,
       fontSize: 10,
-      ml: iconBefore ? '40px' : '12px',
+      ml,
       pt: '6px',
       mb: '-20px',
       style: {
@@ -47,7 +49,8 @@ const FormField = props => {
         transitionDuration: '.1s',
         opacity: showLabel ? 1 : 0,
         pointerEvents: 'none',
-        position: 'relative'
+        position: 'relative',
+        width: `calc(100% - ${ml})`
       }
     })
 

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -94,6 +94,7 @@ exports[`FormField renders 1`] = `
         "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
+        "width": "calc(100% - 12px)",
       }
     }
   >
@@ -231,6 +232,7 @@ exports[`FormField renders with Icon 1`] = `
         "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
+        "width": "calc(100% - 40px)",
       }
     }
   >
@@ -394,6 +396,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
         "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
+        "width": "calc(100% - 40px)",
       }
     }
   >


### PR DESCRIPTION
Before:
<img width="339" alt="Screen Shot 2019-12-02 at 9 53 38 AM" src="https://user-images.githubusercontent.com/16601510/69969541-9d2b8800-14ea-11ea-92c7-90e0e2b4ace7.png">

<img width="338" alt="Screen Shot 2019-12-02 at 9 47 42 AM" src="https://user-images.githubusercontent.com/16601510/69969544-9d2b8800-14ea-11ea-8176-ce13998bc132.png">

After:
<img width="311" alt="Screen Shot 2019-12-02 at 9 53 12 AM" src="https://user-images.githubusercontent.com/16601510/69969542-9d2b8800-14ea-11ea-89c1-614f341d9acd.png">

<img width="332" alt="Screen Shot 2019-12-02 at 9 52 27 AM" src="https://user-images.githubusercontent.com/16601510/69969543-9d2b8800-14ea-11ea-801d-794aa96c6757.png">
