### PR TITLE
Resolve skipped tests

### DIFF
--- a/packages/core/test/Banner.js
+++ b/packages/core/test/Banner.js
@@ -102,28 +102,6 @@ describe('Banner', () => {
     expect(icon).toBeTruthy()
   })
 
-  // these won't be needed if Banner is changed to a more composable API
-  test.skip('does render green left-hand icon by default', () => {
-    const { container } = renderWithTheme(<Banner bg="green" />)
-    const icon = container.querySelector('svg')
-    // name=success
-    expect(icon).toBeTruthy()
-  })
-
-  test.skip('does render orange left-hand icon by default', () => {
-    const { container } = renderWithTheme(<Banner bg="orange" />)
-    const icon = container.querySelector('svg')
-    // name=attention
-    expect(icon).toBeTruthy()
-  })
-
-  test.skip('does render red left-hand icon by default', () => {
-    const { container } = renderWithTheme(<Banner bg="red" />)
-    const icon = container.querySelector('svg')
-    // name=warning
-    expect(icon).toBeTruthy()
-  })
-
   test('does not render blue left-hand icon if showIcon is false', () => {
     const { container } = renderWithTheme(<Banner bg="blue" showIcon={false} />)
     const icon = container.querySelector('svg')

--- a/packages/core/test/Flex.js
+++ b/packages/core/test/Flex.js
@@ -28,28 +28,41 @@ describe('Flex', () => {
   })
 
   describe('deprecated prop types', () => {
-    test('shims the deprecated align prop', () => {
+    const spy = jest.spyOn(console, 'error')
+
+    test('shims the deprecated `align` prop and warns', () => {
       const json = rendererCreateWithTheme(<Flex align="center" />).toJSON()
       expect(json).toHaveStyleRule('align-items', 'center')
+      expect(spy.mock.calls.length).toBe(1)
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `align` prop is deprecated and will be removed in a future release. Please use `alignItems` instead.'
+        )
+      )
     })
 
-    test('shims the deprecated wrap prop', () => {
+    test('shims the deprecated `wrap` prop and warns', () => {
       const json = rendererCreateWithTheme(<Flex wrap />).toJSON()
       expect(json).toHaveStyleRule('flex-wrap', 'wrap')
+      expect(spy.mock.calls.length).toBe(2)
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `wrap` prop is deprecated and will be removed in a future release. Please use `flexWrap` instead.'
+        )
+      )
     })
 
-    test('shims the deprecated justify prop', () => {
+    test('shims the deprecated `justify` prop and warns', () => {
       const json = rendererCreateWithTheme(
         <Flex justify="space-between" />
       ).toJSON()
       expect(json).toHaveStyleRule('justify-content', 'space-between')
-    })
-
-    test.skip('warns when using deprecated align prop', () => {
-      // unsure why this isn't being called
-      const spy = jest.spyOn(global.console, 'error')
-      rendererCreateWithTheme(<Flex align="center" />)
-      expect(spy).toHaveBeenCalled()
+      expect(spy.mock.calls.length).toBe(3)
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `justify` prop is deprecated and will be removed in a future release. Please use `justifyContent` instead.'
+        )
+      )
     })
   })
 })


### PR DESCRIPTION
Removes some skipped tests that are no longer needed due to using a more composed API for Banner. Additionally, fixes a skipped block in Flex.