### PR TITLE
Update @reach/dialog in pcln-modal for DS v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 script: npm test -- --coverage --runInBand
 after_success:
   - npm run codecov
+before_install:
+  - npm i -g npm@6.4.1
 before_deploy:
   - cd docs
   - npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -9112,28 +9112,28 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
@@ -9144,14 +9144,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
@@ -9169,28 +9169,28 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
@@ -9207,21 +9207,21 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
@@ -9238,14 +9238,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -9277,14 +9277,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"resolved": false,
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
@@ -9304,7 +9304,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -9322,14 +9322,14 @@
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
@@ -9339,14 +9339,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
@@ -9356,7 +9356,7 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
@@ -9384,7 +9384,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
@@ -9432,7 +9432,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -9461,7 +9461,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -9474,21 +9474,21 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
@@ -9498,21 +9498,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -9523,7 +9523,7 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
@@ -9537,7 +9537,7 @@
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+					"resolved": false,
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
@@ -9550,7 +9550,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -9559,7 +9559,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
@@ -9585,21 +9585,21 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
@@ -9613,21 +9613,21 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
@@ -9639,7 +9639,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -9649,7 +9649,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
@@ -9659,7 +9659,7 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
@@ -9682,14 +9682,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
@@ -9699,7 +9699,7 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true
@@ -14080,7 +14080,7 @@
 			"dependencies": {
 				"JSONStream": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
 					"requires": {
 						"jsonparse": "^1.2.0",
@@ -14089,12 +14089,12 @@
 				},
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 				},
 				"agent-base": {
 					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 					"requires": {
 						"es6-promisify": "^5.0.0"
@@ -14102,7 +14102,7 @@
 				},
 				"agentkeepalive": {
 					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
 					"requires": {
 						"humanize-ms": "^1.2.1"
@@ -14110,7 +14110,7 @@
 				},
 				"ajv": {
 					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"requires": {
 						"co": "^4.6.0",
@@ -14121,7 +14121,7 @@
 				},
 				"ansi-align": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 					"requires": {
 						"string-width": "^2.0.0"
@@ -14129,12 +14129,12 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -14142,27 +14142,27 @@
 				},
 				"ansicolors": {
 					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
 				},
 				"ansistyles": {
 					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
 				},
 				"aproba": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
 				},
 				"archy": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"requires": {
 						"delegates": "^1.0.0",
@@ -14171,7 +14171,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -14185,7 +14185,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -14195,12 +14195,12 @@
 				},
 				"asap": {
 					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 				},
 				"asn1": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 					"requires": {
 						"safer-buffer": "~2.1.0"
@@ -14208,32 +14208,32 @@
 				},
 				"assert-plus": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 				},
 				"aws4": {
 					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 					"optional": true,
 					"requires": {
@@ -14254,12 +14254,12 @@
 				},
 				"bluebird": {
 					"version": "3.5.5",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
 				},
 				"boxen": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 					"requires": {
 						"ansi-align": "^2.0.0",
@@ -14273,7 +14273,7 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -14282,27 +14282,27 @@
 				},
 				"buffer-from": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 				},
 				"byline": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 				},
 				"byte-size": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw=="
 				},
 				"cacache": {
 					"version": "12.0.3",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
 					"requires": {
 						"bluebird": "^3.5.5",
@@ -14324,27 +14324,27 @@
 				},
 				"call-limit": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ=="
 				},
 				"camelcase": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 				},
 				"chalk": {
 					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -14359,12 +14359,12 @@
 				},
 				"ci-info": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 				},
 				"cidr-regex": {
 					"version": "2.0.10",
-					"resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+					"resolved": false,
 					"integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
 					"requires": {
 						"ip-regex": "^2.1.0"
@@ -14372,12 +14372,12 @@
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 				},
 				"cli-columns": {
 					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
 					"requires": {
 						"string-width": "^2.0.0",
@@ -14386,7 +14386,7 @@
 				},
 				"cli-table3": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
 					"requires": {
 						"colors": "^1.1.2",
@@ -14396,7 +14396,7 @@
 				},
 				"cliui": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
 						"string-width": "^2.1.1",
@@ -14406,12 +14406,12 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -14421,7 +14421,7 @@
 				},
 				"clone": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				},
 				"cmd-shim": {
@@ -14435,17 +14435,17 @@
 				},
 				"co": {
 					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"color-convert": {
 					"version": "1.9.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 					"requires": {
 						"color-name": "^1.1.1"
@@ -14453,18 +14453,18 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"colors": {
 					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
 					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
-					"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 					"requires": {
 						"strip-ansi": "^3.0.0",
@@ -14473,7 +14473,7 @@
 				},
 				"combined-stream": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"requires": {
 						"delayed-stream": "~1.0.0"
@@ -14481,12 +14481,12 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"concat-stream": {
 					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -14497,7 +14497,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -14511,7 +14511,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -14521,7 +14521,7 @@
 				},
 				"config-chain": {
 					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+					"resolved": false,
 					"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
 					"requires": {
 						"ini": "^1.3.4",
@@ -14530,7 +14530,7 @@
 				},
 				"configstore": {
 					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 					"requires": {
 						"dot-prop": "^4.1.0",
@@ -14543,12 +14543,12 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"copy-concurrently": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"requires": {
 						"aproba": "^1.1.1",
@@ -14561,24 +14561,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 						}
 					}
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"create-error-class": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
@@ -14586,7 +14586,7 @@
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -14596,7 +14596,7 @@
 					"dependencies": {
 						"lru-cache": {
 							"version": "4.1.5",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 							"requires": {
 								"pseudomap": "^1.0.2",
@@ -14605,24 +14605,24 @@
 						},
 						"yallist": {
 							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 						}
 					}
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 				},
 				"cyclist": {
 					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -14630,7 +14630,7 @@
 				},
 				"debug": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
@@ -14638,34 +14638,34 @@
 					"dependencies": {
 						"ms": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 						}
 					}
 				},
 				"debuglog": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
 				},
 				"defaults": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"requires": {
 						"clone": "^1.0.2"
@@ -14673,7 +14673,7 @@
 				},
 				"define-properties": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 					"requires": {
 						"object-keys": "^1.0.12"
@@ -14681,27 +14681,27 @@
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 				},
 				"detect-indent": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 				},
 				"detect-newline": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 				},
 				"dezalgo": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
 					"requires": {
 						"asap": "^2.0.0",
@@ -14710,7 +14710,7 @@
 				},
 				"dot-prop": {
 					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 					"requires": {
 						"is-obj": "^1.0.0"
@@ -14718,17 +14718,17 @@
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 				},
 				"duplexify": {
 					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 					"requires": {
 						"end-of-stream": "^1.0.0",
@@ -14739,7 +14739,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -14753,7 +14753,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -14763,7 +14763,7 @@
 				},
 				"ecc-jsbn": {
 					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 					"optional": true,
 					"requires": {
@@ -14773,12 +14773,12 @@
 				},
 				"editor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
 				},
 				"encoding": {
 					"version": "0.1.12",
-					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"resolved": false,
 					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 					"requires": {
 						"iconv-lite": "~0.4.13"
@@ -14786,7 +14786,7 @@
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"requires": {
 						"once": "^1.4.0"
@@ -14794,17 +14794,17 @@
 				},
 				"env-paths": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
 				},
 				"err-code": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
 				},
 				"errno": {
 					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+					"resolved": false,
 					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"requires": {
 						"prr": "~1.0.1"
@@ -14812,7 +14812,7 @@
 				},
 				"es-abstract": {
 					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 					"requires": {
 						"es-to-primitive": "^1.1.1",
@@ -14824,7 +14824,7 @@
 				},
 				"es-to-primitive": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 					"requires": {
 						"is-callable": "^1.1.4",
@@ -14834,12 +14834,12 @@
 				},
 				"es6-promise": {
 					"version": "4.2.8",
-					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+					"resolved": false,
 					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 				},
 				"es6-promisify": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 					"requires": {
 						"es6-promise": "^4.0.3"
@@ -14847,12 +14847,12 @@
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"resolved": false,
 					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -14866,44 +14866,44 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 						}
 					}
 				},
 				"extend": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 				},
 				"extsprintf": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 				},
 				"figgy-pudding": {
 					"version": "3.5.1",
-					"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
 				},
 				"find-npm-prefix": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -14911,7 +14911,7 @@
 				},
 				"flush-write-stream": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"requires": {
 						"inherits": "^2.0.1",
@@ -14920,7 +14920,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -14934,7 +14934,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -14944,12 +14944,12 @@
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 				},
 				"form-data": {
 					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -14959,7 +14959,7 @@
 				},
 				"from2": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"requires": {
 						"inherits": "^2.0.1",
@@ -14968,7 +14968,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -14982,7 +14982,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -15000,7 +15000,7 @@
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
-					"resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+					"resolved": false,
 					"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -15010,7 +15010,7 @@
 				},
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+					"resolved": false,
 					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -15021,12 +15021,12 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -15040,7 +15040,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -15050,17 +15050,17 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"function-bind": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"requires": {
 						"aproba": "^1.0.3",
@@ -15075,12 +15075,12 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -15092,7 +15092,7 @@
 				},
 				"genfun": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
 				},
 				"gentle-fs": {
@@ -15114,24 +15114,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+							"resolved": false,
 							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 						}
 					}
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"requires": {
 						"pump": "^3.0.0"
@@ -15139,7 +15139,7 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"resolved": false,
 					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -15147,7 +15147,7 @@
 				},
 				"glob": {
 					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -15160,7 +15160,7 @@
 				},
 				"global-dirs": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 					"requires": {
 						"ini": "^1.3.4"
@@ -15168,7 +15168,7 @@
 				},
 				"got": {
 					"version": "6.7.1",
-					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"requires": {
 						"create-error-class": "^3.0.0",
@@ -15186,7 +15186,7 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 						}
 					}
@@ -15198,12 +15198,12 @@
 				},
 				"har-schema": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 				},
 				"har-validator": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 					"requires": {
 						"ajv": "^5.3.0",
@@ -15212,7 +15212,7 @@
 				},
 				"has": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 					"requires": {
 						"function-bind": "^1.1.1"
@@ -15220,17 +15220,17 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"has-symbols": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 				},
 				"hosted-git-info": {
@@ -15243,12 +15243,12 @@
 				},
 				"http-cache-semantics": {
 					"version": "3.8.1",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 				},
 				"http-proxy-agent": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 					"requires": {
 						"agent-base": "4",
@@ -15257,7 +15257,7 @@
 				},
 				"http-signature": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -15276,7 +15276,7 @@
 				},
 				"humanize-ms": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 					"requires": {
 						"ms": "^2.0.0"
@@ -15284,7 +15284,7 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"resolved": false,
 					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -15292,7 +15292,7 @@
 				},
 				"iferr": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg=="
 				},
 				"ignore-walk": {
@@ -15305,22 +15305,22 @@
 				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 				},
 				"infer-owner": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
 						"once": "^1.3.0",
@@ -15329,17 +15329,17 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 				},
 				"init-package-json": {
 					"version": "1.10.3",
-					"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
 					"requires": {
 						"glob": "^7.1.1",
@@ -15354,27 +15354,27 @@
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 				},
 				"ip": {
 					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 				},
 				"ip-regex": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
 				},
 				"is-callable": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
 				},
 				"is-ci": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 					"requires": {
 						"ci-info": "^1.0.0"
@@ -15382,14 +15382,14 @@
 					"dependencies": {
 						"ci-info": {
 							"version": "1.6.0",
-							"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
 						}
 					}
 				},
 				"is-cidr": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
 					"requires": {
 						"cidr-regex": "^2.0.10"
@@ -15397,12 +15397,12 @@
 				},
 				"is-date-object": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -15410,7 +15410,7 @@
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 					"requires": {
 						"global-dirs": "^0.1.0",
@@ -15419,17 +15419,17 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"requires": {
 						"path-is-inside": "^1.0.1"
@@ -15437,12 +15437,12 @@
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 				},
 				"is-regex": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 					"requires": {
 						"has": "^1.0.1"
@@ -15450,17 +15450,17 @@
 				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 				},
 				"is-symbol": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 					"requires": {
 						"has-symbols": "^1.0.0"
@@ -15468,58 +15468,58 @@
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"optional": true
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 				},
 				"json-schema-traverse": {
 					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 				},
 				"jsonparse": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 				},
 				"jsprim": {
 					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -15530,7 +15530,7 @@
 				},
 				"latest-version": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 					"requires": {
 						"package-json": "^4.0.0"
@@ -15538,12 +15538,12 @@
 				},
 				"lazy-property": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -15573,7 +15573,7 @@
 				},
 				"libnpm": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -15600,7 +15600,7 @@
 				},
 				"libnpmaccess": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
 					"requires": {
 						"aproba": "^2.0.0",
@@ -15611,7 +15611,7 @@
 				},
 				"libnpmconfig": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -15621,7 +15621,7 @@
 					"dependencies": {
 						"find-up": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 							"requires": {
 								"locate-path": "^3.0.0"
@@ -15629,7 +15629,7 @@
 						},
 						"locate-path": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 							"requires": {
 								"p-locate": "^3.0.0",
@@ -15638,7 +15638,7 @@
 						},
 						"p-limit": {
 							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 							"requires": {
 								"p-try": "^2.0.0"
@@ -15646,7 +15646,7 @@
 						},
 						"p-locate": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 							"requires": {
 								"p-limit": "^2.0.0"
@@ -15654,14 +15654,14 @@
 						},
 						"p-try": {
 							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 						}
 					}
 				},
 				"libnpmhook": {
 					"version": "5.0.3",
-					"resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
 					"requires": {
 						"aproba": "^2.0.0",
@@ -15672,7 +15672,7 @@
 				},
 				"libnpmorg": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
 					"requires": {
 						"aproba": "^2.0.0",
@@ -15683,7 +15683,7 @@
 				},
 				"libnpmpublish": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
 					"requires": {
 						"aproba": "^2.0.0",
@@ -15699,7 +15699,7 @@
 				},
 				"libnpmsearch": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -15709,7 +15709,7 @@
 				},
 				"libnpmteam": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
 					"requires": {
 						"aproba": "^2.0.0",
@@ -15720,7 +15720,7 @@
 				},
 				"libnpx": {
 					"version": "10.2.0",
-					"resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
 					"requires": {
 						"dotenv": "^5.0.1",
@@ -15735,7 +15735,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -15744,7 +15744,7 @@
 				},
 				"lock-verify": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
 					"requires": {
 						"npm-package-arg": "^6.1.0",
@@ -15753,7 +15753,7 @@
 				},
 				"lockfile": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
 					"requires": {
 						"signal-exit": "^3.0.2"
@@ -15761,12 +15761,12 @@
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
 				},
 				"lodash._baseuniq": {
 					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
 					"requires": {
 						"lodash._createset": "~4.0.0",
@@ -15775,17 +15775,17 @@
 				},
 				"lodash._bindcallback": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
 				},
 				"lodash._cacheindexof": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
 				},
 				"lodash._createcache": {
 					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
 					"requires": {
 						"lodash._getnative": "^3.0.0"
@@ -15793,52 +15793,52 @@
 				},
 				"lodash._createset": {
 					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
 				},
 				"lodash._getnative": {
 					"version": "3.9.1",
-					"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 				},
 				"lodash._root": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 				},
 				"lodash.restparam": {
 					"version": "3.6.1",
-					"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
 				},
 				"lodash.union": {
 					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
 				},
 				"lodash.uniq": {
 					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 				},
 				"lodash.without": {
 					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 				},
 				"lru-cache": {
 					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
 						"yallist": "^3.0.2"
@@ -15846,7 +15846,7 @@
 				},
 				"make-dir": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"requires": {
 						"pify": "^3.0.0"
@@ -15872,12 +15872,12 @@
 				},
 				"meant": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -15885,12 +15885,12 @@
 				},
 				"mime-db": {
 					"version": "1.35.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
 				},
 				"mime-types": {
 					"version": "2.1.19",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+					"resolved": false,
 					"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
 					"requires": {
 						"mime-db": "~1.35.0"
@@ -15898,12 +15898,12 @@
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -15911,7 +15911,7 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"minipass": {
@@ -15940,7 +15940,7 @@
 				},
 				"mississippi": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 					"requires": {
 						"concat-stream": "^1.5.0",
@@ -15957,7 +15957,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"requires": {
 						"minimist": "0.0.8"
@@ -15965,7 +15965,7 @@
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"requires": {
 						"aproba": "^1.1.1",
@@ -15978,24 +15978,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 						}
 					}
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				},
 				"mute-stream": {
 					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"resolved": false,
 					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 				},
 				"node-fetch-npm": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
 					"requires": {
 						"encoding": "^0.1.11",
@@ -16023,7 +16023,7 @@
 					"dependencies": {
 						"nopt": {
 							"version": "3.0.6",
-							"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+							"resolved": false,
 							"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 							"requires": {
 								"abbrev": "1"
@@ -16031,14 +16031,14 @@
 						},
 						"semver": {
 							"version": "5.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 						}
 					}
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"requires": {
 						"abbrev": "1",
@@ -16047,7 +16047,7 @@
 				},
 				"normalize-package-data": {
 					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 					"requires": {
 						"hosted-git-info": "^2.1.4",
@@ -16058,7 +16058,7 @@
 					"dependencies": {
 						"resolve": {
 							"version": "1.10.0",
-							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 							"requires": {
 								"path-parse": "^1.0.6"
@@ -16068,7 +16068,7 @@
 				},
 				"npm-audit-report": {
 					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
 					"requires": {
 						"cli-table3": "^0.5.0",
@@ -16082,7 +16082,7 @@
 				},
 				"npm-cache-filename": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
 				},
 				"npm-install-checks": {
@@ -16110,7 +16110,7 @@
 				},
 				"npm-logical-tree": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
 				},
 				"npm-package-arg": {
@@ -16145,7 +16145,7 @@
 				},
 				"npm-profile": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-VRsC04pvRH+9cF+PoVh2nTmJjiG21yu59IHpsBpkxk+jaGAV8lxx96G4SDc0jOHAkfWLXbc6kIph3dGAuRnotQ==",
 					"requires": {
 						"aproba": "^1.1.2 || 2",
@@ -16168,7 +16168,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"requires": {
 						"path-key": "^2.0.0"
@@ -16176,12 +16176,12 @@
 				},
 				"npm-user-validate": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -16192,27 +16192,27 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 				},
 				"object-keys": {
 					"version": "1.0.12",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+					"resolved": false,
 					"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
 				},
 				"object.getownpropertydescriptors": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 					"requires": {
 						"define-properties": "^1.1.2",
@@ -16221,7 +16221,7 @@
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
 						"wrappy": "1"
@@ -16229,17 +16229,17 @@
 				},
 				"opener": {
 					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"requires": {
 						"execa": "^0.7.0",
@@ -16249,12 +16249,12 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -16263,12 +16263,12 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 				},
 				"p-limit": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"requires": {
 						"p-try": "^1.0.0"
@@ -16276,7 +16276,7 @@
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -16284,12 +16284,12 @@
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"package-json": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"requires": {
 						"got": "^6.7.1",
@@ -16347,7 +16347,7 @@
 				},
 				"parallel-transform": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"requires": {
 						"cyclist": "~0.2.2",
@@ -16357,7 +16357,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -16371,7 +16371,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -16381,57 +16381,57 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 				},
 				"path-parse": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 				},
 				"performance-now": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 				},
 				"pify": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 				},
 				"promise-inflight": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 				},
 				"promise-retry": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
 					"requires": {
 						"err-code": "^1.0.0",
@@ -16440,14 +16440,14 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 						}
 					}
 				},
 				"promzard": {
 					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 					"requires": {
 						"read": "1"
@@ -16455,12 +16455,12 @@
 				},
 				"proto-list": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 				},
 				"protoduck": {
 					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
 					"requires": {
 						"genfun": "^5.0.0"
@@ -16468,22 +16468,22 @@
 				},
 				"prr": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 				},
 				"psl": {
 					"version": "1.1.29",
-					"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+					"resolved": false,
 					"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
 				},
 				"pump": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -16492,7 +16492,7 @@
 				},
 				"pumpify": {
 					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 					"requires": {
 						"duplexify": "^3.6.0",
@@ -16502,7 +16502,7 @@
 					"dependencies": {
 						"pump": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 							"requires": {
 								"end-of-stream": "^1.1.0",
@@ -16513,22 +16513,22 @@
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				},
 				"qrcode-terminal": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
 				},
 				"qs": {
 					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 				},
 				"query-string": {
 					"version": "6.8.2",
-					"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
 					"requires": {
 						"decode-uri-component": "^0.2.0",
@@ -16538,12 +16538,12 @@
 				},
 				"qw": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
 				},
 				"rc": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+					"resolved": false,
 					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -16554,14 +16554,14 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 						}
 					}
 				},
 				"read": {
 					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+					"resolved": false,
 					"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 					"requires": {
 						"mute-stream": "~0.0.4"
@@ -16577,7 +16577,7 @@
 				},
 				"read-installed": {
 					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -16603,7 +16603,7 @@
 				},
 				"read-package-tree": {
 					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
 					"requires": {
 						"read-package-json": "^2.0.0",
@@ -16613,7 +16613,7 @@
 				},
 				"readable-stream": {
 					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"requires": {
 						"inherits": "^2.0.3",
@@ -16623,7 +16623,7 @@
 				},
 				"readdir-scoped-modules": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -16634,7 +16634,7 @@
 				},
 				"registry-auth-token": {
 					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"requires": {
 						"rc": "^1.1.6",
@@ -16643,7 +16643,7 @@
 				},
 				"registry-url": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"requires": {
 						"rc": "^1.0.1"
@@ -16651,7 +16651,7 @@
 				},
 				"request": {
 					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 					"requires": {
 						"aws-sign2": "~0.7.0",
@@ -16678,27 +16678,27 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				},
 				"retry": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
 				},
 				"rimraf": {
 					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 					"requires": {
 						"glob": "^7.1.3"
@@ -16706,7 +16706,7 @@
 				},
 				"run-queue": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"requires": {
 						"aproba": "^1.1.1"
@@ -16714,29 +16714,29 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 						}
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
 				"semver-diff": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 					"requires": {
 						"semver": "^5.0.3"
@@ -16744,12 +16744,12 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 				},
 				"sha": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -16757,7 +16757,7 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -16765,12 +16765,12 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 				},
 				"slash": {
@@ -16780,7 +16780,7 @@
 				},
 				"slide": {
 					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 				},
 				"smart-buffer": {
@@ -16799,7 +16799,7 @@
 				},
 				"socks-proxy-agent": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
 					"requires": {
 						"agent-base": "~4.2.1",
@@ -16808,7 +16808,7 @@
 					"dependencies": {
 						"agent-base": {
 							"version": "4.2.1",
-							"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
 							"requires": {
 								"es6-promisify": "^5.0.0"
@@ -16818,12 +16818,12 @@
 				},
 				"sorted-object": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
 				},
 				"sorted-union-stream": {
 					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
 					"requires": {
 						"from2": "^1.3.0",
@@ -16832,7 +16832,7 @@
 					"dependencies": {
 						"from2": {
 							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
 							"requires": {
 								"inherits": "~2.0.1",
@@ -16841,12 +16841,12 @@
 						},
 						"isarray": {
 							"version": "0.0.1",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 						},
 						"readable-stream": {
 							"version": "1.1.14",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+							"resolved": false,
 							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -16857,14 +16857,14 @@
 						},
 						"string_decoder": {
 							"version": "0.10.31",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"resolved": false,
 							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
@@ -16873,12 +16873,12 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
@@ -16887,17 +16887,17 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
 				},
 				"split-on-first": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
 				},
 				"sshpk": {
 					"version": "1.14.2",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 					"requires": {
 						"asn1": "~0.2.3",
@@ -16913,7 +16913,7 @@
 				},
 				"ssri": {
 					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 					"requires": {
 						"figgy-pudding": "^3.5.1"
@@ -16921,7 +16921,7 @@
 				},
 				"stream-each": {
 					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -16930,7 +16930,7 @@
 				},
 				"stream-iterate": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -16939,7 +16939,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -16953,7 +16953,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -16963,17 +16963,17 @@
 				},
 				"stream-shift": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 				},
 				"strict-uri-encode": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -16982,17 +16982,17 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -17002,7 +17002,7 @@
 				},
 				"string_decoder": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -17015,7 +17015,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -17023,17 +17023,17 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -17071,7 +17071,7 @@
 				},
 				"term-size": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 					"requires": {
 						"execa": "^0.7.0"
@@ -17079,17 +17079,17 @@
 				},
 				"text-table": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 				},
 				"through": {
 					"version": "2.3.8",
-					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+					"resolved": false,
 					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 				},
 				"through2": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -17098,7 +17098,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"resolved": false,
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -17112,7 +17112,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"resolved": false,
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -17122,17 +17122,17 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 				},
 				"tiny-relative-date": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"requires": {
 						"psl": "^1.1.24",
@@ -17141,7 +17141,7 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -17149,28 +17149,28 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"resolved": false,
 					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"optional": true
 				},
 				"typedarray": {
 					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
 				},
 				"umask": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
 				},
 				"unique-filename": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 					"requires": {
 						"unique-slug": "^2.0.0"
@@ -17178,7 +17178,7 @@
 				},
 				"unique-slug": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -17186,7 +17186,7 @@
 				},
 				"unique-string": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 					"requires": {
 						"crypto-random-string": "^1.0.0"
@@ -17194,17 +17194,17 @@
 				},
 				"unpipe": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 				},
 				"update-notifier": {
 					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 					"requires": {
 						"boxen": "^1.2.1",
@@ -17221,7 +17221,7 @@
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"requires": {
 						"prepend-http": "^1.0.1"
@@ -17229,17 +17229,17 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"util-extend": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
 				},
 				"util-promisify": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
 					"requires": {
 						"object.getownpropertydescriptors": "^2.0.3"
@@ -17252,7 +17252,7 @@
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"requires": {
 						"spdx-correct": "^3.0.0",
@@ -17261,7 +17261,7 @@
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 					"requires": {
 						"builtins": "^1.0.3"
@@ -17269,7 +17269,7 @@
 				},
 				"verror": {
 					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -17279,7 +17279,7 @@
 				},
 				"wcwidth": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"requires": {
 						"defaults": "^1.0.3"
@@ -17287,7 +17287,7 @@
 				},
 				"which": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"requires": {
 						"isexe": "^2.0.0"
@@ -17295,12 +17295,12 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"requires": {
 						"string-width": "^1.0.2"
@@ -17308,7 +17308,7 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -17320,7 +17320,7 @@
 				},
 				"widest-line": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 					"requires": {
 						"string-width": "^2.1.1"
@@ -17328,7 +17328,7 @@
 				},
 				"worker-farm": {
 					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 					"requires": {
 						"errno": "~0.1.7"
@@ -17336,7 +17336,7 @@
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
 						"string-width": "^1.0.1",
@@ -17345,7 +17345,7 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"resolved": false,
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -17357,12 +17357,12 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"write-file-atomic": {
 					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -17372,27 +17372,27 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
 				},
 				"xtend": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				},
 				"yargs": {
 					"version": "11.0.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -17411,14 +17411,14 @@
 					"dependencies": {
 						"y18n": {
 							"version": "3.2.1",
-							"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+							"resolved": false,
 							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 						}
 					}
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"requires": {
 						"camelcase": "^4.1.0"

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -50,6 +50,7 @@ export { default as createTheme } from './createTheme'
 export {
   borders,
   color,
+  deprecatedPropType,
   getContrastRatio,
   getPaletteColor,
   getTextColorOn,

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -12,7 +12,7 @@
   "author": "Priceline",
   "license": "MIT",
   "dependencies": {
-    "@reach/dialog": "^0.1.2",
+    "@reach/dialog": "^0.7.0",
     "prop-types": "^15.7.2",
     "react-transition-group": "^2.5.3"
   },

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -12,18 +12,23 @@
   "author": "Priceline",
   "license": "MIT",
   "jest": {
-    "coverageReporters": ["lcov", "html"],
-    "setupFilesAfterEnv": ["../../test-setup.js"],
-    "testMatch": ["<rootDir>/test/**/*.js"]
-  },
-  "dependencies": {
-    "react-popper": "^1.3.3"
+    "coverageReporters": [
+      "lcov",
+      "html"
+    ],
+    "setupFilesAfterEnv": [
+      "../../test-setup.js"
+    ],
+    "testMatch": [
+      "<rootDir>/test/**/*.js"
+    ]
   },
   "peerDependencies": {
     "pcln-design-system": ">=2.x",
     "styled-components": ">=3.x <5",
     "react": ">=16.3.0",
-    "react-dom": ">=16.3.0"
+    "react-dom": ">=16.3.0",
+    "react-popper": "^1.3.3"
   },
   "devDependencies": {
     "@reach/component-component": "^0.1.1",
@@ -31,6 +36,7 @@
     "pcln-design-system": "^2.6.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
+    "react-popper": "^1.3.3",
     "react-test-renderer": "^16.10.2",
     "styled-components": "^4.4.0"
   },


### PR DESCRIPTION
- Adds an export to core to allow compatibility with pcln-modal v3
- Makes react-popper a peerDependency to alleviate publishing error
- Uses latest @reach/dialog in pcln-modal