### PR TITLE
Update @reach/dialog in pcln-modal

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -17,7 +17,7 @@
   "author": "Priceline",
   "license": "MIT",
   "dependencies": {
-    "@reach/dialog": "^0.1.2",
+    "@reach/dialog": "^0.7.0",
     "react-transition-group": "^2.5.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
This will allow the host app to specify which versions of dependencies it would like to use, for modal and popover components.