### PR TITLE
feat(deprecated-prop-type-v2): export deprecatedPropType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 script: npm test -- --coverage --runInBand
 after_success:
   - npm run codecov
+before_install:
+  - npm i -g npm@6.4.1
 before_deploy:
   - cd docs
   - npm install

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -50,6 +50,7 @@ export { default as createTheme } from './createTheme'
 export {
   borders,
   color,
+  deprecatedPropType,
   getContrastRatio,
   getPaletteColor,
   getTextColorOn,


### PR DESCRIPTION
Here is a non-breaking change for DS v2 that would allow DS v2 to be used alongside pcln-modal v3