### PR TITLE
fix(browser-modal): fix browser specific bugs

### DIFF
--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -99,7 +99,7 @@ const ContentWrapper = styled(Box)`
   ${props => {
     if (!props.enableoverflow) {
       return `
-        overflow-y: scroll;
+        overflow-y: auto;
         overflow-x: hidden;
         height: 100%;
         -webkit-overflow-scrolling: touch;
@@ -117,6 +117,8 @@ const OverlayWrapper = styled.div`
 const DialogWrapper = styled(Box)`
   display: table-cell;
   vertical-align: ${({ verticalAlignment }) => verticalAlignment};
+  position: relative;
+  height: 100%;
   ${props =>
     props.enableoverflow &&
     `


### PR DESCRIPTION
This addresses a couple browser specific bugs.

1. Changes overflow to auto instead of scroll, so IE11 won't always show a scroll bar.
2. Adds relative position and height 100% to prevent an edge case in Firefox where a percentage height of the modal could be ignored