### PR TITLE
modal header close button focus uses palette color

### DIFF
--- a/packages/modal/src/ModalHeader.js
+++ b/packages/modal/src/ModalHeader.js
@@ -13,7 +13,7 @@ const StyledCloseButton = styled(CloseButton)`
   }
 
   &:focus {
-    background-color: ${props => props.theme.colors.darkBlue};
+    background-color: ${props => props.theme.palette.primary.dark};
     outline: none;
   }
 `


### PR DESCRIPTION
Replace direct color usage with palette color for the modal header close button to align with the theme.