### PR TITLE
Fix style bug in ModalHeader

### DIFF
--- a/packages/modal/src/ModalHeader.js
+++ b/packages/modal/src/ModalHeader.js
@@ -7,7 +7,14 @@ const HeaderWrapper = styled(Flex)`
   height: 40px;
 `
 
+const Title = styled(Text)`
+  display: flex;
+  align-items: center;
+`
+
 const StyledCloseButton = styled(CloseButton)`
+  height: 24px;
+  width: 24px;
   svg {
     vertical-align: top;
   }
@@ -19,11 +26,17 @@ const StyledCloseButton = styled(CloseButton)`
 `
 
 const ModalHeader = ({ bg, color, onClose, title }) => (
-  <HeaderWrapper align="center" color={color} bg={bg} px={3}>
+  <HeaderWrapper
+    align="center"
+    alignItems="center"
+    color={color}
+    bg={bg}
+    px={3}
+  >
     {title && (
-      <Text fontSize={1} bold>
+      <Title fontSize={1} bold>
         {title}
-      </Text>
+      </Title>
     )}
     {onClose && <StyledCloseButton onClick={onClose} ml="auto" />}
   </HeaderWrapper>

--- a/packages/modal/test/__snapshots__/Headers.js.snap
+++ b/packages/modal/test/__snapshots__/Headers.js.snap
@@ -12,11 +12,6 @@ exports[`ModalHeader render 1`] = `
   outline: none;
 }
 
-.c2 {
-  font-size: 14px;
-  font-weight: 700;
-}
-
 .c3 {
   -webkit-font-smoothing: antialiased;
   display: inline-block;
@@ -76,7 +71,29 @@ exports[`ModalHeader render 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   height: 40px;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 700;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  height: 24px;
+  width: 24px;
 }
 
 .c4 svg {


### PR DESCRIPTION
Noticed this when installing `pcln-modal` in a host app using `styled-components@4` and `design-system@2`.

Before:
<img width="613" alt="Screen Shot 2020-03-18 at 11 19 16 AM" src="https://user-images.githubusercontent.com/3260642/76976448-58e1bd80-690a-11ea-8aa5-4707fef3c2d8.png">

After:
<img width="660" alt="Screen Shot 2020-03-18 at 11 24 24 AM" src="https://user-images.githubusercontent.com/3260642/76976952-0ead0c00-690b-11ea-8b45-21f7c80890fd.png">

Tested in Storybook
