### PR TITLE
Bump core version to reflect latest published version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
The latest published version of `pcln-design-system` is `3.2.0`, but the version bump was never committed.