### PR TITLE
Change checkbox hover color to dark rather than dark blue

### DIFF
--- a/packages/core/src/Checkbox.js
+++ b/packages/core/src/Checkbox.js
@@ -83,9 +83,8 @@ const CheckBoxWrapper = styled(Box)`
     &:hover ~ svg[data-name='checked'] {
       color: ${props =>
         props.disabled
-          ? props.theme.colors.borderGray
-          : props.theme.colors.darkBlue};
-        }
+          ? getPaletteColor('border.base')(props)
+          : getPaletteColor('dark')(props)}
   }
 
   ${applyVariations('Checkbox')}

--- a/packages/core/test/__snapshots__/Checkbox.js.snap
+++ b/packages/core/test/__snapshots__/Checkbox.js.snap
@@ -333,7 +333,7 @@ exports[`Checkbox renders with the theme passed specifically 1`] = `
 }
 
 .c0 > input:checked:hover ~ svg[data-name='checked'] {
-  color: #049;
+  color: primary;
 }
 
 .c1 {


### PR DESCRIPTION
Found an issue where the hover color of the checkbox was not respecting the given color based on the theme.

Before:
![image](https://user-images.githubusercontent.com/9325039/77691133-63d3c800-6f72-11ea-8d84-a8ecfc7b055c.png)

After:
![image](https://user-images.githubusercontent.com/9325039/77691009-35ee8380-6f72-11ea-9a58-152e89adebcc.png)
