### PR TITLE
Modal Timeout Prop

### DIFF
--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -14,7 +14,6 @@ import Modal from 'pcln-modal'
 
 ```jsx
 import { Modal } from 'pcln-modal'
-
 ;<Modal
   isOpen={true} //boolean for control this status of modal
   onClose={someFunc} //func function for handle close the modal while click on the overlay
@@ -29,6 +28,7 @@ import { Modal } from 'pcln-modal'
   verticalAlignment="middle" // Aligns dialog body vertically - options = ['middle', 'top', 'bottom']
   overlayAnimation={null} // Accepts a function which overwrites default animation
   dialogAnimation={null} // Accepts a function which overwrites default animation
+  timeout={500} // Accepts a number which overwrites the default delay for the open animation to begin, default is 500ms
 >
   <SomeChildComponent />
 </Modal>

--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -145,11 +145,12 @@ const Modal = ({
   disableCloseButton,
   enableOverflow,
   height,
+  timeout,
   dialogAnimation,
   overlayAnimation,
   verticalAlignment
 }) => (
-  <Transition in={isOpen} unmountOnExit timeout={500}>
+  <Transition in={isOpen} unmountOnExit timeout={timeout}>
     {state => (
       <Overlay
         onDismiss={onClose}
@@ -206,6 +207,7 @@ Modal.defaultProps = {
   header: null,
   bg: 'white',
   height: 420,
+  timeout: 500,
   overlayAnimation: null,
   dialogAnimation: null,
   verticalAlignment: 'middle'
@@ -225,6 +227,7 @@ Modal.propTypes = {
   imgMode: PropTypes.bool,
   className: PropTypes.string,
   header: PropTypes.any,
+  timeout: PropTypes.number,
   overlayAnimation: PropTypes.func,
   dialogAnimation: PropTypes.func,
   verticalAlignment: PropTypes.string

--- a/packages/modal/storybook/Modal.js
+++ b/packages/modal/storybook/Modal.js
@@ -115,3 +115,10 @@ storiesOf('Modal', module)
       verticalAlignment="top"
     />
   ))
+  .add('Zero Timeout', () => (
+    <ModalStory
+      disableCloseButton
+      width={['100px', '200px', '500px']}
+      timeout={0}
+    />
+  ))


### PR DESCRIPTION
Closes #757 

Tested and confirmed that the timeout on the Transition component was causing the open delay.