### PR TITLE
fix: Re-add target prop to link

### DIFF
--- a/packages/core/src/Link.js
+++ b/packages/core/src/Link.js
@@ -7,7 +7,7 @@ import {
   getPaletteColor,
   deprecatedColorValue
 } from './utils'
-import { buttonStyles } from '../src/Button'
+import { buttonStyles } from './Button'
 
 const variations = {
   fill: css`
@@ -34,6 +34,7 @@ const variations = {
 
 const Link = mapProps(({ target, ...props }) => ({
   rel: target === '_blank' ? 'noopener' : null,
+  target,
   ...props
 }))(styled.a`
   ${width} ${space};

--- a/packages/core/test/__snapshots__/BlockLink.js.snap
+++ b/packages/core/test/__snapshots__/BlockLink.js.snap
@@ -2,26 +2,35 @@
 
 exports[`BlockLink renders 1`] = `
 .c0 {
-  cursor: pointer;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
-  color: #007aff;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
   display: block;
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c0:hover {
-  color: #049;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+.c0:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 <a
   className="c0"
-  color="primary"
-  rel={null}
 >
   raw text
 </a>

--- a/packages/core/test/__snapshots__/Breadcrumbs.js.snap
+++ b/packages/core/test/__snapshots__/Breadcrumbs.js.snap
@@ -25,6 +25,28 @@ exports[`Breadcrumbs renders basic 1`] = `
 }
 
 .c2 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #4f6f8f;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -37,11 +59,57 @@ exports[`Breadcrumbs renders basic 1`] = `
   text-decoration: underline;
 }
 
+.c2:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
+}
+
+.c2:hover {
+  color: #4f6f8f;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c4 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #001023;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #001023;
+}
+
+.c4:hover {
+  color: #001023;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c4:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 .c4:hover {
@@ -159,6 +227,28 @@ exports[`Breadcrumbs renders with icons 1`] = `
 }
 
 .c4 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #4f6f8f;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -171,11 +261,57 @@ exports[`Breadcrumbs renders with icons 1`] = `
   text-decoration: underline;
 }
 
+.c4:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
+}
+
+.c4:hover {
+  color: #4f6f8f;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
 .c9 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #001023;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #001023;
+}
+
+.c9:hover {
+  color: #001023;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 .c9:hover {

--- a/packages/core/test/__snapshots__/Link.js.snap
+++ b/packages/core/test/__snapshots__/Link.js.snap
@@ -2,10 +2,44 @@
 
 exports[`Link adds a safe rel when target is blank 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #007aff;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #007aff;
+}
+
+.c0:hover {
+  color: #049;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 .c0:hover {
@@ -26,10 +60,44 @@ exports[`Link adds a safe rel when target is blank 1`] = `
 
 exports[`Link does not add a safe rel when target is not blank 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #007aff;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #007aff;
+}
+
+.c0:hover {
+  color: #049;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 .c0:hover {
@@ -49,10 +117,44 @@ exports[`Link does not add a safe rel when target is not blank 1`] = `
 
 exports[`Link renders 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  -webkit-font-smoothing: inherit;
+  font-weight: 500;
+  color: #007aff;
+  line-height: 1.4;
+  vertical-align: inherit;
+  padding: 0;
+  background-color: transparent;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #007aff;
+}
+
+.c0:hover {
+  color: #049;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:disabled {
+  cursor: not-allowed;
+  color: #4f6f8f;
+  background-color: #edf0f3;
 }
 
 .c0:hover {


### PR DESCRIPTION
- The `target` prop was not getting set on the `Link` component, was revealed when updating the snapshots for tests
- Added `target` back and updated snapshots
- Tweaked import for `buttonStyles` in `Link` so that storybook builds successfully (see screenshot for error)

<img width="1676" alt="Screen Shot 2020-04-28 at 10 51 50 AM" src="https://user-images.githubusercontent.com/12076625/80522479-423f7500-8952-11ea-9736-470d2cc31ef4.png">
