### PR TITLE
Bump core to 3.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Draft release: https://github.com/priceline/design-system/releases/tag/untagged-3efad8f6527c67467436