### PR TITLE
Fix ref prop type ssr

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -295,6 +295,6 @@ export const borders = props => {
 export const refPropType = PropTypes.oneOfType([
   // Either a function
   PropTypes.func,
-  // Or the instance of a DOM native element (see the note about SSR)
-  PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  // Or the instance of any prop type on the current property
+  PropTypes.shape({ current: PropTypes.any })
 ])


### PR DESCRIPTION
Apps using SSR were getting `Element is undefined` errors because we were using `Element` from DOM, which DNE in a Node environment. This makes that prop type more permissive and no longer uses `Element`.