### PR TITLE
Lazy Loading by Default

### DIFF
--- a/packages/core/src/Image.js
+++ b/packages/core/src/Image.js
@@ -2,7 +2,8 @@ import styled from 'styled-components'
 import { width } from 'styled-system'
 
 const Image = styled.img.attrs(props => ({
-  height: props.height || 'auto'
+  height: props.height || 'auto',
+  loading: props.loading || 'lazy'
 }))`
   display: block;
   max-width: 100%;

--- a/packages/core/test/__snapshots__/Image.js.snap
+++ b/packages/core/test/__snapshots__/Image.js.snap
@@ -9,6 +9,7 @@ exports[`Image renders 1`] = `
 <img
   className="c0"
   height="auto"
+  loading="lazy"
   src="https://www.qaa.priceline.com/home/public/735e9d77a0adaeaf0c46845da8c5db8b.jpg"
 />
 `;


### PR DESCRIPTION
Closes #142 

https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

Chrome is already defaulting to lazy load so this doesn't change existing behaviour but it adds the ability to change it if desired.

![image](https://user-images.githubusercontent.com/62619213/81000515-06058c00-8e0c-11ea-96c7-6dc28df8be29.png)
