### PR TITLE
fix(721): Remove hardcoded popover theme

### DIFF
--- a/packages/popover/src/Arrow.js
+++ b/packages/popover/src/Arrow.js
@@ -1,22 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { deprecatedPropType, theme } from 'pcln-design-system'
+import { deprecatedPropType, getPaletteColor } from 'pcln-design-system'
 
 const PopoverArrow = ({
   arrowProps,
   placement,
-  background,
   borderColor,
+  color,
   className
 }) => (
   <Arrow
     className={className}
     style={arrowProps.style}
     data-placement={placement}
-    theme={theme}
-    background={background}
     borderColor={borderColor}
+    color={color}
     aria-hidden="true"
   >
     <div ref={arrowProps.ref} />
@@ -53,9 +52,9 @@ const ArrowAlignment = () =>
     }
   `
 
-const ArrowPlacement = ({ background, borderColor }) => {
-  const bgColor = theme.colors[background]
-  const brColor = theme.colors[borderColor]
+const ArrowPlacement = ({ color, borderColor, ...props }) => {
+  const bgColor = getPaletteColor(color, 'base')(props)
+  const brColor = getPaletteColor(borderColor, 'base')(props)
 
   return `
     &[data-placement*="right"]::before {
@@ -82,6 +81,7 @@ const ArrowPlacement = ({ background, borderColor }) => {
     }
   `
 }
+
 const Arrow = styled.span`
   position: absolute;
   ${ArrowAlignment}
@@ -94,14 +94,13 @@ PopoverArrow.propTypes = {
     style: PropTypes.object
   }).isRequired,
   className: PropTypes.string,
+  color: PropTypes.string,
   bg: deprecatedPropType('color'),
   borderColor: PropTypes.string,
   placement: PropTypes.string
 }
 
 PopoverArrow.defaultProps = {
-  bg: 'white',
-  borderColor: 'borderGray',
   placement: 'top'
 }
 

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -96,6 +96,7 @@ Popover.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
   p: PropTypes.number,
+  color: PropTypes.string,
   bg: deprecatedPropType('color'),
   borderColor: PropTypes.string,
   placement: PropTypes.string,
@@ -108,7 +109,7 @@ Popover.propTypes = {
 }
 
 Popover.defaultProps = {
-  ariaLabel: 'Click to open popover with more information',
+  ariaLabel: 'Click to open popover with more information'
 }
 
 export default Popover

--- a/packages/popover/storybook/Popover.js
+++ b/packages/popover/storybook/Popover.js
@@ -4,17 +4,17 @@ import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { DraggableParent, DraggableItem } from 'react-draggable-playground'
 import styled from 'styled-components'
 import {
-  ThemeProvider,
-  Flex,
+  Absolute,
+  BackgroundImage,
+  Box,
   Button,
   CloseButton,
-  Box,
-  Text,
-  BackgroundImage,
-  Absolute,
-  Link,
+  Flex,
+  getPaletteColor,
   Icon,
-  getPaletteColor
+  Link,
+  Text,
+  ThemeProvider
 } from 'pcln-design-system'
 import Component from '@reach/component-component'
 import Slider from '../../slider/src'
@@ -39,6 +39,53 @@ storiesOf('Popover', module)
       </Playground>
     </React.Fragment>
   ))
+  .add('Colors', () => (
+    <Flex>
+      <Popover
+        renderContent={SimpleTextContent}
+        placement="bottom"
+        ariaLabel="Default Popover"
+        width={130}
+      >
+        <Button color="primary" variation="outline" mx={2}>
+          Default Popover
+        </Button>
+      </Popover>
+      <Popover
+        renderContent={SimpleTextContent}
+        placement="bottom"
+        ariaLabel="Success Popover"
+        width={130}
+        color="success"
+      >
+        <Button color="success" variation="outline" mx={2}>
+          Success Popover
+        </Button>
+      </Popover>
+      <Popover
+        renderContent={SimpleTextContent}
+        placement="bottom"
+        ariaLabel="Alert Popover"
+        width={130}
+        color="alert"
+      >
+        <Button color="alert" variation="outline" mx={2}>
+          Alert Popover
+        </Button>
+      </Popover>
+      <Popover
+        renderContent={SimpleTextContent}
+        placement="bottom"
+        ariaLabel="Error Popover"
+        width={130}
+        color="error"
+      >
+        <Button color="error" variation="outline" mx={2}>
+          Error Popover
+        </Button>
+      </Popover>
+    </Flex>
+  ))
   .add('Forced open via prop', () => (
     <Popover
       renderContent={InnerContent}
@@ -46,7 +93,6 @@ storiesOf('Popover', module)
       ariaLabel="Bottom Popover"
       idx={2}
       width={400}
-      borderColor="darkGray"
       isOpen
     >
       <Link>Open Popover</Link>
@@ -59,7 +105,6 @@ storiesOf('Popover', module)
       ariaLabel="Bottom Popover"
       idx={2}
       width={400}
-      borderColor="darkGray"
       openOnMount
     >
       <Link>Open Popover</Link>
@@ -72,7 +117,6 @@ storiesOf('Popover', module)
       ariaLabel="Bottom Popover"
       idx={2}
       width={400}
-      borderColor="darkGray"
     >
       <Link>Open Popover</Link>
     </Popover>
@@ -88,8 +132,8 @@ storiesOf('Popover', module)
           idx={1}
           width={400}
           overlayOpacity={0.3}
-          bg="lightRed"
-          borderColor="darkRed"
+          color="error.light"
+          borderColor="error.dark"
         >
           <Button>Popover</Button>
         </Popover>
@@ -100,6 +144,14 @@ storiesOf('Popover', module)
 const StyledBox = styled(Box)`
   border-top: 1px solid ${getPaletteColor('border.base')};
 `
+
+const SimpleTextContent = () => (
+  <ThemeProvider>
+    <Box p={2}>
+      <Text textAlign="center">Hello world!</Text>
+    </Box>
+  </ThemeProvider>
+)
 
 const Playground = ({ children }) => (
   <DraggableParent height="calc(100vh - 32px)" width="(100vw - 32px)">

--- a/packages/popover/test/__snapshots__/Popover.js.snap
+++ b/packages/popover/test/__snapshots__/Popover.js.snap
@@ -68,30 +68,30 @@ exports[`Popover Trigger Element renders with FocusLock 1`] = `
 `;
 
 exports[`Popover UI Positioning Bottom 1`] = `
-.c2 {
+.c3 {
   position: absolute;
 }
 
-.c2[data-placement*="right"] {
+.c3[data-placement*="right"] {
   left: 0;
 }
 
-.c2[data-placement*="left"] {
+.c3[data-placement*="left"] {
   right: 0;
 }
 
-.c2[data-placement*="top"] {
+.c3[data-placement*="top"] {
   bottom: 0;
 }
 
-.c2[data-placement*="bottom"] {
+.c3[data-placement*="bottom"] {
   top: 0;
 }
 
-.c2[data-placement*="bottom"]::before,
-.c2[data-placement*="right"]::before,
-.c2[data-placement*="top"]::after,
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="bottom"]::before,
+.c3[data-placement*="right"]::before,
+.c3[data-placement*="top"]::after,
+.c3[data-placement*="left"]::after {
   content: '';
   position: absolute;
   width: 0;
@@ -107,26 +107,26 @@ exports[`Popover UI Positioning Bottom 1`] = `
   border-width: 6px;
 }
 
-.c2[data-placement*="right"]::before {
+.c3[data-placement*="right"]::before {
   left: 8px;
   border-color: #fff transparent transparent #fff;
   box-shadow: -0.75px -0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="left"]::after {
   right: 13px;
   border-color: transparent #fff #fff transparent;
   box-shadow: 0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="top"]::after {
+.c3[data-placement*="top"]::after {
   top: -16px;
   margin-left: -5px;
   border-color: transparent transparent #fff #fff;
   box-shadow: -0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="bottom"]::before {
+.c3[data-placement*="bottom"]::before {
   top: 16px;
   margin-left: -5px;
   border-color: #fff #fff transparent transparent;
@@ -146,10 +146,15 @@ exports[`Popover UI Positioning Bottom 1`] = `
   box-shadow: 0 0 0 1px #c0cad5, 0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08), 0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
   border-radius: 2px;
-  background: #fff;
   box-sizing: border-box;
   outline: 0;
   max-width: 100%;
+}
+
+.c2 {
+  background-color: #fff;
+  color: #001833;
+  border-radius: 2px;
 }
 
 <div
@@ -166,7 +171,8 @@ exports[`Popover UI Positioning Bottom 1`] = `
     width="400"
   >
     <div
-      class=""
+      class="c2"
+      color="background.lightest"
       id="popover-description-1"
     >
       <div
@@ -183,7 +189,8 @@ exports[`Popover UI Positioning Bottom 1`] = `
   </section>
   <span
     aria-hidden="true"
-    class="c2"
+    class="c3"
+    color="background.lightest"
     data-placement="bottom"
   >
     <div />
@@ -192,30 +199,30 @@ exports[`Popover UI Positioning Bottom 1`] = `
 `;
 
 exports[`Popover UI Positioning Bottom End 1`] = `
-.c2 {
+.c3 {
   position: absolute;
 }
 
-.c2[data-placement*="right"] {
+.c3[data-placement*="right"] {
   left: 0;
 }
 
-.c2[data-placement*="left"] {
+.c3[data-placement*="left"] {
   right: 0;
 }
 
-.c2[data-placement*="top"] {
+.c3[data-placement*="top"] {
   bottom: 0;
 }
 
-.c2[data-placement*="bottom"] {
+.c3[data-placement*="bottom"] {
   top: 0;
 }
 
-.c2[data-placement*="bottom"]::before,
-.c2[data-placement*="right"]::before,
-.c2[data-placement*="top"]::after,
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="bottom"]::before,
+.c3[data-placement*="right"]::before,
+.c3[data-placement*="top"]::after,
+.c3[data-placement*="left"]::after {
   content: '';
   position: absolute;
   width: 0;
@@ -231,26 +238,26 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   border-width: 6px;
 }
 
-.c2[data-placement*="right"]::before {
+.c3[data-placement*="right"]::before {
   left: 8px;
   border-color: #fff transparent transparent #fff;
   box-shadow: -0.75px -0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="left"]::after {
   right: 13px;
   border-color: transparent #fff #fff transparent;
   box-shadow: 0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="top"]::after {
+.c3[data-placement*="top"]::after {
   top: -16px;
   margin-left: -5px;
   border-color: transparent transparent #fff #fff;
   box-shadow: -0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="bottom"]::before {
+.c3[data-placement*="bottom"]::before {
   top: 16px;
   margin-left: -5px;
   border-color: #fff #fff transparent transparent;
@@ -270,10 +277,15 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   box-shadow: 0 0 0 1px #c0cad5, 0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08), 0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
   border-radius: 2px;
-  background: #fff;
   box-sizing: border-box;
   outline: 0;
   max-width: 100%;
+}
+
+.c2 {
+  background-color: #fff;
+  color: #001833;
+  border-radius: 2px;
 }
 
 <div
@@ -290,7 +302,8 @@ exports[`Popover UI Positioning Bottom End 1`] = `
     width="400"
   >
     <div
-      class=""
+      class="c2"
+      color="background.lightest"
       id="popover-description-1"
     >
       <div
@@ -307,7 +320,8 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   </section>
   <span
     aria-hidden="true"
-    class="c2"
+    class="c3"
+    color="background.lightest"
     data-placement="bottom-end"
   >
     <div />
@@ -316,30 +330,30 @@ exports[`Popover UI Positioning Bottom End 1`] = `
 `;
 
 exports[`Popover UI Positioning Bottom Start 1`] = `
-.c2 {
+.c3 {
   position: absolute;
 }
 
-.c2[data-placement*="right"] {
+.c3[data-placement*="right"] {
   left: 0;
 }
 
-.c2[data-placement*="left"] {
+.c3[data-placement*="left"] {
   right: 0;
 }
 
-.c2[data-placement*="top"] {
+.c3[data-placement*="top"] {
   bottom: 0;
 }
 
-.c2[data-placement*="bottom"] {
+.c3[data-placement*="bottom"] {
   top: 0;
 }
 
-.c2[data-placement*="bottom"]::before,
-.c2[data-placement*="right"]::before,
-.c2[data-placement*="top"]::after,
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="bottom"]::before,
+.c3[data-placement*="right"]::before,
+.c3[data-placement*="top"]::after,
+.c3[data-placement*="left"]::after {
   content: '';
   position: absolute;
   width: 0;
@@ -355,26 +369,26 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   border-width: 6px;
 }
 
-.c2[data-placement*="right"]::before {
+.c3[data-placement*="right"]::before {
   left: 8px;
   border-color: #fff transparent transparent #fff;
   box-shadow: -0.75px -0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="left"]::after {
+.c3[data-placement*="left"]::after {
   right: 13px;
   border-color: transparent #fff #fff transparent;
   box-shadow: 0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="top"]::after {
+.c3[data-placement*="top"]::after {
   top: -16px;
   margin-left: -5px;
   border-color: transparent transparent #fff #fff;
   box-shadow: -0.75px 0.75px 0px 0.25px #c0cad5;
 }
 
-.c2[data-placement*="bottom"]::before {
+.c3[data-placement*="bottom"]::before {
   top: 16px;
   margin-left: -5px;
   border-color: #fff #fff transparent transparent;
@@ -394,10 +408,15 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   box-shadow: 0 0 0 1px #c0cad5, 0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08), 0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
   border-radius: 2px;
-  background: #fff;
   box-sizing: border-box;
   outline: 0;
   max-width: 100%;
+}
+
+.c2 {
+  background-color: #fff;
+  color: #001833;
+  border-radius: 2px;
 }
 
 <div
@@ -414,7 +433,8 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
     width="400"
   >
     <div
-      class=""
+      class="c2"
+      color="background.lightest"
       id="popover-description-1"
     >
       <div
@@ -431,7 +451,8 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   </section>
   <span
     aria-hidden="true"
-    class="c2"
+    class="c3"
+    color="background.lightest"
     data-placement="bottom-start"
   >
     <div />


### PR DESCRIPTION
- Remove all instances of hardcoded popover theme
- Remove prop `bg`/`background` from being passed into styles for `Arrow` and other inner components
- Substitute instances of `bg`/`background` with `color`
- Allow for specifying `borderColor` but will default to `border.base` if none is provided
- Added storybook example of theme colored Popovers
- Updated snapshots

#### Screenshots

##### New `Colors` storybook example
![Screen Shot 2020-05-06 at 11 28 01 AM](https://user-images.githubusercontent.com/12076625/81202797-b6020300-8f8c-11ea-9419-0644534f4274.png)

![Screen Shot 2020-05-06 at 11 28 10 AM](https://user-images.githubusercontent.com/12076625/81202799-b6020300-8f8c-11ea-80a6-d7a50fbde866.png)

![Screen Shot 2020-05-06 at 11 21 40 AM](https://user-images.githubusercontent.com/12076625/81202792-b4d0d600-8f8c-11ea-9a5c-42a5074d660c.png)

![Screen Shot 2020-05-06 at 11 21 51 AM](https://user-images.githubusercontent.com/12076625/81202796-b5696c80-8f8c-11ea-8946-48cc3920fcd2.png)

##### Playbook (pre-existing storybook example)
![Screen Shot 2020-05-06 at 11 18 48 AM](https://user-images.githubusercontent.com/12076625/81202669-8f43cc80-8f8c-11ea-97fa-854fc108c9f1.png)

Closes #721 