### PR TITLE
Enable types for core project

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "prepare": "run-s clean build",


### PR DESCRIPTION
In order to quickly identify bugs in the type declarations, I'd like to enable the type declarations so I can gather feedback as a few people work in the core project.