### PR TITLE
add custom padding to flag (#259)

### DIFF
--- a/packages/core/src/Flag/Flag.js
+++ b/packages/core/src/Flag/Flag.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled, { withTheme } from 'styled-components'
-import { themeGet } from 'styled-system'
+import { space, themeGet } from 'styled-system'
 
 import { Flex } from '../Flex'
 import { Hide } from '../Hide'
@@ -73,7 +73,7 @@ const StyledFlex = styled(Flex)`
   ${applyVariations('Flag')}
 `
 
-const Flag = ({ color, bg, children, width, ...props }) => (
+const Flag = ({ color, bg, children, pl, pr, py, width, ...props }) => (
   <StyledFlex width={width} {...props} ml={[0, -2]}>
     <RelativeHide xs>
       <FlagShadow
@@ -87,8 +87,9 @@ const Flag = ({ color, bg, children, width, ...props }) => (
       flexAuto={!!width}
       color={color}
       bg={hasPaletteColor({ color, ...props }) ? false : bg}
-      py={[1, 2]}
-      pl={[1, 3]}
+      pl={pl}
+      pr={pr}
+      py={py}
     >
       {children}
     </FlagBody>
@@ -103,11 +104,15 @@ const Flag = ({ color, bg, children, width, ...props }) => (
 Flag.propTypes = {
   color: deprecatedColorValue(),
   bg: deprecatedPropType('color'),
+  ...space.propTypes,
 }
 
 Flag.defaultProps = {
   color: 'white',
   bg: 'green',
+  pl: [1, 3],
+  pr: null,
+  py: [1, 2],
 }
 
 Flag.displayName = 'Flag'

--- a/packages/core/src/Flag/Flag.stories.js
+++ b/packages/core/src/Flag/Flag.stories.js
@@ -77,3 +77,14 @@ storiesOf('Flag', module)
       </Card>
     </Box>
   ))
+  .add('With custom padding', () => (
+    <Box p={3}>
+      <Card pb={3}>
+        <Flag mt={2} py={[1, 2, 3]} pl={[2, 3, 4]} pr={[1, 3, 4]}>
+          <Flex>
+            <Text>Hello World</Text>
+          </Flex>
+        </Flag>
+      </Card>
+    </Box>
+  ))


### PR DESCRIPTION
The right side of the flag already adds an illusion of extra padding which is why the original only had `py` and `pl`. I made both of these props and added `pr` separately (instead of `px`, for this reason).