### PR TITLE
Add Priceline logo to theme

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/addons'
+import theme from './pclnTheme.js'
+
+addons.setConfig({
+  theme,
+})

--- a/.storybook/pclnTheme.js
+++ b/.storybook/pclnTheme.js
@@ -1,0 +1,10 @@
+import { create } from '@storybook/theming/create'
+
+export default create({
+  base: 'light',
+
+  brandTitle: 'Priceline Design System',
+  brandUrl: 'https://www.priceline.com',
+  brandImage:
+    'https://press.priceline.com/wp-content/uploads/2019/10/Priceline_Logo_RGB_Blue_2019-1.png',
+})


### PR DESCRIPTION
<img width="955" alt="Screen Shot 2020-05-29 at 2 01 00 PM" src="https://user-images.githubusercontent.com/3260642/83290674-00098d80-a1b5-11ea-8179-8f9002f1e875.png">
