### PR TITLE
fix(821): Rename size to iconSize in CloseButton

### DIFF
--- a/packages/core/src/CloseButton/CloseButton.js
+++ b/packages/core/src/CloseButton/CloseButton.js
@@ -6,17 +6,17 @@ import { refPropType } from '../utils'
 import { IconButton } from '../IconButton'
 
 const CloseButton = (props) => (
-  <IconButton {...props} icon={<Close size={props.size} />} />
+  <IconButton {...props} icon={<Close size={props.iconSize} />} />
 )
 
 CloseButton.defaultProps = {
-  size: 24,
+  iconSize: 24,
   title: 'close',
 }
 
 CloseButton.propTypes = {
   onClick: PropTypes.func,
-  size: PropTypes.number,
+  iconSize: PropTypes.number,
   dsRef: refPropType,
   title: PropTypes.string,
 }

--- a/packages/core/src/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/packages/core/src/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -53,7 +53,6 @@ exports[`CloseButton renders without props 1`] = `
 
 <button
   className="c0"
-  size={24}
   title="close"
 >
   <div>

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -193,7 +193,7 @@ export interface CloseButtonProps
     SpaceProps,
     WidthProps {
   dsRef?: RefPropType
-  size?: number
+  iconSize?: number
   variation?: 'fill' | 'outline' | 'link'
   /** DEPRECATED: Use "width" prop instead */
   fullWidth?: boolean

--- a/packages/types/types/test.tsx
+++ b/packages/types/types/test.tsx
@@ -153,6 +153,7 @@ const myButton = (
 const myCloseButton = (
   <CloseButton
     color='background.darkest'
+    iconSize={48}
     onClick={() => 'ima function'}
     title='Title'
   />


### PR DESCRIPTION
- Rename the `size` prop to `iconSize` to prevent type conflicts between `Button` and `CloseButton`
- Update snapshots

Closes #821 