### PR TITLE
Create codemod to assist with pcln-icons upgrade

### DIFF
--- a/MIGRATING_to_v3.md
+++ b/MIGRATING_to_v3.md
@@ -51,6 +51,7 @@ import { ThumbsUp } from 'pcln-icons
 
 ### Icons (`pcln-icons`)
 
+- We have a codemod to make this transition easier. See the [readme](codemods/icons-v2-to-v3/README.md) for usage instructions.
 - `main` and `module` fields in `package.json` now point to CommonJS (CJS) and ES Modules (ESM) builds, respectively.
 - Usage: `import { TrendingUp, Timer } from 'pcln-icons'`
   - Imports from `pcln-icons/lib/` are no longer available. This previously contained a CJS build that was incompatible with tree-shaking and dead code elimination in bundlers.

--- a/codemods/icons-v2-to-v3/README.md
+++ b/codemods/icons-v2-to-v3/README.md
@@ -1,0 +1,40 @@
+# Codemod: Transform `pcln-icons/lib` import statements
+
+Example usage:
+
+```shell
+# Prereq: Install jscodeshift
+npm i -g jscodeshift
+
+# Run transform on all files in source
+jscodeshift -t path/to/iconsV2toV3.js src/**
+```
+
+This transform handles the following cases:
+
+```JavaScript
+import Dollar from 'pcln-icons/lib/Dollar'
+import Dollar from "pcln-icons/lib/Dollar";
+import DollarIcon from 'pcln-icons/lib/Dollar'
+```
+
+If a file contains multiple imports from `pcln-icons/lib`, it will combine them as so:
+
+```JavaScript
+// Before
+import Dollar from "pcln-icons/lib/Dollar"
+import Car from "pcln-icons/lib/Car"
+
+// After
+import { Dollar, Car } from "pcln-icons"
+```
+
+It also handles named default imports:
+
+```JavaScript
+// Before
+import Dollar as DollarIcon from "pcln-icons/lib/Dollar"
+
+// After
+import { Dollar as DollarIcon } from "pcln-icons"
+```

--- a/codemods/icons-v2-to-v3/iconsV2toV3.js
+++ b/codemods/icons-v2-to-v3/iconsV2toV3.js
@@ -1,0 +1,46 @@
+module.exports = function (fileInfo, api, options) {
+  // Sample:
+  // import Dollar from 'pcln-icons/lib/Dollar'
+  // import Dollar from "pcln-icons/lib/Dollar";
+  // import DollarIcon from 'pcln-icons/lib/Dollar'
+
+  const importRegex = /import (?<iconName>\w+) from ['"]pcln-icons\/lib\/(?<moduleName>\w+)['"];?\n?/
+  const foundIcons = []
+
+  let out = fileInfo.source.replace(RegExp(importRegex, 'g'), (replace) => {
+    // regex should not use global mode here
+    const match = importRegex.exec(replace)
+
+    if (match) {
+      // delete the old import statement line
+      foundIcons.push(match.groups)
+      return ``
+    }
+  })
+
+  if (foundIcons.length) {
+    // handle default imports that don't match the module name
+    const imports = foundIcons.map(({ iconName, moduleName }) => {
+      return iconName !== moduleName
+        ? `${moduleName} as ${iconName}`
+        : moduleName
+    })
+
+    // create combined import statement
+    const newImport = `import { ${imports.join(', ')} } from 'pcln-icons'`
+
+    // choose anchor; prefer pcln-design-system, but fall back to react
+    let anchor = /from ['"]pcln-design-system['"];?\n?/
+    if (!out.match(anchor)) {
+      anchor = /from ['"]react['"];?\n?/
+    }
+
+    // insert combined import below anchor
+    out = out.replace(
+      RegExp(anchor, 'g'),
+      (replace) => `${replace}${newImport}\n`
+    )
+  }
+
+  return out
+}


### PR DESCRIPTION
This codemod can be run via `jscodeshift`. It is intended to replace imports from `pcln-icons/lib` with named imports from `pcln-icons`.

Resolves #859 