### PR TITLE
Remove types field from core package to avoid breaking TSC builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,9 @@
 {
   "name": "pcln-design-system",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "prepare": "run-s clean build",


### PR DESCRIPTION
We've encountered issues with existing TSC builds failing due to improper usage of various props from before type declarations were available. Since this was a breaking change, we've elected to roll back the `types` field in the core package. We'll re-introduce typings with instructions to opt-in as part of a future release.