### PR TITLE
Enhancement: added additional props to Box to require fewer styled co…

### DIFF
--- a/docs/pages/Box.md
+++ b/docs/pages/Box.md
@@ -5,7 +5,7 @@ Use the `Box` component to control width, margin, padding, and color.
 50% width
 
 ```.jsx
-<Box width={1/2} bg='blue'>
+<Box width={1/2} color='primary.base'>
   Box
 </Box>
 ```
@@ -13,7 +13,7 @@ Use the `Box` component to control width, margin, padding, and color.
 Padding of `theme.space[3]` (16px)
 
 ```.jsx
-<Box p={3} bg='blue'>
+<Box p={3} color='secondary.base'>
   Box
 </Box>
 ```
@@ -21,7 +21,7 @@ Padding of `theme.space[3]` (16px)
 Margin of `theme.space[2]` (8px)
 
 ```.jsx
-<Box m={4} bg='blue'>
+<Box m={2} color='primary.light'>
   Box
 </Box>
 ```
@@ -42,18 +42,23 @@ Background color green from the theme's color palette
 </Box>
 ```
 
-## Responsive Widths
+## Responsive Heights and Widths
 
-The `width` prop accepts an array value to set different widths at different breakpoints with a mobile-first approach.
+The `height` and `width` props accept an array value to set heights and widths at different breakpoints with a mobile-first approach.
 
 ```.jsx
 <Box
+  height={[
+    '100%', // Sets height 100% at the smallest breakpoint
+    '50%', // Sets height 50% at the next breakpoint
+    '25%' // Sets height 25% at the next breakpoint
+  ]}
   width={[
     1,    // Sets width 100% at the smallest breakpoint
     1/2,  // Sets width 50% at the next breakpoint
     1/4,  // Sets width 25% at the next breakpoint
   ]}
-  bg='gray'>
+  color='gray'>
   Hello
 </Box>
 ```
@@ -62,22 +67,29 @@ See [styled-system](https://github.com/jxnblk/styled-system) for more documentat
 
 ## Props
 
-| Prop    | Type                     | Description                                              |
-| ------- | ------------------------ | -------------------------------------------------------- |
-| `width` | number, string, or array | Sets the width of the element                            |
-| `color` | string                   | Sets color based on the theme's color palette            |
-| `bg`    | string                   | Sets background-color based on the theme's color palette |
-| `m`     | number, string, or array | Sets margin based on the `theme.space` scale             |
-| `mt`    | number, string, or array | Sets margin-top                                          |
-| `mr`    | number, string, or array | Sets margin-right                                        |
-| `mb`    | number, string, or array | Sets margin-bottom                                       |
-| `ml`    | number, string, or array | Sets margin-left                                         |
-| `mx`    | number, string, or array | Sets margin-left and margin-right                        |
-| `my`    | number, string, or array | Sets margin-top and margin-bottom                        |
-| `p`     | number, string, or array | Sets padding based on the `theme.space` scale            |
-| `pt`    | number, string, or array | Sets padding-top                                         |
-| `pr`    | number, string, or array | Sets padding-right                                       |
-| `pb`    | number, string, or array | Sets padding-bottom                                      |
-| `pl`    | number, string, or array | Sets padding-left                                        |
-| `px`    | number, string, or array | Sets padding-left and padding-right                      |
-| `py`    | number, string, or array | Sets padding-top and padding-bottom                      |
+| Prop        | Type                     | Description                                                                       |
+| ----------- | ------------------------ | --------------------------------------------------------------------------------- |
+| `bg`        | string                   | Sets background-color based on the theme's color palette (deprecated - use color) |
+| `color`     | string                   | Sets color based on the theme's color palette                                     |
+| `display`   | string, array            | Sets the display value (e.g. block, inline-block,none, etc.)                      |
+| `height`    | number, string, or array | Sets height                                                                       |
+| `maxHeight` | number, string, or array | Sets max-height                                                                   |
+| `maxWidth`  | number, string, or array | Sets max-width                                                                    |
+| `minHeight` | number, string, or array | Sets min-height                                                                   |
+| `minWidth`  | number, string, or array | Sets min-width                                                                    |
+| `m`         | number, string, or array | Sets margin based on the `theme.space` scale                                      |
+| `mt`        | number, string, or array | Sets margin-top                                                                   |
+| `mr`        | number, string, or array | Sets margin-right                                                                 |
+| `mb`        | number, string, or array | Sets margin-bottom                                                                |
+| `ml`        | number, string, or array | Sets margin-left                                                                  |
+| `mx`        | number, string, or array | Sets margin-left and margin-right                                                 |
+| `my`        | number, string, or array | Sets margin-top and margin-bottom                                                 |
+| `p`         | number, string, or array | Sets padding based on the `theme.space` scale                                     |
+| `pt`        | number, string, or array | Sets padding-top                                                                  |
+| `pr`        | number, string, or array | Sets padding-right                                                                |
+| `pb`        | number, string, or array | Sets padding-bottom                                                               |
+| `pl`        | number, string, or array | Sets padding-left                                                                 |
+| `px`        | number, string, or array | Sets padding-left and padding-right                                               |
+| `py`        | number, string, or array | Sets padding-top and padding-bottom                                               |
+| `size`      | number, string, or array | Sets the height and width simultaneously                                          |
+| `width`     | number, string, or array | Sets the width of the element                                                     |

--- a/packages/core/src/Banner/__snapshots__/Banner.spec.js.snap
+++ b/packages/core/src/Banner/__snapshots__/Banner.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Banner accepts non-preset colors 1`] = `
 .c2 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -53,8 +53,8 @@ exports[`Banner accepts non-preset colors 1`] = `
 
 exports[`Banner renders content from children props 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -135,8 +135,8 @@ exports[`Banner renders content from children props 1`] = `
 
 exports[`Banner renders with blue bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -214,8 +214,8 @@ exports[`Banner renders with blue bg 1`] = `
 
 exports[`Banner renders with custom iconName and size 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -293,8 +293,8 @@ exports[`Banner renders with custom iconName and size 1`] = `
 
 exports[`Banner renders with green bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -373,8 +373,8 @@ exports[`Banner renders with green bg 1`] = `
 exports[`Banner renders with header node 1`] = `
 <DocumentFragment>
   .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -465,8 +465,8 @@ exports[`Banner renders with header node 1`] = `
 
 exports[`Banner renders with lightBlue bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -544,8 +544,8 @@ exports[`Banner renders with lightBlue bg 1`] = `
 
 exports[`Banner renders with lightGreen bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -623,8 +623,8 @@ exports[`Banner renders with lightGreen bg 1`] = `
 
 exports[`Banner renders with lightRed bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -702,8 +702,8 @@ exports[`Banner renders with lightRed bg 1`] = `
 
 exports[`Banner renders with no props other than theme 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -781,8 +781,8 @@ exports[`Banner renders with no props other than theme 1`] = `
 
 exports[`Banner renders with orange bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -860,8 +860,8 @@ exports[`Banner renders with orange bg 1`] = `
 
 exports[`Banner renders with red bg 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -939,8 +939,8 @@ exports[`Banner renders with red bg 1`] = `
 
 exports[`Banner renders with text node 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {
@@ -1035,8 +1035,8 @@ exports[`Banner renders with text node 1`] = `
 
 exports[`Banner renders with text string 1`] = `
 .c4 {
-  width: 100%;
   text-align: left;
+  width: 100%;
 }
 
 .c1 {

--- a/packages/core/src/Box/Box.js
+++ b/packages/core/src/Box/Box.js
@@ -1,6 +1,17 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { space, width, textAlign } from 'styled-system'
+import {
+  display,
+  height,
+  maxHeight,
+  maxWidth,
+  minHeight,
+  minWidth,
+  size,
+  space,
+  textAlign,
+  width,
+} from 'styled-system'
 
 import {
   applyVariations,
@@ -11,20 +22,30 @@ import {
 } from '../utils'
 
 const Box = styled.div`
-  ${space} ${width} ${textAlign} ${boxShadow}
-  ${color}
+  ${display} ${height} ${maxHeight} ${maxWidth}
+  ${minHeight} ${minWidth} ${size} ${space} 
+  ${textAlign} ${width} 
+
   ${applyVariations('Box')}
+  ${boxShadow}
+  ${color}
 `
 
 Box.displayName = 'Box'
 
 Box.propTypes = {
+  ...display.propTypes,
+  ...maxHeight.propTypes,
+  ...maxWidth.propTypes,
+  ...minHeight.propTypes,
+  ...minWidth.propTypes,
+  ...size.propTypes,
   ...space.propTypes,
-  ...width.propTypes,
-  color: deprecatedColorValue(),
-  bg: deprecatedPropType('color'),
   ...textAlign.propTypes,
+  ...width.propTypes,
+  bg: deprecatedPropType('color'),
   boxShadowSize: PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+  color: deprecatedColorValue(),
 }
 
 export default Box

--- a/packages/core/src/Box/Box.spec.js
+++ b/packages/core/src/Box/Box.spec.js
@@ -8,9 +8,12 @@ describe('Box', () => {
     expect(json).toMatchSnapshot()
   })
 
-  test('width prop sets width', () => {
-    const json = rendererCreateWithTheme(<Box width={1 / 2} />).toJSON()
+  test('width and height props set width/height', () => {
+    const json = rendererCreateWithTheme(
+      <Box width={1 / 2} height='50%' />
+    ).toJSON()
     expect(json).toMatchSnapshot()
+    expect(json).toHaveStyleRule('height', '50%')
     expect(json).toHaveStyleRule('width', '50%')
   })
 
@@ -18,6 +21,17 @@ describe('Box', () => {
     const json = rendererCreateWithTheme(<Box m={2} />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('margin', theme.space[2] + 'px')
+  })
+
+  test('maxHeight, maxWidth, minHeight, minWidth', () => {
+    const json = rendererCreateWithTheme(
+      <Box maxHeight={250} maxWidth={250} minHeight={55} minWidth={55} />
+    ).toJSON()
+    expect(json).toMatchSnapshot()
+    expect(json).toHaveStyleRule('max-height', '250px')
+    expect(json).toHaveStyleRule('max-width', '250px')
+    expect(json).toHaveStyleRule('min-height', '55px')
+    expect(json).toHaveStyleRule('min-width', '55px')
   })
 
   test('p prop sets padding', () => {

--- a/packages/core/src/Box/Box.stories.js
+++ b/packages/core/src/Box/Box.stories.js
@@ -6,7 +6,7 @@ import { withInfo } from '@storybook/addon-info'
 import { Box, Text } from '..'
 
 const description =
-  'A low-level layout component for setting width, margin, padding, and color'
+  'A low-level layout component for setting color, display, height, margin, maxHeight, maxWidth, minHeight, minWidth, padding, size, textAlign, and width.'
 
 storiesOf('Box', module)
   .add(
@@ -16,10 +16,31 @@ storiesOf('Box', module)
       inline: true,
     })(() => <Box p={3}>Hello</Box>)
   )
+  .add('Display and size', () => (
+    <Box color='alert.base' display={['none', null, 'block']} p={3} size={250}>
+      Hello
+    </Box>
+  ))
   .add('Padding', () => <Box p={3}>Hello</Box>)
+  .add('Height', () => (
+    <Box
+      color='warning.base'
+      height={[250, 350, 450, 550]}
+      width={[150, 250, 350, 450]}
+    />
+  ))
+  .add('Max and min values', () => (
+    <Box
+      color='priceSecondary.base'
+      maxHeight={[300, null, 400, null, 500]}
+      maxWidth={[300, null, 400, null, 500]}
+      minHeight={[100, null, 200, null, 300]}
+      minWidth={[300, null, 200, null, 100]}
+    />
+  ))
   .add('Margin', () => <Box m={3}>Hello</Box>)
   .add('Color', () => (
-    <Box p={3} color='blue'>
+    <Box p={3} color='primary.base'>
       Hello
     </Box>
   ))
@@ -54,6 +75,7 @@ storiesOf('Box', module)
       </Box>
     </React.Fragment>
   ))
+  .add('Size', () => <Box p={3} color='secondary.base' size={200} />)
   .add('Width', () => (
     <Box p={3} width={1 / 2} color='white' bg='blue'>
       Half Width

--- a/packages/core/src/Box/__snapshots__/Box.spec.js.snap
+++ b/packages/core/src/Box/__snapshots__/Box.spec.js.snap
@@ -41,6 +41,19 @@ exports[`Box m prop sets margin 1`] = `
 />
 `;
 
+exports[`Box maxHeight, maxWidth, minHeight, minWidth 1`] = `
+.c0 {
+  max-height: 250px;
+  max-width: 250px;
+  min-height: 55px;
+  min-width: 55px;
+}
+
+<div
+  className="c0"
+/>
+`;
+
 exports[`Box p prop sets padding 1`] = `
 .c0 {
   padding: 8px;
@@ -57,13 +70,15 @@ exports[`Box renders 1`] = `
 />
 `;
 
-exports[`Box width prop sets width 1`] = `
+exports[`Box width and height props set width/height 1`] = `
 .c0 {
+  height: 50%;
   width: 50%;
 }
 
 <div
   className="c0"
+  height="50%"
   width={0.5}
 />
 `;


### PR DESCRIPTION
Add the following props to `Box` and update docs page for Box, to reflect these updates:
```
 display
 height
 maxHeight
 maxWidth
 minHeight
 minWidth
 size
```
https://github.com/styled-system/styled-system/blob/v4.1.1/docs/api.md#layout
(It looks like styled-system v5 nests all layout props under a `layout` prop. Which will simply code in the future, however, now we need to import each individually.)

This was motivated by the desire to have the ability to add responsive arrays for heights, specifically. Styled-system v4 supports each of the layout options above. Any and all are up for debate, but all could be useful.