### PR TITLE
Add lang attribute to html tag for Accessibility

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -31,7 +31,7 @@ export default class MyDocument extends Document {
     const { styles } = this.props
 
     return (
-      <html>
+      <html lang='en-US'>
         <Head>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <meta name='generator' content='mdx-docs' />


### PR DESCRIPTION
Adding lang='en-US' attribute to html tag for Accessibility.