### PR TITLE
Update named icons and IconButton docs

### DIFF
--- a/docs/pages/Banner.md
+++ b/docs/pages/Banner.md
@@ -14,9 +14,9 @@ Use `Banner` component to create a box with a optional header, text, optional le
   bg='lightBlue'
   p={2}>
   <Flex>
-    <Icon name='Calendar' />
+    <Calendar />
     <Box pl={2}>
-      <Heading fontSize={2} bold>Are Your Dates Correct?</Heading>
+      <Heading fontSize={2} m={0} bold>Are Your Dates Correct?</Heading>
       <Text>
         Remember to double check the calendar because availability may change depending on your dates.
       </Text>
@@ -45,8 +45,8 @@ You can choose any palette or theme color for `Banner`.
 ```.jsx
 <Banner
   p={2}
-  color="primary"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
+  color='primary'
+  text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. '
 />
 ```
 
@@ -55,9 +55,9 @@ Uses the color from `theme.palette.primary.base`.
 ```.jsx
 <Banner
   p={2}
-  color="error"
-  icon={<Icon name="Warning"/>}
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
+  color='error'
+  icon={<Warning />}
+  text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. '
 />
 ```
 
@@ -66,9 +66,9 @@ Uses the color from `theme.palette.error.base`.
 ```.jsx
 <Banner
   p={2}
-  color="caution"
-  icon={<Icon name="Attention"/>}
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
+  color='caution'
+  icon={<Attention />}
+  text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. '
 />
 ```
 
@@ -81,9 +81,9 @@ Uses the color from `theme.palette.warning.base`.
 ```.jsx
 <Banner
   p={2}
-  header={<Heading.h4>H4 Heading</Heading.h4>}
-  color="caution"
-  iconName="Attention"
-  text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
+  header={<Heading.h4 m={0}>H4 Heading</Heading.h4>}
+  color='caution'
+  icon={<Attention />}
+  text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. '
 />
 ```

--- a/docs/pages/CloseButton.md
+++ b/docs/pages/CloseButton.md
@@ -3,8 +3,12 @@
 The `CloseButton` component is an extension of the `IconButton` component with default props for use as a button for closing modal dialogs and other UI components.
 
 ```.jsx
-<Flex p={2} color='white' bg='blue'>
+<Flex p={2} color='primary'>
   <Box mx='auto' />
   <CloseButton />
 </Flex>
 ```
+
+### Related
+
+- [IconButton](/IconButton)

--- a/docs/pages/FormField.md
+++ b/docs/pages/FormField.md
@@ -5,7 +5,7 @@ Use the `FormField` component to combine `Input` or `Select`, `Label`, and `Icon
 ```.jsx
 <FormField>
   <Label htmlFor='email'>Email address</Label>
-  <Icon name='Email' size='20' />
+  <Email />
   <Input
     id='email'
     name='email'
@@ -18,7 +18,7 @@ Use the `FormField` component to combine `Input` or `Select`, `Label`, and `Icon
 ```.jsx
 <FormField>
   <Label htmlFor='options'>Select One</Label>
-  <Icon name='Key' size='20' />
+  <Key />
   <Select
     id='options'
     name='options'>
@@ -47,20 +47,27 @@ Error messages can be displayed using the [`Tooltip`](/Tooltip) component.
   <Input
     value='hello@example'
   />
-  <Icon name='Warning' color='red' />
+  <Warning color='error' />
 </FormField>
 <Tooltip
   bottom
   right
-  color='white'
-  bg='red'>
+  color='error'
+>
   Invalid Email Address
 </Tooltip>
 ```
 
 ## Props
 
-| Prop              | Type           | Description                                                                                                                                                      |
-| ----------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`        | React elements | Up to 4 components, two of which can be `<Icon/>`'s, one of which can be an `<Input />`, and one of which can be a `<Label />`. No other elements are supported. |
-| `alwaysShowLabel` | boolean        | Determines whether or not the label shows up statically                                                                                                          |
+| Prop              | Type           | Description                                                                                                                                                       |
+| ----------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`        | React elements | Up to 4 components, two of which can be `<Icon />`'s, one of which can be an `<Input />`, and one of which can be a `<Label />`. No other elements are supported. |
+| `alwaysShowLabel` | boolean        | Determines whether or not the label shows up statically                                                                                                           |
+
+### Related
+
+- [Icon](/Icon)
+- [Input](/Input)
+- [Label](/Label)
+- [Select](/Select)

--- a/docs/pages/Hug.md
+++ b/docs/pages/Hug.md
@@ -5,7 +5,7 @@ Pass in `props.children` to be wrapped.
 
 ```.jsx
 <Hug
-  icon='check'
+  icon={<Check />}
   text={<Text.span>I hug my props.children</Text.span>}>
   <Card p={4}>
     Hello

--- a/docs/pages/Icon.md
+++ b/docs/pages/Icon.md
@@ -1,19 +1,15 @@
 # Icon
 
-Use the `Icon` component for SVG icons.
+Use the named `Icon` components from the `pcln-icons` package for SVG icons.
 
 ```.jsx
-<Icon
-  name='Flame'
-  color='orange'
-/>
+<Flame color='orange' />
 ```
 
 ## Accessibility for Icons
 
 ```.jsx
-<Icon
-  name='Chat'
+<Chat
   color='orange'
   title='Airplane Icon'
   titleId='unique-airplane-title-id'
@@ -27,14 +23,13 @@ When a `title` prop is passed, `aria-hidden` is set to false.
 
 In order to support older browsers, please pass in a `titleId`
 
-To add a descripton, please pass in `desc` and `descId` .
+To add a description, please pass in `desc` and `descId` .
 `<desc id="{unique-desc-id}">{description}</desc>` is generated when `desc` and `descId` props are passed
 
 ## Props
 
 | Prop      | Type   | Description                     |
 | --------- | ------ | ------------------------------- |
-| `name`    | string | Icon key name                   |
 | `size`    | number | Width and height in pixels      |
 | `color`   | string | A color key from `theme.colors` |
 | `title`   | string | Title for to the icon           |

--- a/docs/pages/IconButton.md
+++ b/docs/pages/IconButton.md
@@ -1,14 +1,27 @@
 # IconButton
 
-The `IconButton` component is a `<button>` element with icon.
+The `IconButton` component is a transparent `<button>` element with an icon.
 
 ```.jsx
 <IconButton
-  name='Flame'
-  size={24}
-  color='orange'
-  title='Set on fire'
-  onClick={() => {}}
+  title='Search button'
+  onClick={() => {console.log('Search button clicked!')}}
+  mr={2}
+  icon={
+    <Search
+      color='primary'
+      size={36}
+    />
+  }
+/>
+<IconButton
+  disabled
+  mr={2}
+  icon={<Plus />}
+/>
+<IconButton
+  variation='outline'
+  icon={<Bookmark />}
 />
 ```
 
@@ -16,15 +29,15 @@ Be sure to include a `title` attribute for accessibility.
 
 ## Props
 
-| Prop      | Type     | Description                         |
-| --------- | -------- | ----------------------------------- |
-| `name`    | string   | Icon component `name` prop          |
-| `legacy`  | boolean  | Icon component `legacy` prop        |
-| `color`   | string   | Icon color                          |
-| `title`   | string   | HTML `title` attribute              |
-| `onClick` | function | Sets a function to execute on click |
+| Prop        | Type              | Description                                   |
+| ----------- | ----------------- | --------------------------------------------- |
+| `disabled`  | bool              | Disables the button and applies a light color |
+| `icon`      | node              | Sets the button's svg icon                    |
+| `onClick`   | function          | Sets a function to execute on click           |
+| `title`     | string            | HTML `title` attribute                        |
+| `variation` | `fill`, `outline` | The button variation                          |
 
 ### Related
 
-- [Icon](/Icon)
 - [CloseButton](/CloseButton)
+- [Icon](/Icon)

--- a/docs/pages/IconField.md
+++ b/docs/pages/IconField.md
@@ -4,7 +4,7 @@ Group Inputs and Selects with Icons.
 
 ```.jsx
 <IconField>
-  <Icon name='Calendar' color='blue' />
+  <Calendar color='primary' />
   <Input
     placeholder='Choose Date'
   />
@@ -16,23 +16,23 @@ Group Inputs and Selects with Icons.
   <Input
     placeholder='Choose Date'
   />
-  <Icon name='Calendar' color='blue' />
+  <Calendar color='primary' />
 </IconField>
 ```
 
 ```.jsx
 <IconField>
-  <Icon name='Calendar' color='blue' />
+  <Calendar color='primary' />
   <Input
     placeholder='Choose Date'
   />
-  <Icon name='Check' color='green' />
+  <Check color='secondary' />
 </IconField>
 ```
 
 ```.jsx
 <IconField>
-  <Icon name='Calendar' color='blue' />
+  <Calendar color='primary' />
   <Select>
     <option>Choose Date</option>
     <option>January 2019</option>
@@ -42,19 +42,26 @@ Group Inputs and Selects with Icons.
 
 The `IconField` component accepts children as its only props.
 It will parse children based on the `isField` and `isIcon` static properties.
-By default the design system `Input`, `Select`, and `Icon` components will work with the `IconField` component, but to allow other children to render, add an appropriate static property.
+By default, the design system's `Input` and `Select` and pcln-icon's named icon components will work with the `IconField` component, but to allow other children to render, add an appropriate static property.
 
 ```jsx
 import React from 'react'
-import { IconField, Icon } from 'pcln-design-system'
+import { IconField } from 'pcln-design-system'
+import { Calendar as CalendarIcon } from 'pcln-icons'
 import CustomInput from './CustomInput'
 
 CustomInput.isField = true
 
 export default (props) => (
   <IconField>
-    <Icon name='Calendar' />
+    <CalendarIcon />
     <CustomInput {...props} />
   </IconField>
 )
 ```
+
+### Related
+
+- [Icon](/Icon)
+- [Input](/Input)
+- [Select](/Select)

--- a/docs/pages/Stamp.md
+++ b/docs/pages/Stamp.md
@@ -5,8 +5,8 @@ Use it in conjunction with an `Icon` component to give it more context.
 An Icon placed within a Stamp will inherit the assigned Stamp color.
 
 ```.jsx
-<Stamp color='purple'>
-  <Icon name='TrendingUp' size={16} mr={1} /> top booked hotel
+<Stamp color='promoPrimary'>
+  <TrendingUp size={16} mr={1} /> top booked hotel
 </Stamp>
 ```
 

--- a/docs/pages/Theming.md
+++ b/docs/pages/Theming.md
@@ -179,8 +179,8 @@ global.mountWithTheme = (node, options) => {
 ```.jsx
 <Banner color="primary" p={2} mb={1}>Primary banner</Banner>
 <Banner color="secondary" p={2} mb={1}>Secondary banner</Banner>
-<Banner color="error" iconName="attention" p={2} mb={1}>Error banner</Banner>
-<Banner color="caution" header="Promo" iconName="dollar" p={2}>Caution banner</Banner>
+<Banner color="error" icon={<Attention />} p={2} mb={1}>Error banner</Banner>
+<Banner color="caution" icon={<Warning />} p={2}>Caution banner</Banner>
 ```
 
 ## BlockLink
@@ -483,13 +483,13 @@ global.mountWithTheme = (node, options) => {
 
 ```.jsx
 <Stamp color="primary" mr={2}>
-  <Icon name="Pin" size={16} mr={1} /> primary stamp
+  <Pin size={16} mr={1} /> primary stamp
 </Stamp>
 <Stamp color="error" mr={2}>
-  <Icon name="Warning" size={16} mr={1} /> error stamp
+  <Warning size={16} mr={1} /> error stamp
 </Stamp>
 <Stamp color="caution" bg="background.dark" borderColor="caution">
-  <Icon name="Information" size={16} mr={1} /> just booked
+  <Information size={16} mr={1} /> just booked
 </Stamp>
 ```
 

--- a/docs/src/components.js
+++ b/docs/src/components.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import * as DS from 'pcln-design-system'
+import * as icons from 'pcln-icons'
 import isAbsoluteURL from 'is-absolute-url'
 import styled from 'styled-components'
 import { space, fontSize, color, theme } from 'styled-system'
 import { components as mdxDocsComponents } from 'mdx-docs'
 
 import {
-  Heading,
-  Text,
-  Link,
   Button,
+  Heading,
+  Link,
+  Text,
   getPaletteColor,
   getTextColorOn,
 } from 'pcln-design-system'
@@ -136,6 +137,7 @@ const Paragraph = (p) => <Text.p {...p} />
 
 const components = {
   ...DS,
+  ...icons,
   h1: heading('h1'),
   h2: heading('h2'),
   h3: heading('h3'),

--- a/docs/src/navigation.js
+++ b/docs/src/navigation.js
@@ -33,6 +33,7 @@ export default [
       { name: 'Hug', path: '/Hug' },
       { name: 'Icon', path: '/Icon' },
       { name: 'IconButton', path: '/IconButton' },
+      { name: 'IconField', path: '/IconField' },
       { name: 'Image', path: '/Image' },
       { name: 'Input', path: '/Input' },
       { name: 'InputGroup', path: '/InputGroup' },


### PR DESCRIPTION
- Add named icon imports into `components.js` for use throughout doc examples
  - Replace all `<Icon name='x' />` components except for iconography (update coming later)
- Update props for `IconButton` docs, fix typos, add more examples
- Move `IconField.md` doc into `/pages` and add to navigation

#### Screenshots
![Screen Shot 2020-08-05 at 10 11 51 AM](https://user-images.githubusercontent.com/12076625/89430299-39560080-d704-11ea-9a7f-479774a12804.png)

![Screen Shot 2020-08-05 at 10 16 46 AM](https://user-images.githubusercontent.com/12076625/89430898-dca71580-d704-11ea-9fb8-fb603db00018.png)
![Screen Shot 2020-08-05 at 10 16 53 AM](https://user-images.githubusercontent.com/12076625/89430903-ddd84280-d704-11ea-85b2-6c31dab630ce.png)

