### PR TITLE
Issue(845): Remove deprecated prop type warnings from tests

### DIFF
--- a/packages/core/src/Absolute/Absolute.spec.js
+++ b/packages/core/src/Absolute/Absolute.spec.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Absolute, Flag, Icon, Text } from '..'
+import { Absolute, Flag, Text } from '..'
+import { Coupon as CouponIcon } from 'pcln-icons'
 
 describe('Absolute', () => {
   test('renders with top, left and zIndex props', () => {
@@ -14,13 +15,17 @@ describe('Absolute', () => {
   })
 
   test('renders with flag and Child', () => {
+    const consoleError = console.error
+    console.error = jest.fn()
+
     const json = rendererCreateWithTheme(
       <Absolute top={10} left={0}>
         <Flag>
-          <Icon name='Coupon' /> <Text.span>EXCLUSIVE</Text.span>
+          <CouponIcon /> <Text.span>EXCLUSIVE</Text.span>
         </Flag>
       </Absolute>
     ).toJSON
     expect(json).toMatchSnapshot()
+    console.error = consoleError
   })
 })

--- a/packages/core/src/Badge/Badge.spec.js
+++ b/packages/core/src/Badge/Badge.spec.js
@@ -2,9 +2,12 @@ import React from 'react'
 import { Badge, theme } from '..'
 
 describe('Badge', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('renders', () => {
     const json = rendererCreateWithTheme(<Badge />).toJSON()

--- a/packages/core/src/Badge/Badge.spec.js
+++ b/packages/core/src/Badge/Badge.spec.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { Badge, theme } from '..'
 
 describe('Badge', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('renders', () => {
     const json = rendererCreateWithTheme(<Badge />).toJSON()
     expect(json).toMatchSnapshot()

--- a/packages/core/src/Banner/Banner.spec.js
+++ b/packages/core/src/Banner/Banner.spec.js
@@ -2,9 +2,12 @@ import React from 'react'
 import { Banner, Text, Heading, theme } from '..'
 
 describe('Banner', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('renders with no props other than theme', () => {
     const json = rendererCreateWithTheme(<Banner />).toJSON()

--- a/packages/core/src/Banner/Banner.spec.js
+++ b/packages/core/src/Banner/Banner.spec.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { Banner, Text, Heading, theme } from '..'
 
 describe('Banner', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('renders with no props other than theme', () => {
     const json = rendererCreateWithTheme(<Banner />).toJSON()
     expect(json).toMatchSnapshot()

--- a/packages/core/src/Box/Box.spec.js
+++ b/packages/core/src/Box/Box.spec.js
@@ -46,30 +46,25 @@ describe('Box', () => {
     expect(json).toHaveStyleRule('color', theme.colors.blue)
   })
 
-  test('bg prop sets background color', () => {
-    const json = rendererCreateWithTheme(<Box bg='green' />).toJSON()
-    expect(json).toMatchSnapshot()
-    expect(json).toHaveStyleRule('background-color', theme.colors.green)
-  })
-
   test('boxShadowSize prop sets box-shadow', () => {
     const json = rendererCreateWithTheme(<Box boxShadowSize='sm' />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('box-shadow', theme.boxShadows[0])
   })
 
-  test('align prop triggers warning', () => {
-    console.error = jest.fn()
+  describe('deprecated prop types', () => {
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
 
-    rendererCreateWithTheme(<Box align='center' />).toJSON()
-
-    expect(
-      console.error.mock.calls
-        .toString()
-        .indexOf(
-          'The Box `align` prop will deprecated. Please use Text instead.'
-        ) !== -1
-    )
-    console.error.mockRestore()
+    test('bg prop sets background color and warns', () => {
+      const json = rendererCreateWithTheme(<Box bg='green' />).toJSON()
+      expect(json).toHaveStyleRule('background-color', theme.colors.green)
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `bg` prop is deprecated and will be removed in a future release. Please use `color` instead.'
+        )
+      )
+    })
   })
 })

--- a/packages/core/src/Box/Box.spec.js
+++ b/packages/core/src/Box/Box.spec.js
@@ -53,8 +53,11 @@ describe('Box', () => {
   })
 
   describe('deprecated prop types', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('bg prop sets background color and warns', () => {

--- a/packages/core/src/Box/__snapshots__/Box.spec.js.snap
+++ b/packages/core/src/Box/__snapshots__/Box.spec.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Box bg prop sets background color 1`] = `
-.c0 {
-  background-color: #0a0;
-}
-
-<div
-  className="c0"
-/>
-`;
-
 exports[`Box boxShadowSize prop sets box-shadow 1`] = `
 .c0 {
   box-shadow: 0 0 2px 0 rgba(0,0,0,.08),0 1px 4px 0 rgba(0,0,0,.16);

--- a/packages/core/src/Button/Button.spec.js
+++ b/packages/core/src/Button/Button.spec.js
@@ -112,8 +112,11 @@ describe('Button', () => {
   })
 
   describe('deprecated prop types', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('shims deprecated fullWidth prop', () => {

--- a/packages/core/src/Button/Button.spec.js
+++ b/packages/core/src/Button/Button.spec.js
@@ -111,10 +111,19 @@ describe('Button', () => {
     })
   })
 
-  describe('deprecated props', () => {
+  describe('deprecated prop types', () => {
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
+
     test('shims deprecated fullWidth prop', () => {
       const json = rendererCreateWithTheme(<Button fullWidth />).toJSON()
       expect(json).toHaveStyleRule('width', '100%')
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `fullWidth` prop is deprecated and will be removed in a future release. Please use `width` instead.'
+        )
+      )
     })
   })
 })

--- a/packages/core/src/Checkbox/Checkbox.spec.js
+++ b/packages/core/src/Checkbox/Checkbox.spec.js
@@ -4,9 +4,9 @@ import { fireEvent } from '@testing-library/react'
 import { Checkbox } from '..'
 
 describe('Checkbox', () => {
-  test('renders without the theme passed specifically', () => {
-    const onChange = jest.fn()
+  const onChange = jest.fn()
 
+  test('renders without the theme passed specifically', () => {
     const { asFragment } = renderWithTheme(
       <Checkbox id='check-box' onChange={onChange} />
     )
@@ -15,22 +15,20 @@ describe('Checkbox', () => {
 
   test('renders checked when defaultChecked prop is passed as true', () => {
     const { getByRole } = renderWithTheme(
-      <Checkbox id='check-box' defaultChecked />
+      <Checkbox id='check-box' defaultChecked onChange={onChange} />
     )
     const checkbox = getByRole('checkbox')
     expect(checkbox.checked).toBe(true)
   })
 
   test('renders disabled with disabled prop', () => {
-    const onChange = jest.fn()
     const { asFragment } = renderWithTheme(
-      <Checkbox id='check-box' disabled={true} onChange={onChange} />
+      <Checkbox id='check-box' disabled onChange={onChange} />
     )
     expect(asFragment()).toMatchSnapshot()
   })
 
   test('renders disabled with defaultChecked', () => {
-    const onChange = jest.fn()
     const json = rendererCreateWithTheme(
       <Checkbox
         id='check-box'
@@ -43,7 +41,6 @@ describe('Checkbox', () => {
   })
 
   test('calls onChange when clicked', () => {
-    const onChange = jest.fn()
     const { container } = renderWithTheme(
       <Checkbox id='check-box' onChange={onChange} />
     )

--- a/packages/core/src/Flag/Flag.spec.js
+++ b/packages/core/src/Flag/Flag.spec.js
@@ -1,8 +1,12 @@
 import React from 'react'
 
-import { Flag } from '..'
+import { Flag, theme } from '..'
 
 describe('Flag', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('renders', () => {
     const json = rendererCreateWithTheme(<Flag />).toJSON()
     expect(json).toMatchSnapshot()
@@ -11,6 +15,7 @@ describe('Flag', () => {
   test('renders with width prop', () => {
     const json = rendererCreateWithTheme(<Flag width={256} />).toJSON()
     expect(json).toMatchSnapshot()
+    expect(json).toHaveStyleRule('width', '256px')
   })
 
   test('renders with hex value as bg color', () => {
@@ -18,6 +23,7 @@ describe('Flag', () => {
       <Flag width={256} bg='#085397' />
     ).toJSON()
     expect(json).toMatchSnapshot()
+    expect(json.children[1]).toHaveStyleRule('background-color', '#085397')
   })
 
   test('renders with theme color as bg color', () => {
@@ -25,5 +31,9 @@ describe('Flag', () => {
       <Flag width={256} bg='purple' />
     ).toJSON()
     expect(json).toMatchSnapshot()
+    expect(json.children[1]).toHaveStyleRule(
+      'background-color',
+      theme.colors.purple
+    )
   })
 })

--- a/packages/core/src/Flag/Flag.spec.js
+++ b/packages/core/src/Flag/Flag.spec.js
@@ -3,9 +3,12 @@ import React from 'react'
 import { Flag, theme } from '..'
 
 describe('Flag', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('renders', () => {
     const json = rendererCreateWithTheme(<Flag />).toJSON()

--- a/packages/core/src/Flex/Flex.spec.js
+++ b/packages/core/src/Flex/Flex.spec.js
@@ -29,8 +29,11 @@ describe('Flex', () => {
   })
 
   describe('deprecated prop types', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('shims the deprecated `align` prop and warns', () => {

--- a/packages/core/src/Flex/Flex.spec.js
+++ b/packages/core/src/Flex/Flex.spec.js
@@ -29,13 +29,14 @@ describe('Flex', () => {
   })
 
   describe('deprecated prop types', () => {
-    const spy = jest.spyOn(console, 'error')
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
 
     test('shims the deprecated `align` prop and warns', () => {
       const json = rendererCreateWithTheme(<Flex align='center' />).toJSON()
       expect(json).toHaveStyleRule('align-items', 'center')
-      expect(spy.mock.calls).toHaveLength(1)
-      expect(spy).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining(
           'Warning: Failed prop type: The `align` prop is deprecated and will be removed in a future release. Please use `alignItems` instead.'
         )
@@ -45,8 +46,7 @@ describe('Flex', () => {
     test('shims the deprecated `wrap` prop and warns', () => {
       const json = rendererCreateWithTheme(<Flex wrap />).toJSON()
       expect(json).toHaveStyleRule('flex-wrap', 'wrap')
-      expect(spy.mock.calls).toHaveLength(2)
-      expect(spy).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining(
           'Warning: Failed prop type: The `wrap` prop is deprecated and will be removed in a future release. Please use `flexWrap` instead.'
         )
@@ -58,8 +58,7 @@ describe('Flex', () => {
         <Flex justify='space-between' />
       ).toJSON()
       expect(json).toHaveStyleRule('justify-content', 'space-between')
-      expect(spy.mock.calls).toHaveLength(3)
-      expect(spy).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining(
           'Warning: Failed prop type: The `justify` prop is deprecated and will be removed in a future release. Please use `justifyContent` instead.'
         )

--- a/packages/core/src/FormField/FormField.spec.js
+++ b/packages/core/src/FormField/FormField.spec.js
@@ -13,7 +13,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label>Email Address</Label>
-        <Input id='email' />
+        <Input id='email' name='email' />
       </FormField>
     ).toJSON()
     expect(json).toMatchSnapshot()
@@ -24,7 +24,7 @@ describe('FormField', () => {
       <FormField>
         <Label>Email Address</Label>
         <Icon name='Email' />
-        <Input name='email' />
+        <Input id='email' name='email' />
       </FormField>
     ).toJSON()
     expect(json).toMatchSnapshot()
@@ -33,6 +33,7 @@ describe('FormField', () => {
   test('renders with Select ', () => {
     const json = rendererCreateWithTheme(
       <FormField>
+        <Label>Pick Option</Label>
         <Select />
       </FormField>
     ).toJSON()
@@ -42,6 +43,7 @@ describe('FormField', () => {
   test('renders with Select and Icon', () => {
     const json = rendererCreateWithTheme(
       <FormField>
+        <Label>Pick Email Address</Label>
         <Icon name='Email' />
         <Select />
       </FormField>
@@ -54,7 +56,7 @@ describe('FormField', () => {
       <FormField>
         <Label autoHide>Email</Label>
         <Icon name='Email' />
-        <Input name='email' />
+        <Input id='email' name='email' />
       </FormField>
     ).toJSON()
     expect(json).toMatchSnapshot()
@@ -65,7 +67,7 @@ describe('FormField', () => {
       <FormField>
         <Label autoHide>Email</Label>
         <Icon name='Email' />
-        <Input name='email' value='hello@example.com' />
+        <Input id='email' name='email' value='hello@example.com' />
       </FormField>
     ).toJSON()
     const [label] = json.children
@@ -76,7 +78,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label />
-        <Input name='hello' />
+        <Input id='hello' name='hello' />
       </FormField>
     ).toJSON()
     const [label] = json.children
@@ -84,9 +86,11 @@ describe('FormField', () => {
   })
 
   describe('propTypes', () => {
-    test('warns when field is missing', () => {
-      const spy = jest.spyOn(global.console, 'error')
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
 
+    test('warns when field is missing', () => {
       PropTypes.checkPropTypes(
         FormField.propTypes,
         {
@@ -96,23 +100,28 @@ describe('FormField', () => {
         'children',
         'FormField'
       )
-      expect(spy).toHaveBeenCalledTimes(1)
-      spy.mockRestore()
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed children type: No form field found for FormField. Please include an Input, Select, or other form field as a child.'
+        )
+      )
     })
 
     test('warns when Label is missing', () => {
-      const spy = jest.spyOn(global.console, 'error')
       PropTypes.checkPropTypes(
         FormField.propTypes,
         {
           // eslint-disable-next-line react/jsx-key
-          children: [<Input name='test' />],
+          children: [<Input id='test' name='test' />],
         },
         'children',
         'FormField'
       )
-      expect(spy).toHaveBeenCalledTimes(1)
-      spy.mockRestore()
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed children type: No label found for FormField. Please include a Label as a child.'
+        )
+      )
     })
   })
 })

--- a/packages/core/src/FormField/FormField.spec.js
+++ b/packages/core/src/FormField/FormField.spec.js
@@ -86,8 +86,11 @@ describe('FormField', () => {
   })
 
   describe('propTypes', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('warns when field is missing', () => {

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.js.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.js.snap
@@ -112,6 +112,7 @@ exports[`FormField renders 1`] = `
         ]
       }
       id="email"
+      name="email"
       style={
         Object {
           "paddingBottom": 8,
@@ -472,14 +473,14 @@ exports[`FormField renders with Label autoHide prop 1`] = `
 `;
 
 exports[`FormField renders with Select  1`] = `
-.c0 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c1 {
+.c2 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -491,7 +492,7 @@ exports[`FormField renders with Select  1`] = `
   align-items: center;
 }
 
-.c3 {
+.c4 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -500,12 +501,29 @@ exports[`FormField renders with Select  1`] = `
   color: #4f6f8f;
 }
 
-.c4 {
+.c0 {
+  font-size: 10px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+  display: block;
+  width: 100%;
+  margin: 0;
+  color: #4f6f8f;
+  margin-bottom: -20px;
+  margin-left: 12px;
+  padding-top: 6px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.c5 {
   outline: none;
   pointer-events: none;
 }
 
-.c2 {
+.c3 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -526,32 +544,51 @@ exports[`FormField renders with Select  1`] = `
   font-size: 16px;
 }
 
-.c2:focus {
+.c3:focus {
   outline: 0;
   border-color: #007aff;
   box-shadow: 0 0 0 2px #007aff;
 }
 
-.c2::-ms-expand {
+.c3::-ms-expand {
   display: none;
 }
 
 @media screen and (min-width:40em) {
-  .c2 {
+  .c3 {
     font-size: 14px;
   }
 }
 
 <div>
-  <div
+  <label
     className="c0"
+    color="text.light"
+    fontSize={10}
+    fontWeight="bold"
+    style={
+      Object {
+        "height": 20,
+        "opacity": 1,
+        "pointerEvents": "none",
+        "position": "relative",
+        "transitionDuration": ".1s",
+        "transitionProperty": "opacity",
+        "width": "calc(100% - 12px)",
+      }
+    }
+  >
+    Pick Option
+  </label>
+  <div
+    className="c1"
   >
     <div
-      className="c1"
+      className="c2"
       width={1}
     >
       <select
-        className="c2 "
+        className="c3 "
         fontSize={
           Array [
             2,
@@ -561,10 +598,10 @@ exports[`FormField renders with Select  1`] = `
         }
         style={
           Object {
-            "paddingBottom": 14,
+            "paddingBottom": 8,
             "paddingLeft": undefined,
             "paddingRight": undefined,
-            "paddingTop": 14,
+            "paddingTop": 20,
             "transitionDuration": ".1s",
             "transitionProperty": "padding-top, padding-bottom",
           }
@@ -572,7 +609,7 @@ exports[`FormField renders with Select  1`] = `
       />
       <svg
         aria-hidden={true}
-        className="c3 c4"
+        className="c4 c5"
         color="text.light"
         fill="currentcolor"
         focusable={false}
@@ -592,14 +629,14 @@ exports[`FormField renders with Select  1`] = `
 `;
 
 exports[`FormField renders with Select and Icon 1`] = `
-.c0 {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c4 {
+.c5 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -611,14 +648,14 @@ exports[`FormField renders with Select and Icon 1`] = `
   align-items: center;
 }
 
-.c1 {
+.c2 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
   width: 24px;
 }
 
-.c6 {
+.c7 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -627,20 +664,37 @@ exports[`FormField renders with Select and Icon 1`] = `
   color: #4f6f8f;
 }
 
-.c2 {
-  outline: none;
-}
-
 .c3 {
   outline: none;
 }
 
-.c7 {
+.c4 {
+  outline: none;
+}
+
+.c0 {
+  font-size: 10px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+  display: block;
+  width: 100%;
+  margin: 0;
+  color: #4f6f8f;
+  margin-bottom: -20px;
+  margin-left: 40px;
+  padding-top: 6px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.c8 {
   outline: none;
   pointer-events: none;
 }
 
-.c5 {
+.c6 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -661,29 +715,48 @@ exports[`FormField renders with Select and Icon 1`] = `
   font-size: 16px;
 }
 
-.c5:focus {
+.c6:focus {
   outline: 0;
   border-color: #007aff;
   box-shadow: 0 0 0 2px #007aff;
 }
 
-.c5::-ms-expand {
+.c6::-ms-expand {
   display: none;
 }
 
 @media screen and (min-width:40em) {
-  .c5 {
+  .c6 {
     font-size: 14px;
   }
 }
 
 <div>
-  <div
+  <label
     className="c0"
+    color="text.light"
+    fontSize={10}
+    fontWeight="bold"
+    style={
+      Object {
+        "height": 20,
+        "opacity": 1,
+        "pointerEvents": "none",
+        "position": "relative",
+        "transitionDuration": ".1s",
+        "transitionProperty": "opacity",
+        "width": "calc(100% - 40px)",
+      }
+    }
+  >
+    Pick Email Address
+  </label>
+  <div
+    className="c1"
   >
     <svg
       aria-hidden={true}
-      className="c1 c2 c3"
+      className="c2 c3 c4"
       fill="currentcolor"
       focusable={false}
       height={24}
@@ -711,11 +784,11 @@ exports[`FormField renders with Select and Icon 1`] = `
       />
     </svg>
     <div
-      className="c4"
+      className="c5"
       width={1}
     >
       <select
-        className="c5 "
+        className="c6 "
         fontSize={
           Array [
             2,
@@ -725,10 +798,10 @@ exports[`FormField renders with Select and Icon 1`] = `
         }
         style={
           Object {
-            "paddingBottom": 14,
+            "paddingBottom": 8,
             "paddingLeft": 40,
             "paddingRight": undefined,
-            "paddingTop": 14,
+            "paddingTop": 20,
             "transitionDuration": ".1s",
             "transitionProperty": "padding-top, padding-bottom",
           }
@@ -736,7 +809,7 @@ exports[`FormField renders with Select and Icon 1`] = `
       />
       <svg
         aria-hidden={true}
-        className="c6 c7"
+        className="c7 c8"
         color="text.light"
         fill="currentcolor"
         focusable={false}

--- a/packages/core/src/RatingBadge/RatingBadge.spec.js
+++ b/packages/core/src/RatingBadge/RatingBadge.spec.js
@@ -3,6 +3,10 @@ import React from 'react'
 import { RatingBadge } from '..'
 
 describe('RatingBadge', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('renders', () => {
     const json = rendererCreateWithTheme(<RatingBadge />).toJSON()
     expect(json).toMatchSnapshot()

--- a/packages/core/src/RatingBadge/RatingBadge.spec.js
+++ b/packages/core/src/RatingBadge/RatingBadge.spec.js
@@ -3,9 +3,12 @@ import React from 'react'
 import { RatingBadge } from '..'
 
 describe('RatingBadge', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('renders', () => {
     const json = rendererCreateWithTheme(<RatingBadge />).toJSON()

--- a/packages/core/src/Stamp/Stamp.spec.js
+++ b/packages/core/src/Stamp/Stamp.spec.js
@@ -3,6 +3,10 @@ import React from 'react'
 import { Stamp, theme } from '..'
 
 describe('Stamp', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('renders', () => {
     const json = rendererCreateWithTheme(<Stamp />).toJSON()
     expect(json).toMatchSnapshot()

--- a/packages/core/src/Stamp/Stamp.spec.js
+++ b/packages/core/src/Stamp/Stamp.spec.js
@@ -3,9 +3,12 @@ import React from 'react'
 import { Stamp, theme } from '..'
 
 describe('Stamp', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('renders', () => {
     const json = rendererCreateWithTheme(<Stamp />).toJSON()

--- a/packages/core/src/Text/Text.spec.js
+++ b/packages/core/src/Text/Text.spec.js
@@ -85,8 +85,11 @@ describe('Text', () => {
   })
 
   describe('deprecated prop types', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('shims deprecated align prop', () => {

--- a/packages/core/src/Text/Text.spec.js
+++ b/packages/core/src/Text/Text.spec.js
@@ -84,10 +84,19 @@ describe('Text', () => {
     expect(json).toHaveStyleRule('max-width', '400px')
   })
 
-  describe('deprecated props', () => {
+  describe('deprecated prop types', () => {
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
+
     test('shims deprecated align prop', () => {
       const json = rendererCreateWithTheme(<Text align='center' />).toJSON()
       expect(json).toHaveStyleRule('text-align', 'center')
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `align` prop is deprecated and will be removed in a future release. Please use `textAlign` instead.'
+        )
+      )
     })
   })
 })

--- a/packages/core/src/ToggleBadge/ToggleBadge.spec.js
+++ b/packages/core/src/ToggleBadge/ToggleBadge.spec.js
@@ -2,9 +2,12 @@ import React from 'react'
 import { ToggleBadge, theme } from '..'
 
 describe('ToggleBadge', () => {
-  const consoleError = console.error
-  console.error = jest.fn()
-  afterAll(() => (console.error = consoleError))
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
 
   test('selected ToggleBadge renders with default props', () => {
     const json = rendererCreateWithTheme(<ToggleBadge selected />).toJSON()

--- a/packages/core/src/ToggleBadge/ToggleBadge.spec.js
+++ b/packages/core/src/ToggleBadge/ToggleBadge.spec.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { ToggleBadge, theme } from '..'
 
 describe('ToggleBadge', () => {
+  const consoleError = console.error
+  console.error = jest.fn()
+  afterAll(() => (console.error = consoleError))
+
   test('selected ToggleBadge renders with default props', () => {
     const json = rendererCreateWithTheme(<ToggleBadge selected />).toJSON()
     expect(json).toMatchSnapshot()

--- a/packages/core/src/Tooltip/Tooltip.spec.js
+++ b/packages/core/src/Tooltip/Tooltip.spec.js
@@ -57,8 +57,11 @@ describe('Tooltip', () => {
   })
 
   describe('deprecated prop types', () => {
-    const consoleError = console.error
-    beforeEach(() => (console.error = jest.fn()))
+    let consoleError
+    beforeEach(() => {
+      consoleError = console.error
+      console.error = jest.fn()
+    })
     afterEach(() => (console.error = consoleError))
 
     test('bg prop warns', () => {

--- a/packages/core/src/Tooltip/Tooltip.spec.js
+++ b/packages/core/src/Tooltip/Tooltip.spec.js
@@ -9,7 +9,7 @@ describe('Tooltip', () => {
 
   test('top left', () => {
     const json = rendererCreateWithTheme(
-      <Tooltip bg='blue' color='white' top left>
+      <Tooltip color='primary' top left>
         left tooltip
       </Tooltip>
     ).toJSON()
@@ -17,7 +17,7 @@ describe('Tooltip', () => {
   })
   test('top center', () => {
     const json = rendererCreateWithTheme(
-      <Tooltip bg='black' color='white' top center>
+      <Tooltip color='primary' top center>
         centered tooltip
       </Tooltip>
     ).toJSON()
@@ -25,7 +25,7 @@ describe('Tooltip', () => {
   })
   test('top right', () => {
     const json = rendererCreateWithTheme(
-      <Tooltip bg='red' color='white' top right>
+      <Tooltip color='error' top right>
         right tooltip
       </Tooltip>
     ).toJSON()
@@ -54,5 +54,24 @@ describe('Tooltip', () => {
       </Tooltip>
     ).toJSON()
     expect(json).toMatchSnapshot()
+  })
+
+  describe('deprecated prop types', () => {
+    const consoleError = console.error
+    beforeEach(() => (console.error = jest.fn()))
+    afterEach(() => (console.error = consoleError))
+
+    test('bg prop warns', () => {
+      rendererCreateWithTheme(
+        <Tooltip bg='blue' top left>
+          left tooltip
+        </Tooltip>
+      ).toJSON()
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Warning: Failed prop type: The `bg` prop is deprecated and will be removed in a future release. Please use `color` instead.'
+        )
+      )
+    })
   })
 })

--- a/packages/core/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/packages/core/src/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -255,7 +255,7 @@ exports[`Tooltip top center 1`] = `
   margin-top: 8px;
   margin-bottom: 16px;
   padding: 8px;
-  background-color: #000;
+  background-color: #007aff;
   color: #fff;
   display: inline;
   box-shadow: 0 0 2px 0 rgba(0,0,0,.08),0 2px 8px 0 rgba(0,0,0,.16);
@@ -263,7 +263,7 @@ exports[`Tooltip top center 1`] = `
   position: absolute;
   border-radius: 2px;
   box-sizing: border-box;
-  background: #000;
+  background: #007aff;
   text-align: center;
   bottom: -8px;
   left: 50%;
@@ -280,7 +280,7 @@ exports[`Tooltip top center 1`] = `
   height: 0;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent transparent #000 #000;
+  border-color: transparent transparent #007aff #007aff;
   -webkit-transform-origin: 0 0;
   -ms-transform-origin: 0 0;
   transform-origin: 0 0;
@@ -309,7 +309,7 @@ exports[`Tooltip top center 1`] = `
 >
   <div
     className="c0"
-    color="white"
+    color="primary"
   >
     centered tooltip
   </div>
@@ -370,7 +370,7 @@ exports[`Tooltip top left 1`] = `
 >
   <div
     className="c0"
-    color="white"
+    color="primary"
   >
     left tooltip
   </div>
@@ -432,7 +432,7 @@ exports[`Tooltip top right 1`] = `
 >
   <div
     className="c0"
-    color="white"
+    color="error"
   >
     right tooltip
   </div>


### PR DESCRIPTION
- Refactor tests to remove all deprecated proptype warnings from tests
  - Change mock pattern for tests explicitly asserting `console.error` calls and messages
- Add components or properties where missing in tests
  - `FormField` uses `Input` which requires an `id` prop set, also uses `Select` which requires a `Label`
  - `Checkbox` requires an `onChange` prop which was missing from one test
- Refactor `Box` and `Tooltip` to remove deprecated prop type use from normal tests and move into deprecated prop type test suite like other existing tests
  - Couldn't do this for components that mark `bg` as deprecated but have not yet removed the requirement of `bg` to render the component correctly (includes `Badge`, `Banner`, `Flag`, `RatingBadge`, `Stamp`, `ToggleBadge`) so I added the `console.error` mock hooks in these components' test suites

Fixes #845 

<img width="507" alt="Screen Shot 2020-08-07 at 3 28 49 PM" src="https://user-images.githubusercontent.com/12076625/89686028-1e7dba80-d8c3-11ea-83af-7c22cbe94a7a.png">
