### PR TITLE
fix(missing-box-shadows): provide fallback boxShadows

### DIFF
--- a/packages/core/src/utils/boxShadow.js
+++ b/packages/core/src/utils/boxShadow.js
@@ -6,19 +6,23 @@
  * @param props
  * @returns {{ 'box-shadow': string }}
  */
+
+import { boxShadows as defaultBoxShadowTheme } from '../theme'
+
 export default (props) => {
+  const boxShadowTheme = props.theme.boxShadows || defaultBoxShadowTheme
   const boxShadows = {
     sm: {
-      'box-shadow': props.theme.boxShadows[0],
+      'box-shadow': boxShadowTheme[0],
     },
     md: {
-      'box-shadow': props.theme.boxShadows[1],
+      'box-shadow': boxShadowTheme[1],
     },
     lg: {
-      'box-shadow': props.theme.boxShadows[2],
+      'box-shadow': boxShadowTheme[2],
     },
     xl: {
-      'box-shadow': props.theme.boxShadows[3],
+      'box-shadow': boxShadowTheme[3],
     },
   }
   return boxShadows[props.boxShadowSize]

--- a/packages/core/src/utils/boxShadow.spec.js
+++ b/packages/core/src/utils/boxShadow.spec.js
@@ -1,0 +1,85 @@
+import boxShadow from './boxShadow'
+import { boxShadows } from '../theme'
+
+const theme = {
+  boxShadows: [
+    '0 0 1px 0 rgba(0,0,0,1)',
+    '0 0 2px 0 rgba(0,0,0,1)',
+    '0 0 3px 0 rgba(0,0,0,1)',
+    '0 0 4px 0 rgba(0,0,0,1)',
+  ],
+}
+
+describe('boxShadow', () => {
+  test('should get sm value from theme', () => {
+    expect(
+      boxShadow({
+        theme,
+        boxShadowSize: 'sm',
+      })
+    ).toEqual({ 'box-shadow': '0 0 1px 0 rgba(0,0,0,1)' })
+  })
+
+  test('should get md value from theme', () => {
+    expect(
+      boxShadow({
+        theme,
+        boxShadowSize: 'md',
+      })
+    ).toEqual({ 'box-shadow': '0 0 2px 0 rgba(0,0,0,1)' })
+  })
+
+  test('should get lg value from theme', () => {
+    expect(
+      boxShadow({
+        theme,
+        boxShadowSize: 'lg',
+      })
+    ).toEqual({ 'box-shadow': '0 0 3px 0 rgba(0,0,0,1)' })
+  })
+
+  test('should get xl value from theme', () => {
+    expect(
+      boxShadow({
+        theme,
+        boxShadowSize: 'xl',
+      })
+    ).toEqual({ 'box-shadow': '0 0 4px 0 rgba(0,0,0,1)' })
+  })
+
+  test('should get default sm value for missing boxShadows in theme', () => {
+    expect(
+      boxShadow({
+        theme: {},
+        boxShadowSize: 'sm',
+      })
+    ).toEqual({ 'box-shadow': boxShadows[0] })
+  })
+
+  test('should get default md value for missing boxShadows in theme', () => {
+    expect(
+      boxShadow({
+        theme: {},
+        boxShadowSize: 'md',
+      })
+    ).toEqual({ 'box-shadow': boxShadows[1] })
+  })
+
+  test('should get default lg value for missing boxShadows in theme', () => {
+    expect(
+      boxShadow({
+        theme: {},
+        boxShadowSize: 'lg',
+      })
+    ).toEqual({ 'box-shadow': boxShadows[2] })
+  })
+
+  test('should get default xl value for missing boxShadows in theme', () => {
+    expect(
+      boxShadow({
+        theme: {},
+        boxShadowSize: 'xl',
+      })
+    ).toEqual({ 'box-shadow': boxShadows[3] })
+  })
+})


### PR DESCRIPTION
Provide fallback boxShadows for boxShadow util. The introduction of the boxShadow util in v3 caused a breaking change in rare instances. For example, a Google Maps component could throw an error that props.theme.boxShadows does not exist.  This failsafe helps to prevent that issue.