### PR TITLE
Update all tests and stories to use named icons

### DIFF
--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -33,6 +33,7 @@
     "cross-env": "^6.0.3",
     "npm-run-all": "^4.1.5",
     "pcln-design-system": "^3.6.1",
+    "pcln-icons": "^3.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.13.1",

--- a/packages/autocomplete/storybook/Autocomplete.stories.js
+++ b/packages/autocomplete/storybook/Autocomplete.stories.js
@@ -1,11 +1,12 @@
 /* eslint-disable react/no-children-prop */
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Box, Text, Icon } from 'pcln-design-system'
+import { Box, Text } from 'pcln-design-system'
 import catNames from 'cat-names'
 import Component from '@reach/component-component'
 import { ThemeProvider } from 'pcln-design-system'
 import { Autocomplete, Label, Input, Menu, Item } from '../src'
+import { Pin as PinIcon } from 'pcln-icons'
 
 const cats = catNames.all
 const match = (item, value) => item.includes(value)
@@ -43,7 +44,7 @@ storiesOf('Autocomplete', module)
             <Menu>
               {cats.map((cat) => (
                 <Item key={cat} item={cat}>
-                  <Icon name='Pin' color='primary' mr={2} />
+                  <PinIcon color='primary' mr={2} />
                   <Text fontSize={0}>{cat}</Text>
                 </Item>
               ))}
@@ -76,7 +77,7 @@ storiesOf('Autocomplete', module)
               <Menu>
                 {cats.map((cat) => (
                   <Item key={cat} item={cat}>
-                    <Icon name='Pin' color='primary' mr={2} />
+                    <PinIcon color='primary' mr={2} />
                     <Text fontSize={0}>{cat}</Text>
                   </Item>
                 ))}

--- a/packages/core/src/Absolute/Absolute.stories.js
+++ b/packages/core/src/Absolute/Absolute.stories.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import styled from 'styled-components'
-import { Absolute, Card, Flag, Icon, Image, Relative, Text } from '..'
+import { Absolute, Card, Flag, Image, Relative, Text } from '..'
+import { Close as CloseIcon } from 'pcln-icons'
 
 const TallCard = styled(Card)`
   height: 420px;
@@ -44,7 +45,7 @@ storiesOf('Absolute', module)
           vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
         </Text>
         <Absolute top='10px' right='10px'>
-          <Icon name='close' color='Gray' size={24} />
+          <CloseIcon color='text.base' size={24} />
         </Absolute>
       </Relative>
     </Card>

--- a/packages/core/src/Flag/Flag.stories.js
+++ b/packages/core/src/Flag/Flag.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Box, Card, Flag, Flex, Icon, Text } from '..'
+import { Box, Card, Flag, Flex, Text } from '..'
+import { Loyalty as LoyaltyIcon } from 'pcln-icons'
 
 storiesOf('Flag', module)
   .add('Default', () => (
@@ -70,7 +71,7 @@ storiesOf('Flag', module)
       <Card pb={3}>
         <Flag mt={2}>
           <Flex>
-            <Icon size={14} mr={1} name='Loyalty' />
+            <LoyaltyIcon size={14} mr={1} />
             <Text>Hello World</Text>
           </Flex>
         </Flag>

--- a/packages/core/src/FormField/FormField.spec.js
+++ b/packages/core/src/FormField/FormField.spec.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { FormField, Icon, Input, Label, Select } from '..'
+import { FormField, Input, Label, Select } from '..'
+import { Email as EmailIcon } from 'pcln-icons'
 
 afterEach(() => {
   // bust cache for propTypes
@@ -23,7 +24,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label>Email Address</Label>
-        <Icon name='Email' />
+        <EmailIcon />
         <Input id='email' name='email' />
       </FormField>
     ).toJSON()
@@ -44,7 +45,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label>Pick Email Address</Label>
-        <Icon name='Email' />
+        <EmailIcon />
         <Select />
       </FormField>
     ).toJSON()
@@ -55,7 +56,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label autoHide>Email</Label>
-        <Icon name='Email' />
+        <EmailIcon />
         <Input id='email' name='email' />
       </FormField>
     ).toJSON()
@@ -66,7 +67,7 @@ describe('FormField', () => {
     const json = rendererCreateWithTheme(
       <FormField>
         <Label autoHide>Email</Label>
-        <Icon name='Email' />
+        <EmailIcon />
         <Input id='email' name='email' value='hello@example.com' />
       </FormField>
     ).toJSON()

--- a/packages/core/src/FormField/FormField.stories.js
+++ b/packages/core/src/FormField/FormField.stories.js
@@ -1,12 +1,19 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Flex, Box, FormField, Label, Input, Icon, Select, Tooltip } from '..'
+import { Flex, Box, FormField, Label, Input, Select, Tooltip } from '..'
+import {
+  Check as CheckIcon,
+  Email as EmailIcon,
+  Pin as PinIcon,
+  Success as SuccessIcon,
+  Warning as WarningIcon,
+} from 'pcln-icons'
 
 storiesOf('FormField', module)
   .add('with Icon', () => (
     <FormField>
       <Label htmlFor='demo'>Email Address</Label>
-      <Icon name='Email' color='blue' />
+      <EmailIcon color='primary' />
       <Input
         type='email'
         id='email'
@@ -72,13 +79,13 @@ storiesOf('FormField', module)
         placeholder='hello@example.com'
         value='hello@example.com'
       />
-      <Icon name='Check' color='green' />
+      <CheckIcon color='secondary' />
     </FormField>
   ))
   .add('with Select', () => (
     <FormField>
       <Label htmlFor='dynamic-label-state-select'>State</Label>
-      <Icon name='Pin' color='blue' />
+      <PinIcon color='primary' />
       <Select id='dynamic-label-state-select' name='dynamic-label-state-select'>
         <option>New York</option>
         <option>New Jersey</option>
@@ -92,9 +99,9 @@ storiesOf('FormField', module)
         id='valid'
         name='valid'
         placeholder='hello@example.com'
-        color='green'
+        color='success'
       />
-      <Icon name='Success' color='green' />
+      <SuccessIcon color='success' />
     </FormField>
   ))
   .add('with error Tooltip', () => (
@@ -106,11 +113,11 @@ storiesOf('FormField', module)
           name='error-tooltip'
           placeholder='hello@example.com'
           aria-describedby='demo-error'
-          color='red'
+          color='error'
         />
-        <Icon name='Warning' color='red' />
+        <WarningIcon color='error' />
       </FormField>
-      <Tooltip id='demo-error' right color='white' bg='red'>
+      <Tooltip id='demo-error' right color='error'>
         Email address is required
       </Tooltip>
     </Box>

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.js.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.js.snap
@@ -148,10 +148,6 @@ exports[`FormField renders with Icon 1`] = `
 }
 
 .c4 {
-  outline: none;
-}
-
-.c5 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -172,27 +168,27 @@ exports[`FormField renders with Icon 1`] = `
   font-size: 16px;
 }
 
-.c5::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #4f6f8f;
 }
 
-.c5::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #4f6f8f;
 }
 
-.c5:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #4f6f8f;
 }
 
-.c5::placeholder {
+.c4::placeholder {
   color: #4f6f8f;
 }
 
-.c5::-ms-clear {
+.c4::-ms-clear {
   display: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: 0;
   border-color: #007aff;
   box-shadow: 0 0 0 2px #007aff;
@@ -216,7 +212,7 @@ exports[`FormField renders with Icon 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c5 {
+  .c4 {
     font-size: 14px;
   }
 }
@@ -247,7 +243,7 @@ exports[`FormField renders with Icon 1`] = `
   >
     <svg
       aria-hidden={true}
-      className="c2 c3 c4"
+      className="c2 c3"
       fill="currentcolor"
       focusable={false}
       height={24}
@@ -263,19 +259,15 @@ exports[`FormField renders with Icon 1`] = `
         }
       }
       tabIndex={-1}
-      title="Email"
       viewBox="0 0 24 24"
       width={24}
     >
-      <title>
-        Email
-      </title>
       <path
         d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
       />
     </svg>
     <input
-      className="c5"
+      className="c4"
       fontSize={
         Array [
           2,
@@ -320,10 +312,6 @@ exports[`FormField renders with Label autoHide prop 1`] = `
 }
 
 .c4 {
-  outline: none;
-}
-
-.c5 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -344,27 +332,27 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   font-size: 16px;
 }
 
-.c5::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #4f6f8f;
 }
 
-.c5::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #4f6f8f;
 }
 
-.c5:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #4f6f8f;
 }
 
-.c5::placeholder {
+.c4::placeholder {
   color: #4f6f8f;
 }
 
-.c5::-ms-clear {
+.c4::-ms-clear {
   display: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: 0;
   border-color: #007aff;
   box-shadow: 0 0 0 2px #007aff;
@@ -388,7 +376,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
 }
 
 @media screen and (min-width:40em) {
-  .c5 {
+  .c4 {
     font-size: 14px;
   }
 }
@@ -419,7 +407,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   >
     <svg
       aria-hidden={true}
-      className="c2 c3 c4"
+      className="c2 c3"
       fill="currentcolor"
       focusable={false}
       height={24}
@@ -435,19 +423,15 @@ exports[`FormField renders with Label autoHide prop 1`] = `
         }
       }
       tabIndex={-1}
-      title="Email"
       viewBox="0 0 24 24"
       width={24}
     >
-      <title>
-        Email
-      </title>
       <path
         d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
       />
     </svg>
     <input
-      className="c5"
+      className="c4"
       fontSize={
         Array [
           2,
@@ -636,7 +620,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -655,7 +639,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c6 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -665,10 +649,6 @@ exports[`FormField renders with Select and Icon 1`] = `
 }
 
 .c3 {
-  outline: none;
-}
-
-.c4 {
   outline: none;
 }
 
@@ -689,12 +669,12 @@ exports[`FormField renders with Select and Icon 1`] = `
   font-weight: 700;
 }
 
-.c8 {
+.c7 {
   outline: none;
   pointer-events: none;
 }
 
-.c6 {
+.c5 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -715,18 +695,18 @@ exports[`FormField renders with Select and Icon 1`] = `
   font-size: 16px;
 }
 
-.c6:focus {
+.c5:focus {
   outline: 0;
   border-color: #007aff;
   box-shadow: 0 0 0 2px #007aff;
 }
 
-.c6::-ms-expand {
+.c5::-ms-expand {
   display: none;
 }
 
 @media screen and (min-width:40em) {
-  .c6 {
+  .c5 {
     font-size: 14px;
   }
 }
@@ -756,7 +736,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   >
     <svg
       aria-hidden={true}
-      className="c2 c3 c4"
+      className="c2 c3"
       fill="currentcolor"
       focusable={false}
       height={24}
@@ -772,23 +752,19 @@ exports[`FormField renders with Select and Icon 1`] = `
         }
       }
       tabIndex={-1}
-      title="Email"
       viewBox="0 0 24 24"
       width={24}
     >
-      <title>
-        Email
-      </title>
       <path
         d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"
       />
     </svg>
     <div
-      className="c5"
+      className="c4"
       width={1}
     >
       <select
-        className="c6 "
+        className="c5 "
         fontSize={
           Array [
             2,
@@ -809,7 +785,7 @@ exports[`FormField renders with Select and Icon 1`] = `
       />
       <svg
         aria-hidden={true}
-        className="c7 c8"
+        className="c6 c7"
         color="text.light"
         fill="currentcolor"
         focusable={false}

--- a/packages/core/src/Icon/Icon.stories.js
+++ b/packages/core/src/Icon/Icon.stories.js
@@ -1,49 +1,58 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Box, Flex, Icon, Truncate } from '..'
+import { Box, Flex, Truncate } from '..'
 import * as icons from 'pcln-icons'
+import {
+  Accessible as AccessibleIcon,
+  Cars as CarsIcon,
+  Flights as FlightsIcon,
+  Hotels as HotelsIcon,
+} from 'pcln-icons'
 
 const { Accessible } = icons
-const keys = Object.keys(icons)
+const keys = Object.keys(icons).filter((icon) => icon !== 'Icon')
 
 storiesOf('Icon', module)
   .add('Icons', () => (
     <Box p={2} color='primary'>
       <Flex wrap>
-        {keys.map((name) => (
-          <Flex
-            key={name}
-            flexDirection='column'
-            alignItems='center'
-            width={[1 / 3, 1 / 5, 1 / 6, 1 / 8]}
-            mx={2}
-            my={3}
-          >
-            <Icon name={name} size={48} />
-            <Truncate fontSize={0} mt={1}>
-              {name}
-            </Truncate>
-          </Flex>
-        ))}
+        {keys.map((name) => {
+          const Component = icons[name]
+
+          return (
+            <Flex
+              key={name}
+              flexDirection='column'
+              alignItems='center'
+              width={[1 / 3, 1 / 5, 1 / 6, 1 / 8]}
+              mx={2}
+              my={3}
+            >
+              <Component size={48} />
+              <Truncate fontSize={0} mt={1}>
+                {name}
+              </Truncate>
+            </Flex>
+          )
+        })}
       </Flex>
     </Box>
   ))
   .add('Color', () => (
     <div>
-      <Icon color='primary' size={48} m={2} name='Flights' />
-      <Icon color='secondary' size={48} m={2} name='Hotels' />
-      <Icon color='alert' size={48} m={2} name='Cars' />
+      <FlightsIcon color='primary' size={48} m={2} />
+      <HotelsIcon color='secondary' size={48} m={2} />
+      <CarsIcon color='alert' size={48} m={2} />
     </div>
   ))
   .add('Responsive', () => (
-    <Icon color='primary' size={[100, 200, 300, 50]} name='Flights' />
+    <FlightsIcon color='primary' size={[100, 200, 300, 50]} name='Flights' />
   ))
   .add('a11y', () => (
     <Box>
-      <Icon
+      <AccessibleIcon
         color='primary'
         size={[100, 200, 300, 50]}
-        name='Accessible'
         title='Accessible Logo'
         titleId='titleId'
         desc='Accessible Logo description'

--- a/packages/core/src/Relative/Relative.spec.js
+++ b/packages/core/src/Relative/Relative.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { Absolute, Icon, Text, Relative } from '..'
+import { Absolute, Text, Relative } from '..'
+import { Coupon as CouponIcon } from 'pcln-icons'
 
 describe('Relative', () => {
   test('renders with top, left and zIndex props', () => {
@@ -18,7 +19,7 @@ describe('Relative', () => {
     const json = rendererCreateWithTheme(
       <Relative top={10} left={0}>
         <Absolute top={10} right={0} zIndex={2}>
-          <Icon name='Coupon' />
+          <CouponIcon />
           <Text.span>EXCLUSIVE</Text.span>
         </Absolute>
       </Relative>

--- a/packages/core/src/Relative/Relative.stories.js
+++ b/packages/core/src/Relative/Relative.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Absolute, Card, Flag, Icon, Image, Relative, Text } from '..'
+import { Absolute, Card, Flag, Image, Relative, Text } from '..'
+import { Close as CloseIcon } from 'pcln-icons'
 
 storiesOf('Relative', module)
   .add('Around an Image and an absolutely positioned Flag', () => (
@@ -23,7 +24,7 @@ storiesOf('Relative', module)
           vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
         </Text>
         <Absolute top='10px' right='10px'>
-          <Icon name='Close' color='gray' size={24} />
+          <CloseIcon color='text.base' size={24} />
         </Absolute>
       </Relative>
     </Card>

--- a/packages/core/src/Stamp/Stamp.stories.js
+++ b/packages/core/src/Stamp/Stamp.stories.js
@@ -3,7 +3,8 @@ import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 import { Cartesian } from '@compositor/kit'
 
-import { Stamp, Icon, Text } from '..'
+import { Stamp, Text } from '..'
+import { Pin as PinIcon } from 'pcln-icons'
 
 const sizes = { small: 'small', medium: 'medium' }
 const variations = { outline: 'outline', fill: 'fill' }
@@ -31,7 +32,7 @@ storiesOf('Stamp', module)
     withInfo({
       inline: true,
       text:
-        'Use the <Stamp /> component to subtly display attributes alongside listing cells and on product detail pages. Use it in conjunction with an <Icon /> component to give it more context. An Icon placed within a Stamp will inherit the assigned Stamp color.',
+        'Use the <Stamp /> component to subtly display attributes alongside listing cells and on product detail pages. Use it in conjunction with a named `pcln-icons` icon component to give it more context. An icon placed within a Stamp will inherit the assigned Stamp color.',
     })(() => <Stamp>default stamp</Stamp>)
   )
   .add('All', () => (
@@ -43,7 +44,7 @@ storiesOf('Stamp', module)
       m={3}
     >
       <>
-        <Icon name='Pin' mr={1} /> top location
+        <PinIcon mr={1} /> top location
       </>
     </Cartesian>
   ))

--- a/packages/core/src/stories/Layouts.stories.js
+++ b/packages/core/src/stories/Layouts.stories.js
@@ -2,19 +2,20 @@ import React from 'react'
 import styled from 'styled-components'
 import { storiesOf } from '@storybook/react'
 
-import { Flex, Box, Text, Icon, Image, Heading } from '..'
+import { Flex, Box, Text, Image, Heading, getPaletteColor } from '..'
+import { Hotels as HotelsIcon } from 'pcln-icons'
 
 storiesOf('Layout Examples', module)
   .add('Grid', () => (
     <Box p={4}>
       <Flex wrap mx={-3}>
         <Box width={[1, 1 / 2]} px={3} mb={4}>
-          <Box bg='lightGray'>
+          <Box bg='background.light'>
             <Text>Hello</Text>
           </Box>
         </Box>
         <Box width={[1, 1 / 2]} px={3} mb={4}>
-          <Box bg='lightGray'>
+          <Box bg='background.light'>
             <Text>Hello</Text>
           </Box>
         </Box>
@@ -25,7 +26,7 @@ storiesOf('Layout Examples', module)
     <Flex>
       <Box px={3} width={1 / 4}>
         <Box
-          bg='lightGray'
+          bg='background.light'
           style={{
             minHeight: '50vh',
           }}
@@ -35,7 +36,7 @@ storiesOf('Layout Examples', module)
       </Box>
       <Box px={3} width={3 / 4}>
         <Box
-          bg='lightGray'
+          bg='background.light'
           style={{
             minHeight: '50vh',
           }}
@@ -46,8 +47,8 @@ storiesOf('Layout Examples', module)
     </Flex>
   ))
   .add('Navbar', () => (
-    <Flex p={2} alignItems='center' color='white' bg='blue'>
-      <Icon name='Hotel' mr={2} />
+    <Flex p={2} alignItems='center' color='primary'>
+      <HotelsIcon mr={2} />
       <Text bold mx={2}>
         Hello
       </Text>
@@ -68,7 +69,7 @@ storiesOf('Layout Examples', module)
   ))
 
 const Border = styled(Box)`
-  border: 1px solid ${(props) => props.theme.colors.lightGray};
+  border: 1px solid ${getPaletteColor('background.base')};
   border-radius: 3px;
 `
 

--- a/packages/icons/test/index.js
+++ b/packages/icons/test/index.js
@@ -4,10 +4,9 @@ import TestRenderer from 'react-test-renderer'
 import {
   Airplane as AirplaneIcon,
   Accessible as AccessibleIcon,
-  Icon,
-} from '../'
+} from 'pcln-icons'
 
-import * as icons from '../'
+import * as icons from 'pcln-icons'
 const iconList = Object.keys(icons).map((key) => [key, icons[key]])
 
 test.each(iconList)('renders %s', (key, Component) => {
@@ -17,7 +16,7 @@ test.each(iconList)('renders %s', (key, Component) => {
 
 describe('Icon', () => {
   test('defaults title to name if not provided', () => {
-    const testRenderer = TestRenderer.create(<Icon name='Accessible' />)
+    const testRenderer = TestRenderer.create(<AccessibleIcon />)
     const testInstance = testRenderer.root
     expect(testInstance.findByType('title').children[0]).toBe('Accessible')
   })
@@ -91,11 +90,7 @@ describe('Icon', () => {
 
     test(`aria-labelledby has only titleId when 'desc' prop is missing in <Icon /> `, () => {
       const testRenderer = TestRenderer.create(
-        <Icon
-          name='Accessible'
-          title='Accessible Logo'
-          titleId='accessible-logo'
-        />
+        <AccessibleIcon title='Accessible Logo' titleId='accessible-logo' />
       )
       expect(testRenderer.toJSON().props['aria-labelledby']).toBe(
         'accessible-logo'
@@ -122,10 +117,8 @@ describe('Icon', () => {
     )
 
     test('Icon should render with no outline ', () => {
-      const namedJson = TestRenderer.create(<AirplaneIcon />).toJSON()
-      const json = TestRenderer.create(<Icon name='Airplane' />).toJSON()
+      const json = TestRenderer.create(<AirplaneIcon />).toJSON()
       expect(json).toHaveStyleRule('outline', 'none')
-      expect(namedJson).toHaveStyleRule('outline', 'none')
     })
   })
 })

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -51,6 +51,7 @@
     "jest": "^26.0.1",
     "npm-run-all": "^4.1.5",
     "pcln-design-system": "^3.6.1",
+    "pcln-icons": "^3.2.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-focus-lock": "^2.2.1",

--- a/packages/popover/src/Overlay/Overlay.spec.js
+++ b/packages/popover/src/Overlay/Overlay.spec.js
@@ -8,6 +8,13 @@ const overlayProps = {
 }
 
 describe('Background Overlay', () => {
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
+
   test('Active overlay', () => {
     const { container } = renderWithTheme(
       <Overlay {...overlayProps} popoverOpen={true} />

--- a/packages/popover/src/Popover/Popover.spec.js
+++ b/packages/popover/src/Popover/Popover.spec.js
@@ -22,6 +22,13 @@ const popoverProps = {
 const triggerButtonText = 'Trigger Button'
 
 describe('Popover', () => {
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
+
   describe('Trigger Element', () => {
     it('Renders trigger element and appends action props', () => {
       const { container } = renderWithTheme(

--- a/packages/popover/src/Popover/Popover.stories.js
+++ b/packages/popover/src/Popover/Popover.stories.js
@@ -19,7 +19,6 @@ import {
   CloseButton,
   Flex,
   getPaletteColor,
-  Icon,
   Link,
   Text,
   ThemeProvider,
@@ -27,6 +26,7 @@ import {
 import Component from '@reach/component-component'
 import Slider from '../../../slider/src'
 import Popover from './Popover'
+import { Graph as GraphIcon, Pin as PinIcon } from 'pcln-icons'
 
 export default {
   title: 'Popover',
@@ -243,7 +243,7 @@ const PriceGuidanceContent = ({ handleClose }) => (
     <Box p={3}>
       <Box p={2} pt={0} pb={3}>
         <Flex>
-          <Icon name='Graph' color='primary' size='32px' mr='2' />
+          <GraphIcon color='primary' size='32px' mr='2' />
           <Flex flexDirection='column'>
             <Text color='primary' fontSize='24px' bold>
               Price Guidance
@@ -257,7 +257,7 @@ const PriceGuidanceContent = ({ handleClose }) => (
       </Box>
       <StyledBox p={2} pb={0} pt={3}>
         <Flex>
-          <Icon name='Pin' color='text.base' size='32px' mr='2' />
+          <PinIcon color='text.base' size='32px' mr='2' />
           <Flex flexDirection='column'>
             <Text color='text.base' fontSize='14px' bold>
               New York City

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -2,6 +2,13 @@ import React from 'react'
 import PopoverContent from './PopoverContent'
 
 describe('PopoverContent', () => {
+  let consoleError
+  beforeEach(() => {
+    consoleError = console.error
+    console.error = jest.fn()
+  })
+  afterEach(() => (console.error = consoleError))
+
   it('shows the arrow', () => {
     const { queryByTestId } = renderWithTheme(
       <PopoverContent renderContent={() => 'Content'} />


### PR DESCRIPTION
- Replace all tests and stories usage of `<Icon />` with named icons
- Add console.error mocks to popover tests to remove warnings about `StyledOverlay` (`Box`) `bg` prop use
- Update stories to use palette colours

Duplicate of #915 to try and kickoff CI