### PR TITLE
Update docsite action to create .nojekyll file

### DIFF
--- a/.github/workflows/on-master.yml
+++ b/.github/workflows/on-master.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build docsite
         run: node common/scripts/install-run-rush.js build:docsite
 
+      - name: Create .nojekyll file
+        run: touch apps/docs/out/.nojekyll
+
       - name: Build static Storybook
         working-directory: ./
         env:


### PR DESCRIPTION
This change should fix the 404s that are breaking the static docsite