### PR TITLE
fix(939): IconButton background colour transparent when disabled

### DIFF
--- a/packages/core/src/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/packages/core/src/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -61,6 +61,10 @@ exports[`CloseButton renders without props 1`] = `
   display: flex;
 }
 
+.c0:disabled {
+  background-color: transparent;
+}
+
 <button
   aria-label="close"
   className="c0 c1"

--- a/packages/core/src/IconButton/IconButton.js
+++ b/packages/core/src/IconButton/IconButton.js
@@ -17,6 +17,9 @@ const TransparentButton = styled(Button)`
   & > div {
     display: flex;
   }
+  &:disabled {
+    background-color: transparent;
+  }
 
   ${applyVariations('IconButton')}
 `

--- a/packages/core/src/IconButton/IconButton.spec.js
+++ b/packages/core/src/IconButton/IconButton.spec.js
@@ -2,20 +2,30 @@ import React from 'react'
 import { render, fireEvent } from 'testing-library'
 
 import { IconButton } from '..'
+import { Key as KeyIcon } from 'pcln-icons'
 
 describe('IconButton', () => {
   test('executes onClick prop on click', () => {
     const handleClick = jest.fn()
     const { getByRole } = render(
-      <IconButton name='Key' onClick={handleClick} />
+      <IconButton icon={<KeyIcon />} onClick={handleClick} />
     )
 
     fireEvent.click(getByRole('button'))
     expect(handleClick).toHaveBeenCalled()
   })
 
+  test('renders without background color in disabled state', () => {
+    const { container } = render(<IconButton icon={<KeyIcon />} disabled />)
+
+    const button = container.querySelector('button:disabled')
+    expect(button).toHaveStyleRule('background-color', 'transparent')
+  })
+
   test('renders without props', () => {
-    const json = rendererCreateWithTheme(<IconButton name='Key' />).toJSON()
+    const json = rendererCreateWithTheme(
+      <IconButton icon={<KeyIcon />} />
+    ).toJSON()
     expect(json).toMatchSnapshot()
   })
 })

--- a/packages/core/src/IconButton/IconButton.stories.js
+++ b/packages/core/src/IconButton/IconButton.stories.js
@@ -25,6 +25,13 @@ storiesOf('IconButton', module)
       icon={<Calendar title='Choose date' size={64} />}
     />
   ))
+  .add('with disabled', () => (
+    <IconButton
+      onClick={action('Clicked IconButton')}
+      icon={<Calendar title='Choose date' />}
+      disabled
+    />
+  ))
   .add('Forward refs', () => (
     <ForwardRefDemo
       refChild={(dsRef) => (

--- a/packages/core/src/IconButton/__snapshots__/IconButton.spec.js.snap
+++ b/packages/core/src/IconButton/__snapshots__/IconButton.spec.js.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IconButton renders without props 1`] = `
+.c3 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  width: 24px;
+}
+
+.c2 {
+  outline: none;
+}
+
 .c1 {
   -webkit-font-smoothing: antialiased;
   display: inline-block;
@@ -50,11 +61,30 @@ exports[`IconButton renders without props 1`] = `
   display: flex;
 }
 
+.c0:disabled {
+  background-color: transparent;
+}
+
 <button
   className="c0 c1"
   color="primary"
-  name="Key"
 >
-  <div />
+  <div>
+    <svg
+      aria-hidden={true}
+      className="c2 c3"
+      fill="currentcolor"
+      focusable={false}
+      height={24}
+      role="img"
+      tabIndex={-1}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M12.6 10.1C11.8 8 9.8 6.5 7.5 6.5 4.4 6.5 2 8.9 2 12s2.4 5.5 5.5 5.5c2.4 0 4.4-1.5 5.1-3.6h4v3.6h3.6v-3.7H22v-3.7h-9.4zm-5.1 3.7c-1 0-1.8-.8-1.8-1.8s.8-1.8 1.8-1.8 1.8.8 1.8 1.8-.8 1.8-1.8 1.8z"
+      />
+    </svg>
+  </div>
 </button>
 `;

--- a/packages/core/src/IconField/__snapshots__/IconField.spec.js.snap
+++ b/packages/core/src/IconField/__snapshots__/IconField.spec.js.snap
@@ -189,6 +189,10 @@ exports[`IconField renders icon button 1`] = `
   display: flex;
 }
 
+.c2:disabled {
+  background-color: transparent;
+}
+
 .c1 {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -368,6 +372,10 @@ exports[`IconField renders icon, input and icon button together 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c4:disabled {
+  background-color: transparent;
 }
 
 .c3 {

--- a/packages/modal/src/__snapshots__/Headers.spec.js.snap
+++ b/packages/modal/src/__snapshots__/Headers.spec.js.snap
@@ -85,6 +85,10 @@ exports[`ModalHeader render 1`] = `
   display: flex;
 }
 
+.c7:disabled {
+  background-color: transparent;
+}
+
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
   line-height: 1.4;


### PR DESCRIPTION
- Remove default background colour from disabled class inherited on button
- Add story and test for disabled state example
- Refactor IconButton tests to use named icons

#### Storybook
https://5a85e56213417800200978ab-zgbehvvzqn.chromatic.com/?path=/story/iconbutton--with-disabled

#### Screenshots
![Screen Shot 2020-10-16 at 12 42 59 PM](https://user-images.githubusercontent.com/12076625/96291975-7fee9380-0fae-11eb-9c6e-de689e3c1233.png)

![icon-button-disabled-hover](https://user-images.githubusercontent.com/12076625/96292005-8aa92880-0fae-11eb-805f-2e724f9c0e60.png)


Closes #939 