### PR TITLE
Add background color fallback, so that browser color is not applied when screen is zoomed in to >125%

### DIFF
--- a/common/changes/pcln-design-system/dgiraldo313-patch-1_2020-10-21-14-40.json
+++ b/common/changes/pcln-design-system/dgiraldo313-patch-1_2020-10-21-14-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix styling bug in Divider when browser zoomed-in",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/core/src/Divider/Divider.js
+++ b/packages/core/src/Divider/Divider.js
@@ -12,6 +12,8 @@ const Divider = styled.hr`
   border-bottom-width: 1px;
   border-color: ${(props) =>
     getPaletteColor(props.borderColor || props.color, 'base')(props)};
+  background-color: ${(props) =>
+    getPaletteColor(props.borderColor || props.color, 'base')(props)};
   ${space} ${width};
   ${applyVariations('Divider')}
 `

--- a/packages/core/src/Divider/__snapshots__/Divider.spec.js.snap
+++ b/packages/core/src/Divider/__snapshots__/Divider.spec.js.snap
@@ -6,6 +6,7 @@ exports[`Divider borderColor prop sets borderColor 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-color: #007aff;
+  background-color: #007aff;
   margin-left: 0;
   margin-right: 0;
 }
@@ -22,6 +23,7 @@ exports[`Divider m prop sets margin 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-color: #c0cad5;
+  background-color: #c0cad5;
   margin: 8px;
   margin-left: 0;
   margin-right: 0;
@@ -39,6 +41,7 @@ exports[`Divider renders 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-color: #c0cad5;
+  background-color: #c0cad5;
   margin-left: 0;
   margin-right: 0;
 }
@@ -55,6 +58,7 @@ exports[`Divider width prop sets width 1`] = `
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-color: #c0cad5;
+  background-color: #c0cad5;
   margin-left: 0;
   margin-right: 0;
   width: 50%;


### PR DESCRIPTION
#943 
![image](https://user-images.githubusercontent.com/11232323/96509306-0c9c8a00-1219-11eb-96ca-ca243dd272a4.png)
