### PR TITLE
Revert change to remove mapProps from Button

### DIFF
--- a/common/changes/pcln-design-system/revert-button-style-fix_2020-10-21-14-57.json
+++ b/common/changes/pcln-design-system/revert-button-style-fix_2020-10-21-14-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Revert change to Button that broke refs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/core/src/Button/Button.js
+++ b/packages/core/src/Button/Button.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import { width, space } from 'styled-system'
 import {
+  mapProps,
   deprecatedPropType,
   applyVariations,
   getPaletteColor,
@@ -111,13 +112,14 @@ export const buttonStyles = css`
 /**
  * Use the <Button /> component to render a primitive button. Use the `variation` prop to change the look of the button.
  */
-const Button = styled.button.attrs({
-  width: ({ fullWidth, width }) => (fullWidth ? 1 : width),
-  [getSCMigrationRef()]: ({ dsRef }) => dsRef,
-  'aria-label': ({ title }) => title,
-})`
+const Button = mapProps(({ fullWidth, dsRef, ...props }) => ({
+  width: fullWidth ? 1 : undefined,
+  [getSCMigrationRef()]: dsRef,
+  'aria-label': props.title,
+  ...props,
+}))(styled.button`
   ${buttonStyles}
-`
+`)
 
 Button.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),


### PR DESCRIPTION
We didn't realize that this change broke refs for Button, so reverting it will enable us to release subsequent versions between `3.6.1` and `4.0`.

Original PR:
https://github.com/priceline/design-system/pull/928