### PR TITLE
Fix style bug in popover

### DIFF
--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -47,6 +47,7 @@
     "pcln-design-system": "4.0.0-beta.1",
     "pcln-icons": "4.0.0-beta.1",
     "pcln-slider": "4.0.0-beta.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-focus-lock": "^2.2.1",

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -147,7 +147,7 @@ class PopoverContent extends Component {
 
 const PopperGuide = styled(Box)`
   padding: 16px;
-  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)}
+  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)};
   max-width: ${({ width }) => width}px;
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Noticed the issue in Popover's storybook:
<img width="1268" alt="Screen_Shot_2020-10-28_at_5 02 28_PM" src="https://user-images.githubusercontent.com/3260642/98411431-ef1b4d00-206d-11eb-99c2-5df28d675df1.png">

After:
<img width="684" alt="Screen Shot 2020-11-06 at 3 23 46 PM" src="https://user-images.githubusercontent.com/3260642/98411461-fe9a9600-206d-11eb-9db6-f326a59ad1b0.png">
