### PR TITLE
Fix style bug in popover

### DIFF
--- a/common/changes/pcln-popover/popover-bugfix_2020-11-06-20-33.json
+++ b/common/changes/pcln-popover/popover-bugfix_2020-11-06-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Fix style bug in PopoverContent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -47,6 +47,7 @@
     "pcln-design-system": "^3.6.4",
     "pcln-icons": "^3.2.0",
     "pcln-slider": "^3.2.0",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-focus-lock": "^2.2.1",

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -172,7 +172,8 @@ exports[`Popover UI Positioning Bottom 1`] = `
 
 .c0 {
   padding: 16px;
-  z-index: 102 max-width:400px;
+  z-index: 102;
+  max-width: 400px;
   width: 100%;
   box-sizing: border-box;
 }
@@ -308,7 +309,8 @@ exports[`Popover UI Positioning Bottom End 1`] = `
 
 .c0 {
   padding: 16px;
-  z-index: 102 max-width:400px;
+  z-index: 102;
+  max-width: 400px;
   width: 100%;
   box-sizing: border-box;
 }
@@ -444,7 +446,8 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
 
 .c0 {
   padding: 16px;
-  z-index: 102 max-width:400px;
+  z-index: 102;
+  max-width: 400px;
   width: 100%;
   box-sizing: border-box;
 }

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -158,7 +158,7 @@ class PopoverContent extends Component {
 
 const PopperGuide = styled(Box)`
   padding: 16px;
-  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)}
+  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)};
   max-width: ${({ width }) => width}px;
   width: 100%;
   box-sizing: border-box;

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -24,4 +24,12 @@ describe('PopoverContent', () => {
     )
     expect(queryByTestId('popover-arrow')).not.toBeInTheDocument()
   })
+
+  it('has the correct z-index', () => {
+    const zIndex = '123'
+    const { getByRole } = render(
+      <PopoverContent zIndex={zIndex} renderContent={() => 'Content'} />
+    )
+    expect(getByRole('dialog')).toHaveStyleRule('z-index', zIndex)
+  })
 })


### PR DESCRIPTION
**Before:**
<img width="1268" alt="Screen_Shot_2020-10-28_at_5 02 28_PM" src="https://user-images.githubusercontent.com/3260642/98412197-6f8e7d80-206f-11eb-859a-52b86438a5be.png">

**After:**
<img width="684" alt="Screen Shot 2020-11-06 at 3 23 46 PM" src="https://user-images.githubusercontent.com/3260642/98412203-72896e00-206f-11eb-8675-f8cb11d21111.png">
