### PR TITLE
Convert all stories to CSF

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -24,7 +24,6 @@
     "@storybook/addon-a11y": "^5.3.21",
     "@storybook/addon-actions": "^5.3.21",
     "@storybook/addon-docs": "^5.3.21",
-    "@storybook/addon-info": "^5.3.21",
     "@storybook/addon-knobs": "^5.3.21",
     "@storybook/addon-viewport": "^5.3.21",
     "@storybook/react": "^5.3.21",

--- a/packages/autocomplete/src/Autocomplete.stories.js
+++ b/packages/autocomplete/src/Autocomplete.stories.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-children-prop */
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import Component from '@reach/component-component'
 
 import { Box, Text, ThemeProvider } from 'pcln-design-system'
@@ -28,8 +27,50 @@ const kayakTheme = {
   },
 }
 
-storiesOf('pcln-autocomplete/Autocomplete', module)
-  .add('default', () => (
+export default {
+  title: 'pcln-autocomplete/Autocomplete',
+  component: Autocomplete,
+}
+
+export const Default = () => (
+  <Component
+    initialState={{ value: '' }}
+    children={({ state, setState }) => (
+      <Box>
+        <Autocomplete
+          onChange={(item) => {
+            setState({ value: item })
+          }}
+          match={match}
+        >
+          <Label mb={1}>Cat</Label>
+          <Input />
+          <Menu>
+            {cats.map((cat) => (
+              <Item key={cat} item={cat}>
+                <PinIcon color='primary' mr={2} />
+                <Text fontSize={0}>{cat}</Text>
+              </Item>
+            ))}
+          </Menu>
+        </Autocomplete>
+        <Text my={2}>
+          This text should be covered up by the Autocomplete.Menu when open.
+        </Text>
+        <Text my={2}>
+          The current value is <code>{state.value}</code>
+        </Text>
+      </Box>
+    )}
+  />
+)
+
+Default.story = {
+  name: 'default',
+}
+
+export const Themed = () => (
+  <ThemeProvider theme={kayakTheme}>
     <Component
       initialState={{ value: '' }}
       children={({ state, setState }) => (
@@ -60,38 +101,9 @@ storiesOf('pcln-autocomplete/Autocomplete', module)
         </Box>
       )}
     />
-  ))
-  .add('themed', () => (
-    <ThemeProvider theme={kayakTheme}>
-      <Component
-        initialState={{ value: '' }}
-        children={({ state, setState }) => (
-          <Box>
-            <Autocomplete
-              onChange={(item) => {
-                setState({ value: item })
-              }}
-              match={match}
-            >
-              <Label mb={1}>Cat</Label>
-              <Input />
-              <Menu>
-                {cats.map((cat) => (
-                  <Item key={cat} item={cat}>
-                    <PinIcon color='primary' mr={2} />
-                    <Text fontSize={0}>{cat}</Text>
-                  </Item>
-                ))}
-              </Menu>
-            </Autocomplete>
-            <Text my={2}>
-              This text should be covered up by the Autocomplete.Menu when open.
-            </Text>
-            <Text my={2}>
-              The current value is <code>{state.value}</code>
-            </Text>
-          </Box>
-        )}
-      />
-    </ThemeProvider>
-  ))
+  </ThemeProvider>
+)
+
+Themed.story = {
+  name: 'themed',
+}

--- a/packages/core/src/Absolute/Absolute.stories.js
+++ b/packages/core/src/Absolute/Absolute.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import styled from 'styled-components'
 import { Absolute, Card, Flag, Image, Relative, Text } from '..'
 import { Close as CloseIcon } from 'pcln-icons'
@@ -24,83 +23,101 @@ const ExtraLargeAbsolute = styled(Absolute)`
   height: 400px;
 `
 
-storiesOf('Absolute', module)
-  .add('Over an image', () => (
-    <Relative width={1 / 2}>
-      <Absolute top={8} left={0}>
-        <Flag>Hello Flag</Flag>
+export default {
+  title: 'Absolute',
+  component: Absolute,
+}
+
+export const OverAnImage = () => (
+  <Relative width={1 / 2}>
+    <Absolute top={8} left={0}>
+      <Flag>Hello Flag</Flag>
+    </Absolute>
+    <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
+  </Relative>
+)
+
+OverAnImage.story = {
+  name: 'Over an image',
+}
+
+export const PositioningAnIcon = () => (
+  <Card m={2}>
+    <Relative p={4}>
+      <Text mt={2} textAlign='justify'>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et nisl
+        dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+        quis nisi ac est elementum consequat a eu risus. Phasellus id facilisis
+        nulla. Aliquam vel semper enim, id lobortis dolor. Morbi sed leo at
+        turpis rutrum posuere. Nullam tincidunt ex vitae mi sagittis, vel
+        sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
+      </Text>
+      <Absolute top='10px' right='10px'>
+        <CloseIcon color='text.base' size={24} />
       </Absolute>
-      <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
     </Relative>
-  ))
-  .add('Positioning an icon', () => (
-    <Card m={2}>
-      <Relative p={4}>
-        <Text mt={2} textAlign='justify'>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et
-          nisl dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Donec quis nisi ac est elementum consequat a eu risus. Phasellus id
-          facilisis nulla. Aliquam vel semper enim, id lobortis dolor. Morbi sed
-          leo at turpis rutrum posuere. Nullam tincidunt ex vitae mi sagittis,
-          vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
-        </Text>
-        <Absolute top='10px' right='10px'>
-          <CloseIcon color='text.base' size={24} />
-        </Absolute>
-      </Relative>
-    </Card>
-  ))
-  .add('Multiple absolutely positioned boxes', () => (
-    <TallCard pb={3}>
-      <Relative p={3}>
-        <ExtraLargeAbsolute
-          pl={2}
-          top={0}
-          right={0}
-          zIndex={1}
-          width={400}
-          bg='#085397'
-        >
-          <Text.span fontSize={1} bold>
-            z-index 1
-          </Text.span>
-        </ExtraLargeAbsolute>
-        <LargeAbsolute
-          pl={2}
-          top={0}
-          right={0}
-          zIndex={2}
-          width={300}
-          bg='#f2633a'
-        >
-          <Text.span fontSize={1} bold>
-            z-index 2
-          </Text.span>
-        </LargeAbsolute>
-        <MediumAbsolute
-          pl={2}
-          top={0}
-          right={0}
-          zIndex={3}
-          width={200}
-          bg='#0a84c1'
-        >
-          <Text.span fontSize={1} bold>
-            z-index 3
-          </Text.span>
-        </MediumAbsolute>
-        <SmallAbsolute
-          pl={2}
-          top={0}
-          right={0}
-          zIndex='4'
-          width={100}
-          bg='#3c910e'
-        >
-          <Text.span fontSize={1} bold>
-            z-index 4
-          </Text.span>
-        </SmallAbsolute>
-      </Relative>
-    </TallCard>
-  ))
+  </Card>
+)
+
+PositioningAnIcon.story = {
+  name: 'Positioning an icon',
+}
+
+export const MultipleAbsolutelyPositionedBoxes = () => (
+  <TallCard pb={3}>
+    <Relative p={3}>
+      <ExtraLargeAbsolute
+        pl={2}
+        top={0}
+        right={0}
+        zIndex={1}
+        width={400}
+        bg='#085397'
+      >
+        <Text.span fontSize={1} bold>
+          z-index 1
+        </Text.span>
+      </ExtraLargeAbsolute>
+      <LargeAbsolute
+        pl={2}
+        top={0}
+        right={0}
+        zIndex={2}
+        width={300}
+        bg='#f2633a'
+      >
+        <Text.span fontSize={1} bold>
+          z-index 2
+        </Text.span>
+      </LargeAbsolute>
+      <MediumAbsolute
+        pl={2}
+        top={0}
+        right={0}
+        zIndex={3}
+        width={200}
+        bg='#0a84c1'
+      >
+        <Text.span fontSize={1} bold>
+          z-index 3
+        </Text.span>
+      </MediumAbsolute>
+      <SmallAbsolute
+        pl={2}
+        top={0}
+        right={0}
+        zIndex='4'
+        width={100}
+        bg='#3c910e'
+      >
+        <Text.span fontSize={1} bold>
+          z-index 4
+        </Text.span>
+      </SmallAbsolute>
+    </Relative>
+  </TallCard>
+)
+
+MultipleAbsolutelyPositionedBoxes.story = {
+  name: 'Multiple absolutely positioned boxes',
+}

--- a/packages/core/src/Avatar/Avatar.stories.js
+++ b/packages/core/src/Avatar/Avatar.stories.js
@@ -1,16 +1,20 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Avatar } from '..'
 
 const elonJPG = 'https://pbs.twimg.com/media/DwSta0wUcAAQQR9.jpg'
 
-storiesOf('Avatar', module)
-  .add('Default', () => <Avatar />)
-  .add('Initials', () => <Avatar initials='WS' />)
-  .add('Elon', () => (
-    <Avatar
-      title='Not Elon Musk'
-      subtitle='totally.not.elon@musk.com'
-      src={elonJPG}
-    />
-  ))
+export default {
+  title: 'Avatar',
+  component: Avatar,
+}
+
+export const Default = () => <Avatar />
+export const Initials = () => <Avatar initials='WS' />
+
+export const Elon = () => (
+  <Avatar
+    title='Not Elon Musk'
+    subtitle='totally.not.elon@musk.com'
+    src={elonJPG}
+  />
+)

--- a/packages/core/src/BackgroundImage/BackgroundImage.stories.js
+++ b/packages/core/src/BackgroundImage/BackgroundImage.stories.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { optionsKnob, withKnobs } from '@storybook/addon-knobs'
-import { withInfo } from '@storybook/addon-info'
 import { Catch, LiveEditor, Markdown } from '@compositor/kit'
 import { BackgroundImage, Box, Flex, Text } from '..'
 
@@ -12,31 +10,35 @@ const parallaxImage =
 
 const variations = { static: 'static', parallax: 'parallax' }
 
-storiesOf('BackgroundImage', module)
-  .addParameters({ component: BackgroundImage })
-  .addDecorator((story) => (
-    <Box>
-      <Markdown>
-        {`Use the <code>&lt;BackgroundImage /&gt;</code> component to render a background image. Use the *variation* prop to change the attachment mode of the background.`}
-      </Markdown>
-      {story()}
-    </Box>
-  ))
-  .addDecorator(withKnobs)
-  .addDecorator(
-    withInfo({
-      inline: false,
-    })
-  )
-  .add('Variations', () => {
-    const variation = optionsKnob('Variation', variations, 'parallax', {
-      display: 'select',
-    })
+export default {
+  title: 'BackgroundImage',
 
-    return (
-      <Catch>
-        <LiveEditor
-          code={`
+  decorators: [
+    (story) => (
+      <Box>
+        <Markdown>
+          {`Use the <code>&lt;BackgroundImage /&gt;</code> component to render a background image. Use the *variation* prop to change the attachment mode of the background.`}
+        </Markdown>
+        {story()}
+      </Box>
+    ),
+    withKnobs,
+  ],
+
+  parameters: {
+    component: BackgroundImage,
+  },
+}
+
+export const Variations = () => {
+  const variation = optionsKnob('Variation', variations, 'parallax', {
+    display: 'select',
+  })
+
+  return (
+    <Catch>
+      <LiveEditor
+        code={`
 <BackgroundImage
   height="600px"
   width={1}
@@ -44,34 +46,36 @@ storiesOf('BackgroundImage', module)
   image='${parallaxImage}'
 />
           `}
-          scope={{ BackgroundImage }}
-        />
-      </Catch>
-    )
-  })
-  .add('Fixed Height', () => (
-    <Box>
-      <BackgroundImage height='320px' image={image} width='360px'>
-        <Box p={4}>
-          <Text fontSize={6} bold textAlign='center' color='white'>
-            Hello
-          </Text>
-        </Box>
-      </BackgroundImage>
-    </Box>
-  ))
-  .add('Responsive', () => (
-    <Flex>
-      <BackgroundImage
-        width={['100px', '216px', '260px']}
-        height='320px'
-        image={image}
-      >
-        <Box p={4}>
-          <Text fontSize={6} bold textAlign='center' color='white'>
-            Hello
-          </Text>
-        </Box>
-      </BackgroundImage>
-    </Flex>
-  ))
+        scope={{ BackgroundImage }}
+      />
+    </Catch>
+  )
+}
+
+export const FixedHeight = () => (
+  <Box>
+    <BackgroundImage height='320px' image={image} width='360px'>
+      <Box p={4}>
+        <Text fontSize={6} bold textAlign='center' color='white'>
+          Hello
+        </Text>
+      </Box>
+    </BackgroundImage>
+  </Box>
+)
+
+export const Responsive = () => (
+  <Flex>
+    <BackgroundImage
+      width={['100px', '216px', '260px']}
+      height='320px'
+      image={image}
+    >
+      <Box p={4}>
+        <Text fontSize={6} bold textAlign='center' color='white'>
+          Hello
+        </Text>
+      </Box>
+    </BackgroundImage>
+  </Flex>
+)

--- a/packages/core/src/Badge/Badge.stories.js
+++ b/packages/core/src/Badge/Badge.stories.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Cartesian } from '@compositor/kit'
 
 import { Badge } from '..'
@@ -24,39 +22,95 @@ const colors = {
   background: 'background',
 }
 
-storiesOf('Badge', module)
-  .add(
-    'Badge component',
-    withInfo({
-      inline: true,
-      text: 'Use the <Badge /> component to render a primitive badge.',
-    })(() => <Badge bg='lightGray'>badge</Badge>)
-  )
-  .add('All', () => (
-    <Cartesian
-      component={Badge}
-      color={Object.keys(colors)}
-      size={Object.keys(sizes)}
-      m={3}
-    >
-      Badge
-    </Cartesian>
-  ))
-  .add('default', () => <Badge>default</Badge>)
-  .add('blue', () => <Badge bg='blue'>blue</Badge>)
-  .add('lightBlue', () => <Badge bg='lightBlue'>lightBlue</Badge>)
-  .add('green', () => <Badge bg='green'>green</Badge>)
-  .add('lightGreen', () => <Badge bg='lightGreen'>lightGreen</Badge>)
-  .add('red', () => <Badge bg='red'>red</Badge>)
-  .add('lightRed', () => <Badge bg='lightRed'>lightRed</Badge>)
-  .add('orange', () => <Badge bg='orange'>orange</Badge>)
-  .add('text (custom)', () => (
-    <Badge bg='text' color='white'>
-      text (custom)
-    </Badge>
-  ))
-  .add('lightBlue and text (custom)', () => (
-    <Badge bg='lightBlue' color='text'>
-      lightBlue and text (custom)
-    </Badge>
-  ))
+export default {
+  title: 'Badge',
+  component: Badge,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Use the <Badge /> component to render a primitive badge.',
+      },
+    },
+  },
+}
+
+export const BadgeComponent = () => <Badge bg='lightGray'>badge</Badge>
+
+export const All = () => (
+  <Cartesian
+    component={Badge}
+    color={Object.keys(colors)}
+    size={Object.keys(sizes)}
+    m={3}
+  >
+    Badge
+  </Cartesian>
+)
+
+export const Default = () => <Badge>default</Badge>
+
+Default.story = {
+  name: 'default',
+}
+
+export const Blue = () => <Badge bg='blue'>blue</Badge>
+
+Blue.story = {
+  name: 'blue',
+}
+
+export const LightBlue = () => <Badge bg='lightBlue'>lightBlue</Badge>
+
+LightBlue.story = {
+  name: 'lightBlue',
+}
+
+export const Green = () => <Badge bg='green'>green</Badge>
+
+Green.story = {
+  name: 'green',
+}
+
+export const LightGreen = () => <Badge bg='lightGreen'>lightGreen</Badge>
+
+LightGreen.story = {
+  name: 'lightGreen',
+}
+
+export const Red = () => <Badge bg='red'>red</Badge>
+
+Red.story = {
+  name: 'red',
+}
+
+export const LightRed = () => <Badge bg='lightRed'>lightRed</Badge>
+
+LightRed.story = {
+  name: 'lightRed',
+}
+
+export const Orange = () => <Badge bg='orange'>orange</Badge>
+
+Orange.story = {
+  name: 'orange',
+}
+
+export const TextCustom = () => (
+  <Badge bg='text' color='white'>
+    text (custom)
+  </Badge>
+)
+
+TextCustom.story = {
+  name: 'text (custom)',
+}
+
+export const LightBlueAndTextCustom = () => (
+  <Badge bg='lightBlue' color='text'>
+    lightBlue and text (custom)
+  </Badge>
+)
+
+LightBlueAndTextCustom.story = {
+  name: 'lightBlue and text (custom)',
+}

--- a/packages/core/src/Banner/Banner.stories.js
+++ b/packages/core/src/Banner/Banner.stories.js
@@ -1,719 +1,773 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Box, Banner, Flex, Heading, Text } from '..'
 
-storiesOf('Banner', module)
-  .add('All bgs', () => (
-    <Box>
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='default'
-        text='Secondary Text'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='blue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='green'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare.'
-        bg='green'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='orange'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur.'
-        bg='orange'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='red'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus.'
-        bg='red'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum.'
-        bg='lightBlue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='green'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare.'
-        bg='lightGreen'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='red'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
-        bg='lightRed'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='custom'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
-        bg='text'
-        color='white'
-        onClose={action('closed')}
-      />
-      <Banner
-        mb={2}
-        p={3}
-        color='primary'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
-      />
-      <Banner
-        mb={2}
-        p={3}
-        color='warning'
-        iconName='attention'
-        text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
-      />
-    </Box>
-  ))
-  .add('All bgs header only', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        header='default'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        header='blue'
-        bg='blue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        header='green'
-        bg='green'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        header='orange'
-        bg='orange'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        header='red'
-        bg='red'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        header='blue'
-        bg='lightBlue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        header='green'
-        bg='lightGreen'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        header='red'
-        bg='lightRed'
-        onClose={action('closed')}
-      />
-    </Box>
-  ))
-  .add('All bgs text only', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='default'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='blue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='green'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='orange'
-        bg='orange'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='red'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='Secondary Text'
-        bg='lightBlue'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='Secondary Text'
-        bg='lightGreen'
-        onClose={action('closed')}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='Secondary Text'
-        bg='lightRed'
-        onClose={action('closed')}
-      />
-    </Box>
-  ))
-  .add('Sans Close Button', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='default'
-        text='Secondary Text'
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='blue'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='green'
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='orange'
-        text='Secondary Text'
-        bg='orange'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='red'
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='lightBlue'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='lightGreen'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='lightRed'
-      />
-    </Box>
-  ))
-  .add('Sans Icon', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='default'
-        text='Secondary Text'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='blue'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='green'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='orange'
-        text='Secondary Text'
-        bg='orange'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='red'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='lightBlue'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='lightGreen'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='lightRed'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-    </Box>
-  ))
-  .add('Without Icon or Close Button', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='default'
-        text='Secondary Text'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='blue'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='green'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='orange'
-        text='Secondary Text'
-        bg='orange'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='red'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={3}
-        header='blue'
-        text='Secondary Text'
-        bg='lightBlue'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='green'
-        text='Secondary Text'
-        bg='lightGreen'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={3}
-        header='red'
-        text='Secondary Text'
-        bg='lightRed'
-        showIcon={false}
-      />
-    </Box>
-  ))
-  .add('Sans Close Button, Text only', () => (
-    <Box>
-      <Banner textAlign='right' mb={2} p={2} text='default' />
-      <Banner textAlign='left' mb={2} p={2} text='blue' bg='blue' />
-      <Banner textAlign='right' mb={2} p={2} text='green' bg='green' />
-      <Banner textAlign='left' mb={2} p={2} text='orange' bg='orange' />
-      <Banner textAlign='right' mb={2} p={2} text='red' bg='red' />
-      <Banner textAlign='left' mb={2} p={2} text='blue' bg='lightBlue' />
-      <Banner textAlign='right' mb={2} p={2} text='green' bg='lightGreen' />
-      <Banner textAlign='right' mb={2} p={2} text='red' bg='lightRed' />
-    </Box>
-  ))
-  .add('Sans Icon, Text only', () => (
-    <Box>
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='default'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='blue'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='green'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='orange'
-        bg='orange'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='red'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='lightBlue'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='lightGreen'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='lightRed'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-    </Box>
-  ))
-  .add('Custom header as node', () => (
-    <Box>
-      <Banner
-        header={<Heading>LOUD HEADER</Heading>}
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='default'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-      <Banner
-        header={<Heading.h5>quiet header</Heading.h5>}
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='default'
-        onClose={action('closed')}
-        showIcon={false}
-      />
-    </Box>
-  ))
-  .add('Without Icon or Close Button, Text only', () => (
-    <Box>
-      <Banner textAlign='right' mb={2} p={2} text='default' showIcon={false} />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='blue'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='green'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='orange'
-        bg='orange'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='red'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='lightBlue'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='lightGreen'
-        showIcon={false}
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='lightRed'
-        showIcon={false}
-      />
-    </Box>
-  ))
-  .add('With custom icons and sizes', () => (
-    <Box>
-      <Banner textAlign='right' mb={2} p={2} text='default' iconName='star' />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='blue'
-        iconName='star'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='green'
-        iconName='star'
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='orange'
-        bg='orange'
-        iconName='star'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='red'
-        iconName='star'
-      />
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        text='blue'
-        bg='lightBlue'
-        iconName='star'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='green'
-        bg='lightGreen'
-        iconName='star'
-      />
-      <Banner
-        textAlign='right'
-        mb={2}
-        p={2}
-        text='red'
-        bg='lightRed'
-        iconName='star'
-      />
-    </Box>
-  ))
-  .add('With children', () => (
-    <Box>
-      <Banner p={2} mb={2} onClose={action('closed')}>
-        <Flex>
-          <Box bg={'pink'} p={2} width={1 / 2}>
-            Pink box!
-          </Box>
-          <Box bg={'red'} p={2} width={1 / 2}>
-            Red box!
-          </Box>
-        </Flex>
-      </Banner>
-      <Banner
-        textAlign='left'
-        mb={2}
-        p={2}
-        header='default'
-        onClose={action('closed')}
-      >
-        <Text bold italic>
-          I am a text component!
-        </Text>
-      </Banner>
-    </Box>
-  ))
+export default {
+  title: 'Banner',
+  component: Banner,
+}
+
+export const AllBgs = () => (
+  <Box>
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='default'
+      text='Secondary Text'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='blue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='green'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare.'
+      bg='green'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='orange'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur.'
+      bg='orange'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='red'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus.'
+      bg='red'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum.'
+      bg='lightBlue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='green'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare.'
+      bg='lightGreen'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='red'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
+      bg='lightRed'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='custom'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
+      bg='text'
+      color='white'
+      onClose={action('closed')}
+    />
+    <Banner
+      mb={2}
+      p={3}
+      color='primary'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
+    />
+    <Banner
+      mb={2}
+      p={3}
+      color='warning'
+      iconName='attention'
+      text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. Nullam pretium diam in porta luctus. Etiam viverra porttitor porttitor. Vestibulum at dignissim tellus. Integer eget massa lacus. Mauris placerat augue rhoncus nisl porttitor bibendum. Sed non aliquam orci, id pulvinar justo. Fusce feugiat egestas risus in ornare. Quisque at quam vel nibh tempor imperdiet vitae non orci. Etiam bibendum sem id nibh finibus interdum. Nunc quam neque, tristique porttitor varius a, ultrices a nibh. Nunc et ipsum id eros condimentum convallis. Donec gravida leo facilisis, pharetra tellus eu, dictum mi.'
+    />
+  </Box>
+)
+
+AllBgs.story = {
+  name: 'All bgs',
+}
+
+export const AllBgsHeaderOnly = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      header='default'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      header='blue'
+      bg='blue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      header='green'
+      bg='green'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      header='orange'
+      bg='orange'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      header='red'
+      bg='red'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      header='blue'
+      bg='lightBlue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      header='green'
+      bg='lightGreen'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      header='red'
+      bg='lightRed'
+      onClose={action('closed')}
+    />
+  </Box>
+)
+
+AllBgsHeaderOnly.story = {
+  name: 'All bgs header only',
+}
+
+export const AllBgsTextOnly = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='default'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='blue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='green'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='orange'
+      bg='orange'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='red'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='Secondary Text'
+      bg='lightBlue'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='Secondary Text'
+      bg='lightGreen'
+      onClose={action('closed')}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='Secondary Text'
+      bg='lightRed'
+      onClose={action('closed')}
+    />
+  </Box>
+)
+
+AllBgsTextOnly.story = {
+  name: 'All bgs text only',
+}
+
+export const SansCloseButton = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='default'
+      text='Secondary Text'
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='blue'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='green'
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='orange'
+      text='Secondary Text'
+      bg='orange'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='red'
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='lightBlue'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='lightGreen'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='lightRed'
+    />
+  </Box>
+)
+
+export const SansIcon = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='default'
+      text='Secondary Text'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='blue'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='green'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='orange'
+      text='Secondary Text'
+      bg='orange'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='red'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='lightBlue'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='lightGreen'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='lightRed'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+  </Box>
+)
+
+export const WithoutIconOrCloseButton = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='default'
+      text='Secondary Text'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='blue'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='green'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='orange'
+      text='Secondary Text'
+      bg='orange'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='red'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={3}
+      header='blue'
+      text='Secondary Text'
+      bg='lightBlue'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='green'
+      text='Secondary Text'
+      bg='lightGreen'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={3}
+      header='red'
+      text='Secondary Text'
+      bg='lightRed'
+      showIcon={false}
+    />
+  </Box>
+)
+
+WithoutIconOrCloseButton.story = {
+  name: 'Without Icon or Close Button',
+}
+
+export const SansCloseButtonTextOnly = () => (
+  <Box>
+    <Banner textAlign='right' mb={2} p={2} text='default' />
+    <Banner textAlign='left' mb={2} p={2} text='blue' bg='blue' />
+    <Banner textAlign='right' mb={2} p={2} text='green' bg='green' />
+    <Banner textAlign='left' mb={2} p={2} text='orange' bg='orange' />
+    <Banner textAlign='right' mb={2} p={2} text='red' bg='red' />
+    <Banner textAlign='left' mb={2} p={2} text='blue' bg='lightBlue' />
+    <Banner textAlign='right' mb={2} p={2} text='green' bg='lightGreen' />
+    <Banner textAlign='right' mb={2} p={2} text='red' bg='lightRed' />
+  </Box>
+)
+
+SansCloseButtonTextOnly.story = {
+  name: 'Sans Close Button, Text only',
+}
+
+export const SansIconTextOnly = () => (
+  <Box>
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='default'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='blue'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='green'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='orange'
+      bg='orange'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='red'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='lightBlue'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='lightGreen'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='lightRed'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+  </Box>
+)
+
+SansIconTextOnly.story = {
+  name: 'Sans Icon, Text only',
+}
+
+export const CustomHeaderAsNode = () => (
+  <Box>
+    <Banner
+      header={<Heading>LOUD HEADER</Heading>}
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='default'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+    <Banner
+      header={<Heading.h5>quiet header</Heading.h5>}
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='default'
+      onClose={action('closed')}
+      showIcon={false}
+    />
+  </Box>
+)
+
+CustomHeaderAsNode.story = {
+  name: 'Custom header as node',
+}
+
+export const WithoutIconOrCloseButtonTextOnly = () => (
+  <Box>
+    <Banner textAlign='right' mb={2} p={2} text='default' showIcon={false} />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='blue'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='green'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='orange'
+      bg='orange'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='red'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='lightBlue'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='lightGreen'
+      showIcon={false}
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='lightRed'
+      showIcon={false}
+    />
+  </Box>
+)
+
+WithoutIconOrCloseButtonTextOnly.story = {
+  name: 'Without Icon or Close Button, Text only',
+}
+
+export const WithCustomIconsAndSizes = () => (
+  <Box>
+    <Banner textAlign='right' mb={2} p={2} text='default' iconName='star' />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='blue'
+      iconName='star'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='green'
+      iconName='star'
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='orange'
+      bg='orange'
+      iconName='star'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='red'
+      iconName='star'
+    />
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      text='blue'
+      bg='lightBlue'
+      iconName='star'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='green'
+      bg='lightGreen'
+      iconName='star'
+    />
+    <Banner
+      textAlign='right'
+      mb={2}
+      p={2}
+      text='red'
+      bg='lightRed'
+      iconName='star'
+    />
+  </Box>
+)
+
+WithCustomIconsAndSizes.story = {
+  name: 'With custom icons and sizes',
+}
+
+export const WithChildren = () => (
+  <Box>
+    <Banner p={2} mb={2} onClose={action('closed')}>
+      <Flex>
+        <Box bg={'pink'} p={2} width={1 / 2}>
+          Pink box!
+        </Box>
+        <Box bg={'red'} p={2} width={1 / 2}>
+          Red box!
+        </Box>
+      </Flex>
+    </Banner>
+    <Banner
+      textAlign='left'
+      mb={2}
+      p={2}
+      header='default'
+      onClose={action('closed')}
+    >
+      <Text bold italic>
+        I am a text component!
+      </Text>
+    </Banner>
+  </Box>
+)
+
+WithChildren.story = {
+  name: 'With children',
+}

--- a/packages/core/src/BlockLink/BlockLink.stories.js
+++ b/packages/core/src/BlockLink/BlockLink.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 
 import { BackgroundImage, BlockLink, Box, Button, Flex, Text } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
@@ -7,45 +6,63 @@ import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 const image =
   'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=aee8a50c86478d935556d865624506e4'
 
-storiesOf('BlockLink', module)
-  .add('containing BackgroundImage', () => (
-    <Flex justifyContent='center' alignItems='center' color='white'>
-      <BlockLink href='https://www.priceline.com' target='_blank'>
-        <BackgroundImage image={image} width='640px'>
-          <Box p={4}>
-            <Text textAlign='center'>
-              Click to open priceline.com in new tab!
-            </Text>
-          </Box>
-        </BackgroundImage>
-      </BlockLink>
-    </Flex>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <BlockLink color='text.dark' ref={dsRef}>
-            I am a link!
-          </BlockLink>
-          <br />
-          <Button
-            color='error'
-            onClick={() => (dsRef.current.innerHTML = 'Bacon!')}
-            mt={4}
-          >
-            Click to update link text via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
-  .add('composition without container', () => (
-    <Flex justifyContent='center' alignItems='center' color='purple'>
-      <BlockLink href='https://www.google.com'>
-        <Text fontSize={2} bold textAlign='center'>
-          Click to go to google.com!
-        </Text>
-      </BlockLink>
-    </Flex>
-  ))
+export default {
+  title: 'BlockLink',
+  component: BlockLink,
+}
+
+export const ContainingBackgroundImage = () => (
+  <Flex justifyContent='center' alignItems='center' color='white'>
+    <BlockLink href='https://www.priceline.com' target='_blank'>
+      <BackgroundImage image={image} width='640px'>
+        <Box p={4}>
+          <Text textAlign='center'>
+            Click to open priceline.com in new tab!
+          </Text>
+        </Box>
+      </BackgroundImage>
+    </BlockLink>
+  </Flex>
+)
+
+ContainingBackgroundImage.story = {
+  name: 'containing BackgroundImage',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <BlockLink color='text.dark' ref={dsRef}>
+          I am a link!
+        </BlockLink>
+        <br />
+        <Button
+          color='error'
+          onClick={() => (dsRef.current.innerHTML = 'Bacon!')}
+          mt={4}
+        >
+          Click to update link text via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}
+
+export const CompositionWithoutContainer = () => (
+  <Flex justifyContent='center' alignItems='center' color='purple'>
+    <BlockLink href='https://www.google.com'>
+      <Text fontSize={2} bold textAlign='center'>
+        Click to go to google.com!
+      </Text>
+    </BlockLink>
+  </Flex>
+)
+
+CompositionWithoutContainer.story = {
+  name: 'composition without container',
+}

--- a/packages/core/src/Box/Box.stories.js
+++ b/packages/core/src/Box/Box.stories.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-unescaped-entities */
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 
 import { Box, Text } from '..'
@@ -8,152 +7,192 @@ import { Box, Text } from '..'
 const description =
   'A low-level layout component for setting color, display, height, margin, maxHeight, maxWidth, minHeight, minWidth, padding, size, textAlign, and width.'
 
-storiesOf('Box', module)
-  .add(
-    'Layout component',
-    withInfo({
-      text: description,
-      inline: true,
-    })(() => <Box p={3}>Hello</Box>)
-  )
-  .add('Display and size', () => (
-    <Box color='alert.base' display={['none', null, 'block']} p={3} size={250}>
+export default {
+  title: 'Box',
+}
+
+export const LayoutComponent = withInfo({
+  text: description,
+  inline: true,
+})(() => <Box p={3}>Hello</Box>)
+
+LayoutComponent.story = {
+  name: 'Layout component',
+  component: Box,
+}
+
+export const DisplayAndSize = () => (
+  <Box color='alert.base' display={['none', null, 'block']} p={3} size={250}>
+    Hello
+  </Box>
+)
+
+DisplayAndSize.story = {
+  name: 'Display and size',
+}
+
+export const Padding = () => <Box p={3}>Hello</Box>
+
+export const Height = () => (
+  <Box
+    color='warning.base'
+    height={[250, 350, 450, 550]}
+    width={[150, 250, 350, 450]}
+  />
+)
+
+export const MaxAndMinValues = () => (
+  <Box
+    color='priceSecondary.base'
+    maxHeight={[300, null, 400, null, 500]}
+    maxWidth={[300, null, 400, null, 500]}
+    minHeight={[100, null, 200, null, 300]}
+    minWidth={[300, null, 200, null, 100]}
+  />
+)
+
+MaxAndMinValues.story = {
+  name: 'Max and min values',
+}
+
+export const Margin = () => <Box m={3}>Hello</Box>
+
+export const Color = () => (
+  <Box p={3} color='primary.base'>
+    Hello
+  </Box>
+)
+
+export const BoxShadow = () => (
+  <div>
+    {['sm', 'md', 'lg', 'xl'].map((boxShadow) => (
+      <Box
+        p={2}
+        mb={'42px'}
+        color='blue'
+        boxShadowSize={boxShadow}
+        key={boxShadow}
+      >
+        box-shadow: <Text bold>{boxShadow}</Text>
+      </Box>
+    ))}
+  </div>
+)
+
+BoxShadow.story = {
+  name: 'Box shadow',
+}
+
+export const BackgroundColor = () => (
+  <React.Fragment>
+    <Box p={3} color='white' bg='blue'>
       Hello
     </Box>
-  ))
-  .add('Padding', () => <Box p={3}>Hello</Box>)
-  .add('Height', () => (
-    <Box
-      color='warning.base'
-      height={[250, 350, 450, 550]}
-      width={[150, 250, 350, 450]}
-    />
-  ))
-  .add('Max and min values', () => (
-    <Box
-      color='priceSecondary.base'
-      maxHeight={[300, null, 400, null, 500]}
-      maxWidth={[300, null, 400, null, 500]}
-      minHeight={[100, null, 200, null, 300]}
-      minWidth={[300, null, 200, null, 100]}
-    />
-  ))
-  .add('Margin', () => <Box m={3}>Hello</Box>)
-  .add('Color', () => (
-    <Box p={3} color='primary.base'>
+    <Box p={3} mt={2} color='primary'>
       Hello
     </Box>
-  ))
-  .add('Box shadow', () => (
-    <div>
-      {['sm', 'md', 'lg', 'xl'].map((boxShadow) => (
-        <Box
-          p={2}
-          mb={'42px'}
-          color='blue'
-          boxShadowSize={boxShadow}
-          key={boxShadow}
-        >
-          box-shadow: <Text bold>{boxShadow}</Text>
-        </Box>
-      ))}
-    </div>
-  ))
-  .add('Background Color', () => (
-    <React.Fragment>
-      <Box p={3} color='white' bg='blue'>
-        Hello
-      </Box>
-      <Box p={3} mt={2} color='primary'>
-        Hello
-      </Box>
-      <Box p={3} mt={2} color='error'>
-        Hello
-      </Box>
-      <Box p={3} mt={2} color='warning'>
-        Hello
-      </Box>
-    </React.Fragment>
-  ))
-  .add('Size', () => <Box p={3} color='secondary.base' size={200} />)
-  .add('Width', () => (
-    <Box p={3} width={1 / 2} color='white' bg='blue'>
-      Half Width
+    <Box p={3} mt={2} color='error'>
+      Hello
     </Box>
-  ))
-  .add('Pixel Width', () => (
-    <Box p={3} width={256} color='white' bg='blue'>
-      256px width
+    <Box p={3} mt={2} color='warning'>
+      Hello
     </Box>
-  ))
-  .add('VW Width', () => (
-    <Box p={3} width='50vw' color='white' bg='blue'>
-      50vw width
+  </React.Fragment>
+)
+
+export const Size = () => <Box p={3} color='secondary.base' size={200} />
+
+export const Width = () => (
+  <Box p={3} width={1 / 2} color='white' bg='blue'>
+    Half Width
+  </Box>
+)
+
+export const PixelWidth = () => (
+  <Box p={3} width={256} color='white' bg='blue'>
+    256px width
+  </Box>
+)
+
+export const VwWidth = () => (
+  <Box p={3} width='50vw' color='white' bg='blue'>
+    50vw width
+  </Box>
+)
+
+VwWidth.story = {
+  name: 'VW Width',
+}
+
+export const DirectionalPadding = () => (
+  <Box p={3}>
+    <Box m={1} pt={3} color='white' bg='blue'>
+      Padding Top
     </Box>
-  ))
-  .add('Directional Padding', () => (
+    <Box m={1} pr={3} color='white' bg='blue'>
+      Padding Right
+    </Box>
+    <Box m={1} pb={3} color='white' bg='blue'>
+      Padding Bottom
+    </Box>
+    <Box m={1} pl={3} color='white' bg='blue'>
+      Padding Left
+    </Box>
+    <Box m={1} px={3} color='white' bg='blue'>
+      Padding X-Axis
+    </Box>
+    <Box m={1} py={3} color='white' bg='blue'>
+      Padding Y-Axis
+    </Box>
+  </Box>
+)
+
+export const DirectionalMargin = () => (
+  <Box p={3}>
+    <Box mt={3} color='white' bg='blue'>
+      Margin Top
+    </Box>
+    <Box mr={3} color='white' bg='blue'>
+      Margin Right
+    </Box>
+    <Box mb={3} color='white' bg='blue'>
+      Margin Bottom
+    </Box>
+    <Box ml={3} color='white' bg='blue'>
+      Margin Left
+    </Box>
+    <Box mx={3} color='white' bg='blue'>
+      Margin X-Axis
+    </Box>
+    <Box my={3} color='white' bg='blue'>
+      Margin Y-Axis
+    </Box>
+  </Box>
+)
+
+export const ThemeUserCaseColorText = () => (
+  <React.Fragment>
     <Box p={3}>
-      <Box m={1} pt={3} color='white' bg='blue'>
-        Padding Top
+      <Box mt={3} color='text'>
+        color="text" w/o bg prop: retains the original "text" color from
+        original color set as backward compatible: expected style w. "text"
+        color and white background
       </Box>
-      <Box m={1} pr={3} color='white' bg='blue'>
-        Padding Right
-      </Box>
-      <Box m={1} pb={3} color='white' bg='blue'>
-        Padding Bottom
-      </Box>
-      <Box m={1} pl={3} color='white' bg='blue'>
-        Padding Left
-      </Box>
-      <Box m={1} px={3} color='white' bg='blue'>
-        Padding X-Axis
-      </Box>
-      <Box m={1} py={3} color='white' bg='blue'>
-        Padding Y-Axis
+      <Box mt={3} color='purple'>
+        color="purple" as none "text" color w/o bg prop
       </Box>
     </Box>
-  ))
-  .add('Directional Margin', () => (
-    <Box p={3}>
-      <Box mt={3} color='white' bg='blue'>
-        Margin Top
+    <Box p={5}>
+      <Box mt={3} color='text.lightest' bg='background.dark'>
+        Theme 1: color="text.lightest" value & bg="background.dark"
       </Box>
-      <Box mr={3} color='white' bg='blue'>
-        Margin Right
-      </Box>
-      <Box mb={3} color='white' bg='blue'>
-        Margin Bottom
-      </Box>
-      <Box ml={3} color='white' bg='blue'>
-        Margin Left
-      </Box>
-      <Box mx={3} color='white' bg='blue'>
-        Margin X-Axis
-      </Box>
-      <Box my={3} color='white' bg='blue'>
-        Margin Y-Axis
+      <Box mt={3} color='text' bg='background.lightest'>
+        Theme 2: color="text" & "bg"="background.lightest"
       </Box>
     </Box>
-  ))
-  .add('Theme user case: color=text', () => (
-    <React.Fragment>
-      <Box p={3}>
-        <Box mt={3} color='text'>
-          color="text" w/o bg prop: retains the original "text" color from
-          original color set as backward compatible: expected style w. "text"
-          color and white background
-        </Box>
-        <Box mt={3} color='purple'>
-          color="purple" as none "text" color w/o bg prop
-        </Box>
-      </Box>
-      <Box p={5}>
-        <Box mt={3} color='text.lightest' bg='background.dark'>
-          Theme 1: color="text.lightest" value & bg="background.dark"
-        </Box>
-        <Box mt={3} color='text' bg='background.lightest'>
-          Theme 2: color="text" & "bg"="background.lightest"
-        </Box>
-      </Box>
-    </React.Fragment>
-  ))
+  </React.Fragment>
+)
+
+ThemeUserCaseColorText.story = {
+  name: 'Theme user case: color=text',
+}

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.stories.js
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import {
   Flights as FlightsIcon,
   Home as HomeIcon,
@@ -9,65 +8,75 @@ import {
 import { Breadcrumbs, Button } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('Breadcrumbs', module)
-  .add('Basic', () => (
-    <Breadcrumbs>
-      <Breadcrumbs.Link href='https://www.priceline.com' label='Home' />
-      <Breadcrumbs.Link
-        href='https://www.priceline.com/flights/'
-        label='Flights'
-      />
-      <Breadcrumbs.Link
-        href='https://www.priceline.com/flights/'
-        label='Seat Selection'
-      />
-    </Breadcrumbs>
-  ))
-  .add('Icons', () => (
-    <Breadcrumbs>
-      <Breadcrumbs.Link
-        href='https://www.priceline.com'
-        label='Home'
-        icon={<HomeIcon color='text.light' size={16} mr={2} />}
-      />
-      <Breadcrumbs.Link
-        href='https://www.priceline.com/flights/'
-        label='Flights'
-        icon={<FlightsIcon color='text.light' size={16} mr={2} />}
-      />
-      <Breadcrumbs.Link
-        href='https://www.priceline.com/flights/'
-        label='Seat Selection'
-        icon={<SeatIcon color='text.dark' size={16} mr={2} />}
-      />
-    </Breadcrumbs>
-  ))
-  .add('Forward refs to links', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Breadcrumbs>
-            <Breadcrumbs.Link
-              href='https://www.priceline.com'
-              label='Home'
-              ref={dsRef}
-              icon={<HomeIcon color='text.light' size={16} mr={2} />}
-            />
-            <Breadcrumbs.Link
-              href='https://www.priceline.com/flights/'
-              label='Flights'
-              icon={<FlightsIcon color='text.light' size={16} mr={2} />}
-            />
-          </Breadcrumbs>
-          <Button
-            mt={4}
-            onClick={() =>
-              (dsRef.current.innerHTML = "What's the frequency, Kenneth?")
-            }
-          >
-            Click to change the first link via ref
-          </Button>
-        </>
-      )}
+export default {
+  title: 'Breadcrumbs',
+  component: Breadcrumbs,
+}
+
+export const Basic = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Link href='https://www.priceline.com' label='Home' />
+    <Breadcrumbs.Link
+      href='https://www.priceline.com/flights/'
+      label='Flights'
     />
-  ))
+    <Breadcrumbs.Link
+      href='https://www.priceline.com/flights/'
+      label='Seat Selection'
+    />
+  </Breadcrumbs>
+)
+
+export const Icons = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Link
+      href='https://www.priceline.com'
+      label='Home'
+      icon={<HomeIcon color='text.light' size={16} mr={2} />}
+    />
+    <Breadcrumbs.Link
+      href='https://www.priceline.com/flights/'
+      label='Flights'
+      icon={<FlightsIcon color='text.light' size={16} mr={2} />}
+    />
+    <Breadcrumbs.Link
+      href='https://www.priceline.com/flights/'
+      label='Seat Selection'
+      icon={<SeatIcon color='text.dark' size={16} mr={2} />}
+    />
+  </Breadcrumbs>
+)
+
+export const ForwardRefsToLinks = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Breadcrumbs>
+          <Breadcrumbs.Link
+            href='https://www.priceline.com'
+            label='Home'
+            ref={dsRef}
+            icon={<HomeIcon color='text.light' size={16} mr={2} />}
+          />
+          <Breadcrumbs.Link
+            href='https://www.priceline.com/flights/'
+            label='Flights'
+            icon={<FlightsIcon color='text.light' size={16} mr={2} />}
+          />
+        </Breadcrumbs>
+        <Button
+          mt={4}
+          onClick={() =>
+            (dsRef.current.innerHTML = "What's the frequency, Kenneth?")
+          }
+        >
+          Click to change the first link via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefsToLinks.story = {
+  name: 'Forward refs to links',
+}

--- a/packages/core/src/Button/Button.stories.js
+++ b/packages/core/src/Button/Button.stories.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { withKnobs, boolean, optionsKnob } from '@storybook/addon-knobs'
-import { withInfo } from '@storybook/addon-info'
 import { Cartesian, Catch, LiveEditor, Markdown, XRay } from '@compositor/kit'
 
 import { Box, Button } from '..'
@@ -32,41 +30,45 @@ const colors = {
   background: 'background',
 }
 
-storiesOf('Button', module)
-  .addParameters({ component: Button })
-  .addDecorator((story) => (
-    <Box>
-      <Markdown>
-        {`
-Use the <code>&lt;Button /&gt;</code> component to render a primitive button. Use the *variation* prop to change the appearance of the button.
-        `}
-      </Markdown>
-      {story()}
-    </Box>
-  ))
-  .addDecorator(withKnobs)
-  .addDecorator(
-    withInfo({
-      inline: false,
-    })
-  )
-  .add('Button', () => {
-    const variation = optionsKnob('Variation', variations, 'fill', {
-      display: 'select',
-    })
-    const size = optionsKnob('Size', sizes, 'medium', {
-      display: 'select',
-    })
-    const color = optionsKnob('Palette Color', colors, 'primary', {
-      display: 'select',
-    })
-    const disabled = boolean('Disabled?', false)
-    const fullWidth = boolean('Full Width?', false)
+export default {
+  title: 'Button',
 
-    return (
-      <Catch>
-        <LiveEditor
-          code={`<Button
+  decorators: [
+    (story) => (
+      <Box>
+        <Markdown>
+          {`
+  Use the <code>&lt;Button /&gt;</code> component to render a primitive button. Use the *variation* prop to change the appearance of the button.
+          `}
+        </Markdown>
+        {story()}
+      </Box>
+    ),
+    withKnobs,
+  ],
+
+  parameters: {
+    component: Button,
+  },
+}
+
+export const _Button = () => {
+  const variation = optionsKnob('Variation', variations, 'fill', {
+    display: 'select',
+  })
+  const size = optionsKnob('Size', sizes, 'medium', {
+    display: 'select',
+  })
+  const color = optionsKnob('Palette Color', colors, 'primary', {
+    display: 'select',
+  })
+  const disabled = boolean('Disabled?', false)
+  const fullWidth = boolean('Full Width?', false)
+
+  return (
+    <Catch>
+      <LiveEditor
+        code={`<Button
   variation='${variation}'
   size='${size}'
   color='${color}'
@@ -74,90 +76,104 @@ Use the <code>&lt;Button /&gt;</code> component to render a primitive button. Us
   width={${fullWidth ? 1 : null}}>
   BUTTON
 </Button>`}
-          scope={{
-            Button,
-          }}
-        />
-      </Catch>
-    )
-  })
-  .add('Try It!', () => {
-    const variation = optionsKnob('Variation', variations, 'fill', {
-      display: 'multi-select',
-    })
-    const size = optionsKnob('Size', sizes, 'medium', {
-      display: 'multi-select',
-    })
-    const color = optionsKnob('Palette Color', colors, 'primary', {
-      display: 'multi-select',
-    })
-    const disabled = boolean('Disabled?', false)
-    const fullWidth = boolean('Full Width?', false)
+        scope={{
+          Button,
+        }}
+      />
+    </Catch>
+  )
+}
 
-    return (
-      <Cartesian
-        component={Button}
-        m={3}
-        variation={variation}
-        size={size}
-        color={color}
-        disabled={disabled}
-        width={fullWidth ? 1 : null}
-        onClick={action('Clicked button in Try It!')}
-      >
-        Try This Button!
-      </Cartesian>
-    )
+export const TryIt = () => {
+  const variation = optionsKnob('Variation', variations, 'fill', {
+    display: 'multi-select',
   })
-
-  .add('All', () => {
-    return (
-      <Cartesian
-        component={Button}
-        m={3}
-        color={Object.keys(colors)}
-        variation={Object.keys(variations)}
-        disabled={[false, true]}
-        size={Object.keys(sizes)}
-        onClick={action('Clicked button in All')}
-      >
-        I am a Button
-      </Cartesian>
-    )
+  const size = optionsKnob('Size', sizes, 'medium', {
+    display: 'multi-select',
   })
-
-  .add('Geometry', () => (
-    <XRay>
-      <Cartesian
-        component={Button}
-        m={3}
-        variation={Object.keys(variations)}
-        size={Object.keys(sizes)}
-      >
-        Button Geometry
-      </Cartesian>
-    </XRay>
-  ))
-
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Button ref={dsRef} color='error' size='large'>
-            PANIC
-          </Button>
-          <br />
-          <Button mt={4} onClick={() => dsRef.current.focus()}>
-            Click to focus PANIC button via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
-  .add('Styled Button should not lose its styling', () => {
-    return (
-      <Box>
-        <StyledButton>BUTTON</StyledButton>
-      </Box>
-    )
+  const color = optionsKnob('Palette Color', colors, 'primary', {
+    display: 'multi-select',
   })
+  const disabled = boolean('Disabled?', false)
+  const fullWidth = boolean('Full Width?', false)
+
+  return (
+    <Cartesian
+      component={Button}
+      m={3}
+      variation={variation}
+      size={size}
+      color={color}
+      disabled={disabled}
+      width={fullWidth ? 1 : null}
+      onClick={action('Clicked button in Try It!')}
+    >
+      Try This Button!
+    </Cartesian>
+  )
+}
+
+TryIt.story = {
+  name: 'Try It!',
+}
+
+export const All = () => {
+  return (
+    <Cartesian
+      component={Button}
+      m={3}
+      color={Object.keys(colors)}
+      variation={Object.keys(variations)}
+      disabled={[false, true]}
+      size={Object.keys(sizes)}
+      onClick={action('Clicked button in All')}
+    >
+      I am a Button
+    </Cartesian>
+  )
+}
+
+export const Geometry = () => (
+  <XRay>
+    <Cartesian
+      component={Button}
+      m={3}
+      variation={Object.keys(variations)}
+      size={Object.keys(sizes)}
+    >
+      Button Geometry
+    </Cartesian>
+  </XRay>
+)
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Button ref={dsRef} color='error' size='large'>
+          PANIC
+        </Button>
+        <br />
+        <Button mt={4} onClick={() => dsRef.current.focus()}>
+          Click to focus PANIC button via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}
+
+export const StyledButtonShouldNotLoseItsStyling = () => {
+  return (
+    <Box>
+      <StyledButton>BUTTON</StyledButton>
+    </Box>
+  )
+}
+
+StyledButtonShouldNotLoseItsStyling.story = {
+  name: 'Styled Button should not lose its styling',
+}

--- a/packages/core/src/Card/Card.stories.js
+++ b/packages/core/src/Card/Card.stories.js
@@ -1,149 +1,166 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Box, Card } from '..'
 
-storiesOf('Card', module)
-  .add('Box Shadows with default border', () => (
-    <Box>
-      <Card
-        boxShadowSize='sm'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='black'
-        bg='white'
-        borderWidth={1}
-      >
-        Small Shadow
-      </Card>
-      <Card
-        boxShadowSize='md'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={1}
-      >
-        Medium Shadow
-      </Card>
-      <Card
-        boxShadowSize='lg'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={1}
-      >
-        Large Shadow
-      </Card>
-      <Card
-        boxShadowSize='xl'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={1}
-      >
-        XLarge Shadow
-      </Card>
-    </Box>
-  ))
-  .add('Box Shadows with focused 2px border', () => (
-    <Box>
-      <Card
-        boxShadowSize='sm'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={2}
-      >
-        Small Shadow
-      </Card>
-      <Card
-        boxShadowSize='md'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={2}
-      >
-        Medium Shadow
-      </Card>
-      <Card
-        boxShadowSize='lg'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={2}
-      >
-        Large Shadow
-      </Card>
-      <Card
-        boxShadowSize='xl'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='text'
-        bg='white'
-        borderWidth={2}
-      >
-        XLarge Shadow
-      </Card>
-    </Box>
-  ))
-  .add('Box Shadows with varying border radii', () => (
-    <Box>
-      <Card
-        boxShadowSize='sm'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='black'
-        bg='white'
-        borderRadius={0}
-      >
-        Small Shadow - 0px
-      </Card>
-      <Card
-        boxShadowSize='md'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='black'
-        bg='white'
-        borderRadius={10}
-      >
-        Medium Shadow - 10px
-      </Card>
-      <Card
-        boxShadowSize='lg'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='black'
-        bg='white'
-        borderRadius={20}
-      >
-        Large Shadow - 20px
-      </Card>
-      <Card
-        boxShadowSize='xl'
-        m={4}
-        p={4}
-        width={1 / 2}
-        color='black'
-        bg='white'
-        borderRadius='30px'
-      >
-        XLarge Shadow - 30px
-      </Card>
-    </Box>
-  ))
+export default {
+  title: 'Card',
+  component: Card,
+}
+
+export const BoxShadowsWithDefaultBorder = () => (
+  <Box>
+    <Card
+      boxShadowSize='sm'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderWidth={1}
+    >
+      Small Shadow
+    </Card>
+    <Card
+      boxShadowSize='md'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={1}
+    >
+      Medium Shadow
+    </Card>
+    <Card
+      boxShadowSize='lg'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={1}
+    >
+      Large Shadow
+    </Card>
+    <Card
+      boxShadowSize='xl'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={1}
+    >
+      XLarge Shadow
+    </Card>
+  </Box>
+)
+
+BoxShadowsWithDefaultBorder.story = {
+  name: 'Box Shadows with default border',
+}
+
+export const BoxShadowsWithFocused2PxBorder = () => (
+  <Box>
+    <Card
+      boxShadowSize='sm'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={2}
+    >
+      Small Shadow
+    </Card>
+    <Card
+      boxShadowSize='md'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={2}
+    >
+      Medium Shadow
+    </Card>
+    <Card
+      boxShadowSize='lg'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={2}
+    >
+      Large Shadow
+    </Card>
+    <Card
+      boxShadowSize='xl'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='text'
+      bg='white'
+      borderWidth={2}
+    >
+      XLarge Shadow
+    </Card>
+  </Box>
+)
+
+BoxShadowsWithFocused2PxBorder.story = {
+  name: 'Box Shadows with focused 2px border',
+}
+
+export const BoxShadowsWithVaryingBorderRadii = () => (
+  <Box>
+    <Card
+      boxShadowSize='sm'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderRadius={0}
+    >
+      Small Shadow - 0px
+    </Card>
+    <Card
+      boxShadowSize='md'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderRadius={10}
+    >
+      Medium Shadow - 10px
+    </Card>
+    <Card
+      boxShadowSize='lg'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderRadius={20}
+    >
+      Large Shadow - 20px
+    </Card>
+    <Card
+      boxShadowSize='xl'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderRadius='30px'
+    >
+      XLarge Shadow - 30px
+    </Card>
+  </Box>
+)
+
+BoxShadowsWithVaryingBorderRadii.story = {
+  name: 'Box Shadows with varying border radii',
+}

--- a/packages/core/src/Checkbox/Checkbox.stories.js
+++ b/packages/core/src/Checkbox/Checkbox.stories.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
 import styled from 'styled-components'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { Checkbox, Text, Box, Heading, Button, Label } from '..'
@@ -32,141 +31,159 @@ const checkAction = (e) => {
   action(`${e.target.id} was clicked`)(e.target.value, e.target.checked)
 }
 
-storiesOf('Checkbox', module)
-  .add('Checkbox states', () => (
-    <div>
-      <Wrapper>
-        <StyledLabel htmlFor='unchecked_box'>
-          <Checkbox id='unchecked_box' onChange={checkAction} />
-          Unchecked by default
-        </StyledLabel>
-      </Wrapper>
+export default {
+  title: 'Checkbox',
+  component: Checkbox,
+}
 
-      <Wrapper>
-        <StyledLabel htmlFor='checked_box'>
-          <Checkbox id='checked_box' defaultChecked onChange={checkAction} />
-          Checked by default
-        </StyledLabel>
-      </Wrapper>
+export const CheckboxStates = () => (
+  <div>
+    <Wrapper>
+      <StyledLabel htmlFor='unchecked_box'>
+        <Checkbox id='unchecked_box' onChange={checkAction} />
+        Unchecked by default
+      </StyledLabel>
+    </Wrapper>
 
-      <Wrapper>
-        <StyledLabel htmlFor='disabled_box'>
-          <Checkbox id='disabled_box' disabled onChange={checkAction} />
-          <Text.span color='border.base'>Disabled</Text.span>
-        </StyledLabel>
-      </Wrapper>
+    <Wrapper>
+      <StyledLabel htmlFor='checked_box'>
+        <Checkbox id='checked_box' defaultChecked onChange={checkAction} />
+        Checked by default
+      </StyledLabel>
+    </Wrapper>
 
-      <Wrapper>
-        <StyledLabel htmlFor='disabled_checked_box'>
-          <Checkbox
-            id='disabled_checked_box'
-            disabled
-            defaultChecked
-            onChange={checkAction}
-          />
-          <Text.span color='border.base'>Disabled &amp; Checked</Text.span>
-        </StyledLabel>
-      </Wrapper>
+    <Wrapper>
+      <StyledLabel htmlFor='disabled_box'>
+        <Checkbox id='disabled_box' disabled onChange={checkAction} />
+        <Text.span color='border.base'>Disabled</Text.span>
+      </StyledLabel>
+    </Wrapper>
 
-      <Wrapper title='In A Form'>
-        <form onSubmit={(e) => formAction(e)}>
-          <fieldset style={{ display: 'inline-block', padding: '16px' }}>
-            <legend>Fancy Form</legend>
+    <Wrapper>
+      <StyledLabel htmlFor='disabled_checked_box'>
+        <Checkbox
+          id='disabled_checked_box'
+          disabled
+          defaultChecked
+          onChange={checkAction}
+        />
+        <Text.span color='border.base'>Disabled &amp; Checked</Text.span>
+      </StyledLabel>
+    </Wrapper>
 
-            <Wrapper>
-              <StyledLabel fontSize='14px' htmlFor='form_checkbox'>
-                <Checkbox id='form_checkbox' size={30} onChange={checkAction} />
-                &nbsp;In This Form
-              </StyledLabel>
-            </Wrapper>
+    <Wrapper title='In A Form'>
+      <form onSubmit={(e) => formAction(e)}>
+        <fieldset style={{ display: 'inline-block', padding: '16px' }}>
+          <legend>Fancy Form</legend>
 
-            <Button type='submit'>Submit Me</Button>
-            <br />
-            <br />
-            <Button variation='outline' color='border.base' type='reset'>
-              Reset Me
-            </Button>
-          </fieldset>
-        </form>
-      </Wrapper>
-    </div>
-  ))
-  .add('color', () => (
-    <div>
-      <Wrapper>
-        <StyledLabel htmlFor='secondary_unchecked_box'>
-          <Checkbox
-            id='secondary_unchecked_box'
-            onChange={checkAction}
-            color='secondary'
-          />
-          Secondary color unchecked by default
-        </StyledLabel>
-        <StyledLabel htmlFor='secondary_checked_box'>
-          <Checkbox
-            id='secondary_checked_box'
-            defaultChecked
-            onChange={checkAction}
-            color='secondary'
-          />
-          Secondary color checked by default
-        </StyledLabel>
-        <StyledLabel htmlFor='secondary_disabled_box'>
-          <Checkbox
-            id='secondary_disabled_box'
-            disabled
-            onChange={checkAction}
-            color='secondary'
-          />
-          Secondary color disabled
-        </StyledLabel>
-      </Wrapper>
-      <Wrapper>
-        <StyledLabel htmlFor='error_unchecked_box'>
-          <Checkbox
-            id='error_unchecked_box'
-            onChange={checkAction}
-            color='error'
-          />
-          Error color unchecked by default
-        </StyledLabel>
-        <StyledLabel htmlFor='error_checked_box'>
-          <Checkbox
-            id='error_checked_box'
-            defaultChecked
-            onChange={checkAction}
-            color='error'
-          />
-          Error color checked by default
-        </StyledLabel>
-        <StyledLabel htmlFor='error_disabled_box'>
-          <Checkbox
-            id='error_disabled_box'
-            disabled
-            onChange={checkAction}
-            color='error'
-          />
-          Error color disabled
-        </StyledLabel>
-      </Wrapper>
-    </div>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          {/*
+          <Wrapper>
+            <StyledLabel fontSize='14px' htmlFor='form_checkbox'>
+              <Checkbox id='form_checkbox' size={30} onChange={checkAction} />
+              &nbsp;In This Form
+            </StyledLabel>
+          </Wrapper>
+
+          <Button type='submit'>Submit Me</Button>
+          <br />
+          <br />
+          <Button variation='outline' color='border.base' type='reset'>
+            Reset Me
+          </Button>
+        </fieldset>
+      </form>
+    </Wrapper>
+  </div>
+)
+
+CheckboxStates.story = {
+  name: 'Checkbox states',
+}
+
+export const Color = () => (
+  <div>
+    <Wrapper>
+      <StyledLabel htmlFor='secondary_unchecked_box'>
+        <Checkbox
+          id='secondary_unchecked_box'
+          onChange={checkAction}
+          color='secondary'
+        />
+        Secondary color unchecked by default
+      </StyledLabel>
+      <StyledLabel htmlFor='secondary_checked_box'>
+        <Checkbox
+          id='secondary_checked_box'
+          defaultChecked
+          onChange={checkAction}
+          color='secondary'
+        />
+        Secondary color checked by default
+      </StyledLabel>
+      <StyledLabel htmlFor='secondary_disabled_box'>
+        <Checkbox
+          id='secondary_disabled_box'
+          disabled
+          onChange={checkAction}
+          color='secondary'
+        />
+        Secondary color disabled
+      </StyledLabel>
+    </Wrapper>
+    <Wrapper>
+      <StyledLabel htmlFor='error_unchecked_box'>
+        <Checkbox
+          id='error_unchecked_box'
+          onChange={checkAction}
+          color='error'
+        />
+        Error color unchecked by default
+      </StyledLabel>
+      <StyledLabel htmlFor='error_checked_box'>
+        <Checkbox
+          id='error_checked_box'
+          defaultChecked
+          onChange={checkAction}
+          color='error'
+        />
+        Error color checked by default
+      </StyledLabel>
+      <StyledLabel htmlFor='error_disabled_box'>
+        <Checkbox
+          id='error_disabled_box'
+          disabled
+          onChange={checkAction}
+          color='error'
+        />
+        Error color disabled
+      </StyledLabel>
+    </Wrapper>
+  </div>
+)
+
+Color.story = {
+  name: 'color',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        {/*
             This example is for SC3
               <Button dsRef={e => this.btnRef = e}>Click me</Button>
           */}
-          <StyledLabel htmlFor='check'>
-            <Checkbox id='check' ref={dsRef} />
-            Checkbox with ref
-          </StyledLabel>
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus checkbox via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+        <StyledLabel htmlFor='check'>
+          <Checkbox id='check' ref={dsRef} />
+          Checkbox with ref
+        </StyledLabel>
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus checkbox via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/CloseButton/CloseButton.stories.js
+++ b/packages/core/src/CloseButton/CloseButton.stories.js
@@ -1,28 +1,40 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { Button, CloseButton } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('CloseButton', module)
-  .add('with click handler', () => (
-    <CloseButton color='background.darkest' onClick={action('clicked')} />
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <CloseButton
-            color='background.darkest'
-            onClick={action('clicked')}
-            dsRef={dsRef}
-          />
-          <br />
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus button via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+export default {
+  title: 'CloseButton',
+  component: CloseButton,
+}
+
+export const WithClickHandler = () => (
+  <CloseButton color='background.darkest' onClick={action('clicked')} />
+)
+
+WithClickHandler.story = {
+  name: 'with click handler',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <CloseButton
+          color='background.darkest'
+          onClick={action('clicked')}
+          dsRef={dsRef}
+        />
+        <br />
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus button via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/Container/Container.stories.js
+++ b/packages/core/src/Container/Container.stories.js
@@ -1,19 +1,31 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Container, Box } from '..'
 
-storiesOf('Container', module)
-  .add('Default align with theme max width', () => (
-    <Container>
-      <Box p={4} bg='lightGray' style={{ height: `100vh` }}>
-        Container Compnent
-      </Box>
-    </Container>
-  ))
-  .add('Input maxWidth', () => (
-    <Container maxWidth={500}>
-      <Box p={4} bg='lightGray' style={{ height: `100vh` }}>
-        Container Compnent
-      </Box>
-    </Container>
-  ))
+export default {
+  title: 'Container',
+  component: Container,
+}
+
+export const DefaultAlignWithThemeMaxWidth = () => (
+  <Container>
+    <Box p={4} bg='lightGray' style={{ height: `100vh` }}>
+      Container Compnent
+    </Box>
+  </Container>
+)
+
+DefaultAlignWithThemeMaxWidth.story = {
+  name: 'Default align with theme max width',
+}
+
+export const InputMaxWidth = () => (
+  <Container maxWidth={500}>
+    <Box p={4} bg='lightGray' style={{ height: `100vh` }}>
+      Container Compnent
+    </Box>
+  </Container>
+)
+
+InputMaxWidth.story = {
+  name: 'Input maxWidth',
+}

--- a/packages/core/src/Divider/Divider.stories.js
+++ b/packages/core/src/Divider/Divider.stories.js
@@ -1,44 +1,47 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Divider, Flex } from '..'
 import styled from 'styled-components'
 
 const description =
-  '<hr /> with settings for padding, margin, width, and borderColor'
+  'Horizontal rule with settings for padding, margin, width, and borderColor'
 const ColumnFlex = styled(Flex)`
   flex-direction: column;
 `
 
-storiesOf('Divider', module)
-  .add(
-    'Divider component',
-    withInfo({
-      text: description,
-      inline: true,
-    })(() => <Divider />)
-  )
-  .add('Margin', () => <Divider m={3} />)
-  .add('Width', () => <Divider p={3} width={1 / 2} />)
-  .add('Pixel Width', () => <Divider width={256} />)
-  .add('VW Width', () => <Divider width='50vw' />)
-  .add('Border Color', () => <Divider m={3} borderColor='blue' />)
-  .add('Directional Margin', () => (
-    <div>
-      <Divider mt={3} />
-      <Divider mr={3} />
-      <Divider mb={3} />
-      <Divider ml={3} />
-      <Divider mx={3} />
-      <Divider my={3} />
-    </div>
-  ))
-  .add('Inside Column Flex', () => (
-    <ColumnFlex>
-      <Divider />
-      <Divider ml={4} mr={4} />
-      <Divider ml={4} />
-      <Divider ml={4} mr={5} />
-      <Divider mx={2} />
-    </ColumnFlex>
-  ))
+export default {
+  title: 'Divider',
+  component: Divider,
+  parameters: {
+    docs: {
+      description: {
+        component: description,
+      },
+    },
+  },
+}
+
+export const Default = () => <Divider />
+export const Margin = () => <Divider m={3} />
+export const Width = () => <Divider p={3} width={1 / 2} />
+export const PixelWidth = () => <Divider width={256} />
+export const VWWidth = () => <Divider width='50vw' />
+export const BorderColor = () => <Divider m={3} borderColor='blue' />
+export const DirectionalMargin = () => (
+  <div>
+    <Divider mt={3} />
+    <Divider mr={3} />
+    <Divider mb={3} />
+    <Divider ml={3} />
+    <Divider mx={3} />
+    <Divider my={3} />
+  </div>
+)
+export const InsideColumnFlex = () => (
+  <ColumnFlex>
+    <Divider />
+    <Divider ml={4} mr={4} />
+    <Divider ml={4} />
+    <Divider ml={4} mr={5} />
+    <Divider mx={2} />
+  </ColumnFlex>
+)

--- a/packages/core/src/Flag/Flag.stories.js
+++ b/packages/core/src/Flag/Flag.stories.js
@@ -1,91 +1,115 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Box, Card, Flag, Flex, Text } from '..'
 import { Loyalty as LoyaltyIcon } from 'pcln-icons'
 
-storiesOf('Flag', module)
-  .add('Default', () => (
-    <Box p={3}>
-      <Card py={0}>
-        <Flag mt={2}>Hello Flag</Flag>
-        <Box p={3}>Hello</Box>
-      </Card>
-    </Box>
-  ))
-  .add('Colors', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag width={192} mt={2} bg='orange'>
-          <b>Hello</b> Orange
-        </Flag>
-        <Flag mt={3} bg='blue'>
-          Hello Blue
-        </Flag>
-        <Flag mt={3} bg='purple'>
-          Hello Purple
-        </Flag>
-      </Card>
-    </Box>
-  ))
+export default {
+  title: 'Flag',
+  component: Flag,
+}
 
-  .add('with custom hex bg color', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag width={192} mt={2} bg='#085397'>
-          <b>Hello</b> #085397
-        </Flag>
-        <Flag width={192} mt={2} bg='#f2633a'>
-          <b>Hello</b> #f2633a
-        </Flag>
-        <Flag width={192} mt={2} bg='#0a84c1'>
-          <b>Hello</b> #0a84c1
-        </Flag>
-        <Flag width={192} mt={2} bg='#3c910e'>
-          <b>Hello</b> #3c910e
-        </Flag>
-      </Card>
-    </Box>
-  ))
-  .add('Compensating for 1px border', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag width={192} ml={-9} mt={2}>
-          <b>Hello</b>
-        </Flag>
-      </Card>
-    </Box>
-  ))
-  .add('Wrapped text', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag mt={2}>
-          <b>Hello</b>
-          This is a really long string of text that should wrap when it gets too
-          long. But then the flag part to the right will probably break.
-        </Flag>
-      </Card>
-    </Box>
-  ))
-  .add('With Icon', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag mt={2}>
-          <Flex>
-            <LoyaltyIcon size={14} mr={1} />
-            <Text>Hello World</Text>
-          </Flex>
-        </Flag>
-      </Card>
-    </Box>
-  ))
-  .add('With custom padding', () => (
-    <Box p={3}>
-      <Card pb={3}>
-        <Flag mt={2} py={[1, 2, 3]} pl={[2, 3, 4]} pr={[1, 3, 4]}>
-          <Flex>
-            <Text>Hello World</Text>
-          </Flex>
-        </Flag>
-      </Card>
-    </Box>
-  ))
+export const Default = () => (
+  <Box p={3}>
+    <Card py={0}>
+      <Flag mt={2}>Hello Flag</Flag>
+      <Box p={3}>Hello</Box>
+    </Card>
+  </Box>
+)
+
+export const Colors = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag width={192} mt={2} bg='orange'>
+        <b>Hello</b> Orange
+      </Flag>
+      <Flag mt={3} bg='blue'>
+        Hello Blue
+      </Flag>
+      <Flag mt={3} bg='purple'>
+        Hello Purple
+      </Flag>
+    </Card>
+  </Box>
+)
+
+export const WithCustomHexBgColor = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag width={192} mt={2} bg='#085397'>
+        <b>Hello</b> #085397
+      </Flag>
+      <Flag width={192} mt={2} bg='#f2633a'>
+        <b>Hello</b> #f2633a
+      </Flag>
+      <Flag width={192} mt={2} bg='#0a84c1'>
+        <b>Hello</b> #0a84c1
+      </Flag>
+      <Flag width={192} mt={2} bg='#3c910e'>
+        <b>Hello</b> #3c910e
+      </Flag>
+    </Card>
+  </Box>
+)
+
+WithCustomHexBgColor.story = {
+  name: 'with custom hex bg color',
+}
+
+export const CompensatingFor1PxBorder = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag width={192} ml={-9} mt={2}>
+        <b>Hello</b>
+      </Flag>
+    </Card>
+  </Box>
+)
+
+CompensatingFor1PxBorder.story = {
+  name: 'Compensating for 1px border',
+}
+
+export const WrappedText = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag mt={2}>
+        <b>Hello</b>
+        This is a really long string of text that should wrap when it gets too
+        long. But then the flag part to the right will probably break.
+      </Flag>
+    </Card>
+  </Box>
+)
+
+WrappedText.story = {
+  name: 'Wrapped text',
+}
+
+export const WithIcon = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag mt={2}>
+        <Flex>
+          <LoyaltyIcon size={14} mr={1} />
+          <Text>Hello World</Text>
+        </Flex>
+      </Flag>
+    </Card>
+  </Box>
+)
+
+export const WithCustomPadding = () => (
+  <Box p={3}>
+    <Card pb={3}>
+      <Flag mt={2} py={[1, 2, 3]} pl={[2, 3, 4]} pr={[1, 3, 4]}>
+        <Flex>
+          <Text>Hello World</Text>
+        </Flex>
+      </Flag>
+    </Card>
+  </Box>
+)
+
+WithCustomPadding.story = {
+  name: 'With custom padding',
+}

--- a/packages/core/src/Flex/Flex.stories.js
+++ b/packages/core/src/Flex/Flex.stories.js
@@ -1,55 +1,70 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Flex, Box } from '..'
 
-storiesOf('Flex', module)
-  .add('Basic', () => (
-    <Flex alignItems='center'>
-      <Box width={1 / 2} p={3} color='white' bg='blue'>
-        Flex
-      </Box>
-      <Box width={1 / 2} p={1} color='white' bg='green'>
-        Box
-      </Box>
-    </Flex>
-  ))
-  .add('Wrap', () => (
-    <Flex flexWrap='wrap'>
-      <Box width={[1, 1 / 2]} p={3} color='white' bg='blue'>
-        Flex
-      </Box>
-      <Box width={[1, 1 / 2]} p={1} color='white' bg='green'>
-        Wrap
-      </Box>
-    </Flex>
-  ))
-  .add('Justify', () => (
-    <Flex justifyContent='space-around'>
-      <Box width={1 / 3} p={2} color='white' bg='blue'>
-        Flex
-      </Box>
-      <Box width={1 / 3} p={2} color='white' bg='green'>
-        Justify
-      </Box>
-    </Flex>
-  ))
-  .add('deprecated align shim', () => (
-    <Flex align='center'>
-      <Box width={1 / 2} p={3} color='white' bg='blue'>
-        Flex
-      </Box>
-      <Box width={1 / 2} p={1} color='white' bg='green'>
-        Box
-      </Box>
-    </Flex>
-  ))
-  .add('deprecated bg shim', () => (
-    <Flex bg='blue'>
-      <Box width={1 / 2} p={3} color='white' bg='blue'>
-        Flex
-      </Box>
-      <Box width={1 / 2} p={1} color='white' bg='green'>
-        Box
-      </Box>
-    </Flex>
-  ))
+export default {
+  title: 'Flex',
+  component: Flex,
+}
+
+export const Basic = () => (
+  <Flex alignItems='center'>
+    <Box width={1 / 2} p={3} color='white' bg='blue'>
+      Flex
+    </Box>
+    <Box width={1 / 2} p={1} color='white' bg='green'>
+      Box
+    </Box>
+  </Flex>
+)
+
+export const Wrap = () => (
+  <Flex flexWrap='wrap'>
+    <Box width={[1, 1 / 2]} p={3} color='white' bg='blue'>
+      Flex
+    </Box>
+    <Box width={[1, 1 / 2]} p={1} color='white' bg='green'>
+      Wrap
+    </Box>
+  </Flex>
+)
+
+export const Justify = () => (
+  <Flex justifyContent='space-around'>
+    <Box width={1 / 3} p={2} color='white' bg='blue'>
+      Flex
+    </Box>
+    <Box width={1 / 3} p={2} color='white' bg='green'>
+      Justify
+    </Box>
+  </Flex>
+)
+
+export const DeprecatedAlignShim = () => (
+  <Flex align='center'>
+    <Box width={1 / 2} p={3} color='white' bg='blue'>
+      Flex
+    </Box>
+    <Box width={1 / 2} p={1} color='white' bg='green'>
+      Box
+    </Box>
+  </Flex>
+)
+
+DeprecatedAlignShim.story = {
+  name: 'deprecated align shim',
+}
+
+export const DeprecatedBgShim = () => (
+  <Flex bg='blue'>
+    <Box width={1 / 2} p={3} color='white' bg='blue'>
+      Flex
+    </Box>
+    <Box width={1 / 2} p={1} color='white' bg='green'>
+      Box
+    </Box>
+  </Flex>
+)
+
+DeprecatedBgShim.story = {
+  name: 'deprecated bg shim',
+}

--- a/packages/core/src/FormField/FormField.stories.js
+++ b/packages/core/src/FormField/FormField.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Flex, Box, FormField, Label, Input, Select, Tooltip } from '..'
 import {
   Check as CheckIcon,
@@ -9,116 +8,154 @@ import {
   Warning as WarningIcon,
 } from 'pcln-icons'
 
-storiesOf('FormField', module)
-  .add('with Icon', () => (
-    <FormField>
-      <Label htmlFor='demo'>Email Address</Label>
-      <EmailIcon color='primary' />
-      <Input
-        type='email'
-        id='email'
-        name='email'
-        defaultValue='hello@example.com'
-      />
-    </FormField>
-  ))
-  .add('dynamic label', () => (
-    <Flex>
-      <Box px={2} width={1 / 3}>
-        <FormField>
-          <Label autoHide htmlFor='dynamic-label-without-a-value'>
-            No value
-          </Label>
-          <Input
-            id='dynamic-label-without-a-value'
-            name='dynamic-label-without-a-value'
-            placeholder='Without a value'
-          />
-        </FormField>
-      </Box>
-      <Box px={2} width={1 / 3}>
-        <FormField>
-          <Label autoHide htmlFor='dynamic-label-with-a-value'>
-            With value
-          </Label>
-          <Input
-            id='dynamic-label-with-a-value'
-            name='dynamic-label-with-a-value'
-            value='hello@example.com'
-          />
-        </FormField>
-      </Box>
-      <Box px={2} width={1 / 3}>
-        <FormField>
-          <Input
-            id='dynamic-label-without-a-label'
-            name='dynamic-label-without-a-label'
-            value='Value without label'
-          />
-        </FormField>
-      </Box>
-    </Flex>
-  ))
-  .add('dynamic label with value', () => (
-    <FormField>
-      <Label htmlFor='dynamic-label-email'>Email Address</Label>
-      <Input
-        id='dynamic-label-email'
-        name='dynamic-label-email'
-        placeholder='hello@example.com'
-        value='hello@example.com'
-      />
-    </FormField>
-  ))
-  .add('Icon to the right', () => (
-    <FormField>
-      <Label htmlFor='dynamic-label-email-icon-right'>Email Address</Label>
-      <Input
-        id='dynamic-label-email-icon-right'
-        name='dynamic-label-email-icon-right'
-        placeholder='hello@example.com'
-        value='hello@example.com'
-      />
-      <CheckIcon color='secondary' />
-    </FormField>
-  ))
-  .add('with Select', () => (
-    <FormField>
-      <Label htmlFor='dynamic-label-state-select'>State</Label>
-      <PinIcon color='primary' />
-      <Select id='dynamic-label-state-select' name='dynamic-label-state-select'>
-        <option>New York</option>
-        <option>New Jersey</option>
-      </Select>
-    </FormField>
-  ))
-  .add('with successful validation', () => (
-    <FormField>
-      <Label htmlFor='valid'>Email Address</Label>
-      <Input
-        id='valid'
-        name='valid'
-        placeholder='hello@example.com'
-        color='success'
-      />
-      <SuccessIcon color='success' />
-    </FormField>
-  ))
-  .add('with error Tooltip', () => (
-    <Box>
+export default {
+  title: 'FormField',
+  component: FormField,
+}
+
+export const WithIcon = () => (
+  <FormField>
+    <Label htmlFor='demo'>Email Address</Label>
+    <EmailIcon color='primary' />
+    <Input
+      type='email'
+      id='email'
+      name='email'
+      defaultValue='hello@example.com'
+    />
+  </FormField>
+)
+
+WithIcon.story = {
+  name: 'with Icon',
+}
+
+export const DynamicLabel = () => (
+  <Flex>
+    <Box px={2} width={1 / 3}>
       <FormField>
-        <Label htmlFor='error-tooltip'>Email Address</Label>
+        <Label autoHide htmlFor='dynamic-label-without-a-value'>
+          No value
+        </Label>
         <Input
-          id='error-tooltip'
-          name='error-tooltip'
-          placeholder='hello@example.com'
-          aria-describedby='demo-error'
-          color='error'
+          id='dynamic-label-without-a-value'
+          name='dynamic-label-without-a-value'
+          placeholder='Without a value'
         />
-        <WarningIcon color='error' />
       </FormField>
-      <Tooltip id='demo-error' right color='error'>
-        Email address is required
-      </Tooltip>
     </Box>
-  ))
+    <Box px={2} width={1 / 3}>
+      <FormField>
+        <Label autoHide htmlFor='dynamic-label-with-a-value'>
+          With value
+        </Label>
+        <Input
+          id='dynamic-label-with-a-value'
+          name='dynamic-label-with-a-value'
+          value='hello@example.com'
+        />
+      </FormField>
+    </Box>
+    <Box px={2} width={1 / 3}>
+      <FormField>
+        <Input
+          id='dynamic-label-without-a-label'
+          name='dynamic-label-without-a-label'
+          value='Value without label'
+        />
+      </FormField>
+    </Box>
+  </Flex>
+)
+
+DynamicLabel.story = {
+  name: 'dynamic label',
+}
+
+export const DynamicLabelWithValue = () => (
+  <FormField>
+    <Label htmlFor='dynamic-label-email'>Email Address</Label>
+    <Input
+      id='dynamic-label-email'
+      name='dynamic-label-email'
+      placeholder='hello@example.com'
+      value='hello@example.com'
+    />
+  </FormField>
+)
+
+DynamicLabelWithValue.story = {
+  name: 'dynamic label with value',
+}
+
+export const IconToTheRight = () => (
+  <FormField>
+    <Label htmlFor='dynamic-label-email-icon-right'>Email Address</Label>
+    <Input
+      id='dynamic-label-email-icon-right'
+      name='dynamic-label-email-icon-right'
+      placeholder='hello@example.com'
+      value='hello@example.com'
+    />
+    <CheckIcon color='secondary' />
+  </FormField>
+)
+
+IconToTheRight.story = {
+  name: 'Icon to the right',
+}
+
+export const WithSelect = () => (
+  <FormField>
+    <Label htmlFor='dynamic-label-state-select'>State</Label>
+    <PinIcon color='primary' />
+    <Select id='dynamic-label-state-select' name='dynamic-label-state-select'>
+      <option>New York</option>
+      <option>New Jersey</option>
+    </Select>
+  </FormField>
+)
+
+WithSelect.story = {
+  name: 'with Select',
+}
+
+export const WithSuccessfulValidation = () => (
+  <FormField>
+    <Label htmlFor='valid'>Email Address</Label>
+    <Input
+      id='valid'
+      name='valid'
+      placeholder='hello@example.com'
+      color='success'
+    />
+    <SuccessIcon color='success' />
+  </FormField>
+)
+
+WithSuccessfulValidation.story = {
+  name: 'with successful validation',
+}
+
+export const WithErrorTooltip = () => (
+  <Box>
+    <FormField>
+      <Label htmlFor='error-tooltip'>Email Address</Label>
+      <Input
+        id='error-tooltip'
+        name='error-tooltip'
+        placeholder='hello@example.com'
+        aria-describedby='demo-error'
+        color='error'
+      />
+      <WarningIcon color='error' />
+    </FormField>
+    <Tooltip id='demo-error' right color='error'>
+      Email address is required
+    </Tooltip>
+  </Box>
+)
+
+WithErrorTooltip.story = {
+  name: 'with error Tooltip',
+}

--- a/packages/core/src/Heading/Heading.stories.js
+++ b/packages/core/src/Heading/Heading.stories.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Heading } from '..'
 
 const description =
@@ -8,44 +6,60 @@ const description =
   ' using HTML h1-h6 element for setting section headings,' +
   ' supporting all <Text> props'
 
-storiesOf('Heading', module)
-  .add(
-    'Heading component',
-    withInfo({
-      inline: true,
-      text: description,
-    })(() => <Heading m={3}>Heading component</Heading>)
-  )
-  .add('Using dot-notation with h1-h6', () => (
-    <section>
-      <Heading.h1>Heading h1</Heading.h1>
-      <Heading.h2>Heading h2</Heading.h2>
-      <Heading.h3>Heading h3</Heading.h3>
-      <Heading.h4>Heading h4</Heading.h4>
-      <Heading.h5>Heading h5</Heading.h5>
-      <Heading.h6>Heading h6</Heading.h6>
-    </section>
-  ))
-  .add('With Text Shadows', () => (
-    <section>
-      <Heading.h1 enableTextShadow>Heading h1</Heading.h1>
-      <Heading.h2 enableTextShadow>Heading h2</Heading.h2>
-      <Heading.h3 enableTextShadow>Heading h3</Heading.h3>
-      <Heading.h4 enableTextShadow>Heading h4</Heading.h4>
-      <Heading.h5 enableTextShadow>Heading h5</Heading.h5>
-      <Heading.h6 enableTextShadow>Heading h6</Heading.h6>
-    </section>
-  ))
-  .add('Using <Text> props', () => (
-    <section>
-      <Heading textAlign='left' bold fontSize={6} color='green'>
-        Heading Left
-      </Heading>
-      <Heading textAlign='center' medium fontSize={5} color='blue'>
-        Heading Center
-      </Heading>
-      <Heading textAlign='right' regular fontSize={4} color='orange'>
-        Heading Right
-      </Heading>
-    </section>
-  ))
+export default {
+  title: 'Heading',
+  component: Heading,
+  parameters: {
+    docs: {
+      description: {
+        component: description,
+      },
+    },
+  },
+}
+
+export const HeadingComponent = () => <Heading m={3}>Heading component</Heading>
+
+export const UsingDotNotationWithH1H6 = () => (
+  <section>
+    <Heading.h1>Heading h1</Heading.h1>
+    <Heading.h2>Heading h2</Heading.h2>
+    <Heading.h3>Heading h3</Heading.h3>
+    <Heading.h4>Heading h4</Heading.h4>
+    <Heading.h5>Heading h5</Heading.h5>
+    <Heading.h6>Heading h6</Heading.h6>
+  </section>
+)
+
+UsingDotNotationWithH1H6.story = {
+  name: 'Using dot-notation with h1-h6',
+}
+
+export const WithTextShadows = () => (
+  <section>
+    <Heading.h1 enableTextShadow>Heading h1</Heading.h1>
+    <Heading.h2 enableTextShadow>Heading h2</Heading.h2>
+    <Heading.h3 enableTextShadow>Heading h3</Heading.h3>
+    <Heading.h4 enableTextShadow>Heading h4</Heading.h4>
+    <Heading.h5 enableTextShadow>Heading h5</Heading.h5>
+    <Heading.h6 enableTextShadow>Heading h6</Heading.h6>
+  </section>
+)
+
+export const UsingTextProps = () => (
+  <section>
+    <Heading textAlign='left' bold fontSize={6} color='green'>
+      Heading Left
+    </Heading>
+    <Heading textAlign='center' medium fontSize={5} color='blue'>
+      Heading Center
+    </Heading>
+    <Heading textAlign='right' regular fontSize={4} color='orange'>
+      Heading Right
+    </Heading>
+  </section>
+)
+
+UsingTextProps.story = {
+  name: 'Using <Text> props',
+}

--- a/packages/core/src/Hide/Hide.stories.js
+++ b/packages/core/src/Hide/Hide.stories.js
@@ -1,8 +1,12 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Hide, Box, Flex } from '..'
 
-storiesOf('Hide', module).add('Hide', () => (
+export default {
+  title: 'Hide',
+  component: Hide,
+}
+
+export const _Hide = () => (
   <Flex justifyContent='space-between'>
     <Hide xs sm md lg xl xxl>
       <Box p={2} bg='warning'>
@@ -41,4 +45,4 @@ storiesOf('Hide', module).add('Hide', () => (
     </Hide>
     <Hide.text sm>Hide.text (inline)</Hide.text>
   </Flex>
-))
+)

--- a/packages/core/src/Hug/Hug.stories.js
+++ b/packages/core/src/Hug/Hug.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { withKnobs, select } from '@storybook/addon-knobs'
 import { ThumbsUp } from 'pcln-icons'
 import { Hug, Hide, Card, Text } from '..'
@@ -21,58 +20,91 @@ const responsiveText = (
   </Text.span>
 )
 
-storiesOf('Hug', module)
-  .addDecorator(withKnobs)
-  .add('With a card inside', () => (
-    <Hug text={text}>
+export default {
+  title: 'Hug',
+  component: Hug,
+  decorators: [withKnobs],
+}
+
+export const WithACardInside = () => (
+  <Hug text={text}>
+    <Card p={3} bg='white' color='text'>
+      I‘m a card within a hug!
+    </Card>
+  </Hug>
+)
+
+WithACardInside.story = {
+  name: 'With a card inside',
+}
+
+export const WithIconAndACardInside = () => (
+  <Hug text={text} color='primary' icon={<ThumbsUp />}>
+    <Card p={3} bg='white' color='text'>
+      I‘m a card within a hug!
+    </Card>
+  </Hug>
+)
+
+WithIconAndACardInside.story = {
+  name: 'With icon and a card inside',
+}
+
+export const WithACardInACard = () => (
+  <Hug text={text}>
+    <Card p={3} bg='white' color='text'>
       <Card p={3} bg='white' color='text'>
-        I‘m a card within a hug!
+        I‘m a card within a card within a hug!
       </Card>
-    </Hug>
-  ))
-  .add('With icon and a card inside', () => (
-    <Hug text={text} color='primary' icon={<ThumbsUp />}>
-      <Card p={3} bg='white' color='text'>
-        I‘m a card within a hug!
-      </Card>
-    </Hug>
-  ))
-  .add('With a card in a card', () => (
-    <Hug text={text}>
-      <Card p={3} bg='white' color='text'>
-        <Card p={3} bg='white' color='text'>
-          I‘m a card within a card within a hug!
-        </Card>
-      </Card>
-    </Hug>
-  ))
-  .add('With plain text instead of component', () => (
-    <Hug text="I am plain ol' text">
-      <Card p={3} bg='white' color='text'>
-        I‘m a card within a hug!
-      </Card>
-    </Hug>
-  ))
-  .add('With an array of nodes', () => (
-    <Hug text={[text, text]}>
-      <Card p={3} bg='white' color='text'>
-        I‘m a card within a hug!
-      </Card>
-    </Hug>
-  ))
-  .add('With a responsive hug', () => (
-    <Hug
-      text={responsiveText}
-      p={2}
-      fontSize={[0, 1]}
-      icon={<ThumbsUp />}
-      iconDisplay={select('Display', {
-        Block: 'block',
-        None: 'none',
-      })}
-    >
-      <Card p={3} bg='white' color='text'>
-        I‘m a card within a hug!
-      </Card>
-    </Hug>
-  ))
+    </Card>
+  </Hug>
+)
+
+WithACardInACard.story = {
+  name: 'With a card in a card',
+}
+
+export const WithPlainTextInsteadOfComponent = () => (
+  <Hug text="I am plain ol' text">
+    <Card p={3} bg='white' color='text'>
+      I‘m a card within a hug!
+    </Card>
+  </Hug>
+)
+
+WithPlainTextInsteadOfComponent.story = {
+  name: 'With plain text instead of component',
+}
+
+export const WithAnArrayOfNodes = () => (
+  <Hug text={[text, text]}>
+    <Card p={3} bg='white' color='text'>
+      I‘m a card within a hug!
+    </Card>
+  </Hug>
+)
+
+WithAnArrayOfNodes.story = {
+  name: 'With an array of nodes',
+}
+
+export const WithAResponsiveHug = () => (
+  <Hug
+    text={responsiveText}
+    p={2}
+    fontSize={[0, 1]}
+    icon={<ThumbsUp />}
+    iconDisplay={select('Display', {
+      Block: 'block',
+      None: 'none',
+    })}
+  >
+    <Card p={3} bg='white' color='text'>
+      I‘m a card within a hug!
+    </Card>
+  </Hug>
+)
+
+WithAResponsiveHug.story = {
+  name: 'With a responsive hug',
+}

--- a/packages/core/src/IconButton/IconButton.stories.js
+++ b/packages/core/src/IconButton/IconButton.stories.js
@@ -1,51 +1,78 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Calendar } from 'pcln-icons'
 
 import { Button, IconButton } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('IconButton', module)
-  .add('default', () => (
-    <IconButton
-      onClick={action('Clicked IconButton')}
-      icon={<Calendar title='Choose date' />}
-    />
-  ))
-  .add('with color', () => (
-    <IconButton
-      onClick={action('Clicked IconButton')}
-      icon={<Calendar title='Choose date' color='primary' />}
-    />
-  ))
-  .add('with size', () => (
-    <IconButton
-      onClick={action('Clicked IconButton')}
-      icon={<Calendar title='Choose date' size={64} />}
-    />
-  ))
-  .add('with disabled', () => (
-    <IconButton
-      onClick={action('Clicked IconButton')}
-      icon={<Calendar title='Choose date' />}
-      disabled
-    />
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <IconButton
-            onClick={action('Clicked IconButton')}
-            icon={<Calendar title='Choose date' size={64} />}
-            dsRef={dsRef}
-          />
-          <br />
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus button via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+export default {
+  title: 'IconButton',
+  component: IconButton,
+}
+
+export const Default = () => (
+  <IconButton
+    onClick={action('Clicked IconButton')}
+    icon={<Calendar title='Choose date' />}
+  />
+)
+
+Default.story = {
+  name: 'default',
+}
+
+export const WithColor = () => (
+  <IconButton
+    onClick={action('Clicked IconButton')}
+    icon={<Calendar title='Choose date' color='primary' />}
+  />
+)
+
+WithColor.story = {
+  name: 'with color',
+}
+
+export const WithSize = () => (
+  <IconButton
+    onClick={action('Clicked IconButton')}
+    icon={<Calendar title='Choose date' size={64} />}
+  />
+)
+
+WithSize.story = {
+  name: 'with size',
+}
+
+export const WithDisabled = () => (
+  <IconButton
+    onClick={action('Clicked IconButton')}
+    icon={<Calendar title='Choose date' />}
+    disabled
+  />
+)
+
+WithDisabled.story = {
+  name: 'with disabled',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <IconButton
+          onClick={action('Clicked IconButton')}
+          icon={<Calendar title='Choose date' size={64} />}
+          dsRef={dsRef}
+        />
+        <br />
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus button via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/IconField/IconField.stories.js
+++ b/packages/core/src/IconField/IconField.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { IconField, Input, Select, IconButton } from '..'
 import {
   Calendar as CalendarIcon,
@@ -8,57 +7,90 @@ import {
 } from 'pcln-icons'
 import { action } from '@storybook/addon-actions'
 
-storiesOf('IconField', module)
-  .add('Icon and Input', () => (
-    <IconField>
-      <CalendarIcon color='blue' />
-      <Input placeholder='Choose Date' />
-    </IconField>
-  ))
-  .add('Input and Icon', () => (
-    <IconField>
-      <Input placeholder='Choose Date' />
-      <CalendarIcon color='blue' />
-    </IconField>
-  ))
-  .add('Input and Icon Button', () => (
-    <IconField>
-      <Input placeholder='Choose Date' />
-      <IconButton
-        icon={<CloseIcon />}
-        size={24}
-        color='gray'
-        title='Clear text'
-        onClick={action('Icon button clicked')}
-      />
-    </IconField>
-  ))
-  .add('Icon, Input, and Icon', () => (
-    <IconField>
-      <CalendarIcon color='blue' />
-      <Input placeholder='Choose Date' />
-      <CheckIcon color='green' />
-    </IconField>
-  ))
-  .add('Icon, Input and Icon Button', () => (
-    <IconField>
-      <CalendarIcon color='blue' />
-      <Input placeholder='Choose Date' />
-      <IconButton
-        icon={<CloseIcon />}
-        size={24}
-        color='gray'
-        title='Clear text'
-        onClick={action('Icon button clicked')}
-      />
-    </IconField>
-  ))
-  .add('Icon and Select', () => (
-    <IconField>
-      <CalendarIcon color='blue' />
-      <Select>
-        <option>Choose Date</option>
-        <option>January 2019</option>
-      </Select>
-    </IconField>
-  ))
+export default {
+  title: 'IconField',
+  component: IconField,
+}
+
+export const IconAndInput = () => (
+  <IconField>
+    <CalendarIcon color='blue' />
+    <Input placeholder='Choose Date' />
+  </IconField>
+)
+
+IconAndInput.story = {
+  name: 'Icon and Input',
+}
+
+export const InputAndIcon = () => (
+  <IconField>
+    <Input placeholder='Choose Date' />
+    <CalendarIcon color='blue' />
+  </IconField>
+)
+
+InputAndIcon.story = {
+  name: 'Input and Icon',
+}
+
+export const InputAndIconButton = () => (
+  <IconField>
+    <Input placeholder='Choose Date' />
+    <IconButton
+      icon={<CloseIcon />}
+      size={24}
+      color='gray'
+      title='Clear text'
+      onClick={action('Icon button clicked')}
+    />
+  </IconField>
+)
+
+InputAndIconButton.story = {
+  name: 'Input and Icon Button',
+}
+
+export const IconInputAndIcon = () => (
+  <IconField>
+    <CalendarIcon color='blue' />
+    <Input placeholder='Choose Date' />
+    <CheckIcon color='green' />
+  </IconField>
+)
+
+IconInputAndIcon.story = {
+  name: 'Icon, Input, and Icon',
+}
+
+export const IconInputAndIconButton = () => (
+  <IconField>
+    <CalendarIcon color='blue' />
+    <Input placeholder='Choose Date' />
+    <IconButton
+      icon={<CloseIcon />}
+      size={24}
+      color='gray'
+      title='Clear text'
+      onClick={action('Icon button clicked')}
+    />
+  </IconField>
+)
+
+IconInputAndIconButton.story = {
+  name: 'Icon, Input and Icon Button',
+}
+
+export const IconAndSelect = () => (
+  <IconField>
+    <CalendarIcon color='blue' />
+    <Select>
+      <option>Choose Date</option>
+      <option>January 2019</option>
+    </Select>
+  </IconField>
+)
+
+IconAndSelect.story = {
+  name: 'Icon and Select',
+}

--- a/packages/core/src/Image/Image.stories.js
+++ b/packages/core/src/Image/Image.stories.js
@@ -1,24 +1,27 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Image } from '..'
 
 const description = 'A low-level layout component that renders an image'
 
-storiesOf('Image', module)
-  .add(
-    'Image component',
-    withInfo({
-      text: description,
-      inline: true,
-    })(() => (
-      <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
-    ))
-  )
+export default {
+  title: 'Image',
+  component: Image,
+  parameters: {
+    docs: {
+      description: {
+        component: description,
+      },
+    },
+  },
+}
 
-  .add('Responsive width', () => (
-    <Image
-      width={1 / 2}
-      src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg'
-    />
-  ))
+export const Default = () => (
+  <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
+)
+
+export const ResponsiveWidth = () => (
+  <Image
+    width={1 / 2}
+    src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg'
+  />
+)

--- a/packages/core/src/Input/Input.stories.js
+++ b/packages/core/src/Input/Input.stories.js
@@ -1,37 +1,46 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Box, Input, Label } from '..'
 
-storiesOf('Input', module)
-  .add(
-    'Input component',
-    withInfo({
-      inline: true,
-      text:
-        'Simple styled input component that accepts a color and whether or not to show an error container.',
-    })(() => <Input my={3} />)
-  )
-  .add('Colors', () => (
-    <Box width={400}>
-      <Input mb={3} id='input-colors-1' placeholder='No color' />
-      <Input mb={3} id='input-colors-2' color='primary' placeholder='Primary' />
-      <Input
-        mb={3}
-        id='input-colors-3'
-        color='secondary'
-        placeholder='Secondary'
-      />
-      <Input mb={3} id='input-colors-4' color='warning' placeholder='Warning' />
-      <Input mb={3} id='input-colors-5' color='alert' placeholder='Alert' />
-      <Input mb={3} id='input-colors-6' color='caution' placeholder='Caution' />
-    </Box>
-  ))
-  .add('With external label', () => (
-    <Box width={400}>
-      <Label fontSize={4} htmlFor='sample-input'>
-        Label!
-      </Label>
-      <Input id='sample-input' placeholder='Click the label' />
-    </Box>
-  ))
+export default {
+  title: 'Input',
+  component: Input,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Simple styled input component that accepts a color and whether or not to show an error container.',
+      },
+    },
+  },
+}
+
+export const InputComponent = () => <Input my={3} />
+
+export const Colors = () => (
+  <Box width={400}>
+    <Input mb={3} id='input-colors-1' placeholder='No color' />
+    <Input mb={3} id='input-colors-2' color='primary' placeholder='Primary' />
+    <Input
+      mb={3}
+      id='input-colors-3'
+      color='secondary'
+      placeholder='Secondary'
+    />
+    <Input mb={3} id='input-colors-4' color='warning' placeholder='Warning' />
+    <Input mb={3} id='input-colors-5' color='alert' placeholder='Alert' />
+    <Input mb={3} id='input-colors-6' color='caution' placeholder='Caution' />
+  </Box>
+)
+
+export const WithExternalLabel = () => (
+  <Box width={400}>
+    <Label fontSize={4} htmlFor='sample-input'>
+      Label!
+    </Label>
+    <Input id='sample-input' placeholder='Click the label' />
+  </Box>
+)
+
+WithExternalLabel.story = {
+  name: 'With external label',
+}

--- a/packages/core/src/InputGroup/InputGroup.stories.js
+++ b/packages/core/src/InputGroup/InputGroup.stories.js
@@ -1,54 +1,65 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 
 import { Box, Button, Input, Label } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('Input', module)
-  .add(
-    'Input component',
-    withInfo({
-      inline: true,
-      text:
-        'Simple styled input component that accepts a color and whether or not to show an error container.',
-    })(() => <Input my={3} />)
-  )
-  .add('Colors', () => (
-    <Box width={400}>
-      <Input mb={3} id='input-colors-1' placeholder='No color' />
-      <Input mb={3} id='input-colors-2' color='primary' placeholder='Primary' />
-      <Input
-        mb={3}
-        id='input-colors-3'
-        color='secondary'
-        placeholder='Secondary'
-      />
-      <Input mb={3} id='input-colors-4' color='warning' placeholder='Warning' />
-      <Input mb={3} id='input-colors-5' color='alert' placeholder='Alert' />
-      <Input mb={3} id='input-colors-6' color='caution' placeholder='Caution' />
-    </Box>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Input dsRef={dsRef} value='Sad Panda :(' />
-          <Button
-            onClick={() => (dsRef.current.value = 'Happy Panda :D')}
-            mt={4}
-          >
-            Click to change input value via ref
-          </Button>
-        </>
-      )}
+export default {
+  title: 'Input',
+  component: Input,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Simple styled input component that accepts a color and whether or not to show an error container.',
+      },
+    },
+  },
+}
+
+export const InputComponent = () => <Input my={3} />
+
+export const Colors = () => (
+  <Box width={400}>
+    <Input mb={3} id='input-colors-1' placeholder='No color' />
+    <Input mb={3} id='input-colors-2' color='primary' placeholder='Primary' />
+    <Input
+      mb={3}
+      id='input-colors-3'
+      color='secondary'
+      placeholder='Secondary'
     />
-  ))
-  .add('With external label', () => (
-    <Box width={400}>
-      <Label fontSize={4} htmlFor='sample-input'>
-        Label!
-      </Label>
-      <Input id='sample-input' placeholder='Click the label' />
-    </Box>
-  ))
+    <Input mb={3} id='input-colors-4' color='warning' placeholder='Warning' />
+    <Input mb={3} id='input-colors-5' color='alert' placeholder='Alert' />
+    <Input mb={3} id='input-colors-6' color='caution' placeholder='Caution' />
+  </Box>
+)
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Input dsRef={dsRef} value='Sad Panda :(' />
+        <Button onClick={() => (dsRef.current.value = 'Happy Panda :D')} mt={4}>
+          Click to change input value via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}
+
+export const WithExternalLabel = () => (
+  <Box width={400}>
+    <Label fontSize={4} htmlFor='sample-input'>
+      Label!
+    </Label>
+    <Input id='sample-input' placeholder='Click the label' />
+  </Box>
+)
+
+WithExternalLabel.story = {
+  name: 'With external label',
+}

--- a/packages/core/src/Label/Label.stories.js
+++ b/packages/core/src/Label/Label.stories.js
@@ -1,77 +1,106 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Label, Input, Radio, Flex } from '..'
 
-storiesOf('Label', module)
-  .add(
-    'Label component',
-    withInfo({
-      inline: true,
-      text:
-        'Simple styled label component that supports a number of the styled-system props.',
-    })(() => <Label m={3}>Label Component</Label>)
-  )
-  .add('Using fontSize', () => (
-    <div>
-      <Label fontSize={6}>Label with fontSize 6</Label>
-      <Label fontSize={5}>Label with fontSize 5</Label>
-      <Label fontSize={4}>Label with fontSize 4</Label>
-      <Label fontSize={3}>Label with fontSize 3</Label>
-      <Label fontSize={2}>Label with fontSize 2</Label>
-      <Label fontSize={1}>Label with fontSize 1</Label>
-      <Label fontSize={0}>Label with fontSize 0</Label>
-    </div>
-  ))
-  .add('Spacing', () => (
-    <div>
-      <Label mt={4} mb={2}>
-        A tish of margin
-      </Label>
-      <Label pl={3}>A dash of padding</Label>
-    </div>
-  ))
-  .add('color', () => (
-    <div>
-      <Label color='blue'>A blue label</Label>
-      <Label color='green'>a green label</Label>
-    </div>
-  ))
-  .add('htmlFor', () => (
-    <div>
-      Clicking{' '}
-      <Label fontSize={4} htmlFor='sample-input'>
-        here
-      </Label>{' '}
-      should focus on the input element.
-      <br />
-      <Input id='sample-input' />
-    </div>
-  ))
-  .add('nowrap', () => (
-    <Flex>
-      <Label nowrap>
-        <Radio checked />
-        Round-trip
-      </Label>
-      <Label nowrap>
-        <Radio checked />
-        One-way
-      </Label>
-      <Label nowrap>
-        <Radio checked />
-        Multi-destination
-      </Label>
-    </Flex>
-  ))
-  .add('width', () => (
-    <div>
-      <Label width={1 / 2} color='blue'>
-        label with 50% width
-      </Label>
-      <Label width='20px' color='green'>
-        label with 20px width
-      </Label>
-      <Label color='orange'>default label width</Label>
-    </div>
-  ))
+export default {
+  title: 'Label',
+  component: Label,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Simple styled label component that supports a number of the styled-system props.',
+      },
+    },
+  },
+}
+
+export const LabelComponent = () => <Label m={3}>Label Component</Label>
+
+export const UsingFontSize = () => (
+  <div>
+    <Label fontSize={6}>Label with fontSize 6</Label>
+    <Label fontSize={5}>Label with fontSize 5</Label>
+    <Label fontSize={4}>Label with fontSize 4</Label>
+    <Label fontSize={3}>Label with fontSize 3</Label>
+    <Label fontSize={2}>Label with fontSize 2</Label>
+    <Label fontSize={1}>Label with fontSize 1</Label>
+    <Label fontSize={0}>Label with fontSize 0</Label>
+  </div>
+)
+
+UsingFontSize.story = {
+  name: 'Using fontSize',
+}
+
+export const Spacing = () => (
+  <div>
+    <Label mt={4} mb={2}>
+      A tish of margin
+    </Label>
+    <Label pl={3}>A dash of padding</Label>
+  </div>
+)
+
+export const Color = () => (
+  <div>
+    <Label color='blue'>A blue label</Label>
+    <Label color='green'>a green label</Label>
+  </div>
+)
+
+Color.story = {
+  name: 'color',
+}
+
+export const HtmlFor = () => (
+  <div>
+    Clicking{' '}
+    <Label fontSize={4} htmlFor='sample-input'>
+      here
+    </Label>{' '}
+    should focus on the input element.
+    <br />
+    <Input id='sample-input' />
+  </div>
+)
+
+HtmlFor.story = {
+  name: 'htmlFor',
+}
+
+export const Nowrap = () => (
+  <Flex>
+    <Label nowrap>
+      <Radio checked />
+      Round-trip
+    </Label>
+    <Label nowrap>
+      <Radio checked />
+      One-way
+    </Label>
+    <Label nowrap>
+      <Radio checked />
+      Multi-destination
+    </Label>
+  </Flex>
+)
+
+Nowrap.story = {
+  name: 'nowrap',
+}
+
+export const Width = () => (
+  <div>
+    <Label width={1 / 2} color='blue'>
+      label with 50% width
+    </Label>
+    <Label width='20px' color='green'>
+      label with 20px width
+    </Label>
+    <Label color='orange'>default label width</Label>
+  </div>
+)
+
+Width.story = {
+  name: 'width',
+}

--- a/packages/core/src/Link/Link.stories.js
+++ b/packages/core/src/Link/Link.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Cartesian } from '@compositor/kit'
 
@@ -25,53 +24,73 @@ const colors = {
   background: 'background',
 }
 
-storiesOf('Link', module)
-  .add('Link component', () => (
-    <Link href='https://www.priceline.com/home/' target='_blank'>
-      Priceline Home
-    </Link>
-  ))
-  .add('Link open self', () => (
-    <Link href='https://www.priceline.com/home/' target='_self'>
-      Open the Priceline Home in the same window
-    </Link>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Link color='text.dark' ref={dsRef}>
-            I am a link!
-          </Link>
-          <br />
-          <Button
-            color='error'
-            onClick={() => (dsRef.current.innerHTML = 'Bacon!')}
-            mt={4}
-          >
-            Click to update link text via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
-  .add('Color', () => (
-    <div>
-      <Link color='text.dark'>I am a different color!</Link>
-      <br />
-      <Link color='secondary'>I am a different color!</Link>
-      <br />
-      <Link color='error'>I am a different color!</Link>
-    </div>
-  ))
-  .add('All', () => (
-    <Cartesian
-      component={Link}
-      color={Object.keys(colors)}
-      variation={Object.keys(variations)}
-      onClick={action('Clicked button in All')}
-      m={3}
-    >
-      Link Text
-    </Cartesian>
-  ))
+export default {
+  title: 'Link',
+  component: Link,
+}
+
+export const LinkComponent = () => (
+  <Link href='https://www.priceline.com/home/' target='_blank'>
+    Priceline Home
+  </Link>
+)
+
+LinkComponent.story = {
+  name: 'Link component',
+}
+
+export const LinkOpenSelf = () => (
+  <Link href='https://www.priceline.com/home/' target='_self'>
+    Open the Priceline Home in the same window
+  </Link>
+)
+
+LinkOpenSelf.story = {
+  name: 'Link open self',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Link color='text.dark' ref={dsRef}>
+          I am a link!
+        </Link>
+        <br />
+        <Button
+          color='error'
+          onClick={() => (dsRef.current.innerHTML = 'Bacon!')}
+          mt={4}
+        >
+          Click to update link text via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}
+
+export const Color = () => (
+  <div>
+    <Link color='text.dark'>I am a different color!</Link>
+    <br />
+    <Link color='secondary'>I am a different color!</Link>
+    <br />
+    <Link color='error'>I am a different color!</Link>
+  </div>
+)
+
+export const All = () => (
+  <Cartesian
+    component={Link}
+    color={Object.keys(colors)}
+    variation={Object.keys(variations)}
+    onClick={action('Clicked button in All')}
+    m={3}
+  >
+    Link Text
+  </Cartesian>
+)

--- a/packages/core/src/Radio/Radio.stories.js
+++ b/packages/core/src/Radio/Radio.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
 
@@ -58,36 +57,54 @@ class MockForm extends React.Component {
   }
 }
 
-storiesOf('Radio', module)
-  .add('3 states', () => (
-    <div onChange={action('changed')}>
-      <Label fontSize='14px'>
-        <Radio checked />
-        <LabelText>selected</LabelText>
-      </Label>
-      <Label fontSize='14px'>
-        <Radio />
-        <LabelText>not selected</LabelText>
-      </Label>
-      <Label fontSize='14px'>
-        <Radio disabled />
-        <LabelText>disabled</LabelText>
-      </Label>
-    </div>
-  ))
-  .add('Mock form', () => <MockForm />)
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Label fontSize='14px'>
-            <Radio checked dsRef={dsRef} />
-            <LabelText>selected</LabelText>
-          </Label>
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus radio via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+export default {
+  title: 'Radio',
+  component: Radio,
+}
+
+export const _3States = () => (
+  <div onChange={action('changed')}>
+    <Label fontSize='14px'>
+      <Radio checked />
+      <LabelText>selected</LabelText>
+    </Label>
+    <Label fontSize='14px'>
+      <Radio />
+      <LabelText>not selected</LabelText>
+    </Label>
+    <Label fontSize='14px'>
+      <Radio disabled />
+      <LabelText>disabled</LabelText>
+    </Label>
+  </div>
+)
+
+_3States.story = {
+  name: '3 states',
+}
+
+export const _MockForm = () => <MockForm />
+
+_MockForm.story = {
+  name: 'Mock form',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Label fontSize='14px'>
+          <Radio checked dsRef={dsRef} />
+          <LabelText>selected</LabelText>
+        </Label>
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus radio via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/RatingBadge/RatingBadge.stories.js
+++ b/packages/core/src/RatingBadge/RatingBadge.stories.js
@@ -1,7 +1,13 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { RatingBadge } from '..'
 
-storiesOf('RatingBadge', module).add('default', () => (
-  <RatingBadge>9.0</RatingBadge>
-))
+export default {
+  title: 'RatingBadge',
+  component: RatingBadge,
+}
+
+export const Default = () => <RatingBadge>9.0</RatingBadge>
+
+Default.story = {
+  name: 'default',
+}

--- a/packages/core/src/Relative/Relative.stories.js
+++ b/packages/core/src/Relative/Relative.stories.js
@@ -1,31 +1,43 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Absolute, Card, Flag, Image, Relative, Text } from '..'
 import { Close as CloseIcon } from 'pcln-icons'
 
-storiesOf('Relative', module)
-  .add('Around an Image and an absolutely positioned Flag', () => (
-    <Relative width={1 / 2}>
-      <Absolute top={8} left={0}>
-        <Flag>Hello Flag</Flag>
+export default {
+  title: 'Relative',
+  component: Relative,
+}
+
+export const AroundAnImageAndAnAbsolutelyPositionedFlag = () => (
+  <Relative width={1 / 2}>
+    <Absolute top={8} left={0}>
+      <Flag>Hello Flag</Flag>
+    </Absolute>
+    <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
+  </Relative>
+)
+
+AroundAnImageAndAnAbsolutelyPositionedFlag.story = {
+  name: 'Around an Image and an absolutely positioned Flag',
+}
+
+export const AroundTextAndAnAbsolutelyPositionedIcon = () => (
+  <Card m={2}>
+    <Relative p={4}>
+      <Text mt={2} textAlign='justify'>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et nisl
+        dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+        quis nisi ac est elementum consequat a eu risus. Phasellus id facilisis
+        nulla. Aliquam vel semper enim, id lobortis dolor. Morbi sed leo at
+        turpis rutrum posuere. Nullam tincidunt ex vitae mi sagittis, vel
+        sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
+      </Text>
+      <Absolute top='10px' right='10px'>
+        <CloseIcon color='text.base' size={24} />
       </Absolute>
-      <Image src='https://www.priceline.com/home/public/assets/images/photos/photo-aruba.jpg' />
     </Relative>
-  ))
-  .add('Around Text and an absolutely positioned Icon', () => (
-    <Card m={2}>
-      <Relative p={4}>
-        <Text mt={2} textAlign='justify'>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et
-          nisl dolor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          Donec quis nisi ac est elementum consequat a eu risus. Phasellus id
-          facilisis nulla. Aliquam vel semper enim, id lobortis dolor. Morbi sed
-          leo at turpis rutrum posuere. Nullam tincidunt ex vitae mi sagittis,
-          vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
-        </Text>
-        <Absolute top='10px' right='10px'>
-          <CloseIcon color='text.base' size={24} />
-        </Absolute>
-      </Relative>
-    </Card>
-  ))
+  </Card>
+)
+
+AroundTextAndAnAbsolutelyPositionedIcon.story = {
+  name: 'Around Text and an absolutely positioned Icon',
+}

--- a/packages/core/src/Select/Select.stories.js
+++ b/packages/core/src/Select/Select.stories.js
@@ -1,61 +1,83 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 
 import { Select, Label, Box, Button } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('Select', module)
-  .add('default', () => (
-    <Box>
-      <Label htmlFor='cabinClass'>Cabin Class</Label>
-      <Select id='cabinClass' name='cabinClass' defaultValue='Premium Economy'>
-        <option>Economy</option>
-        <option>Premium Economy</option>
-        <option>Business</option>
-        <option>First Class</option>
-        <option>
-          With a super long label that does not get clobbered by the chevron
-        </option>
-      </Select>
-    </Box>
-  ))
-  .add('long option string', () => (
-    <Box width={[1, 320]}>
-      <Label htmlFor='cabinClass'>Cabin Class</Label>
-      <Select id='cabinClass' name='cabinClass' defaultValue=''>
-        <option>
-          With a super long label that does not collide with the chevron
-        </option>
-      </Select>
-    </Box>
-  ))
-  .add('hidden label', () => (
-    <Box width={[1, 320]}>
-      <Label hidden htmlFor='cabinClass'>
-        Cabin Class
-      </Label>
-      <Select id='cabinClass' name='cabinClass' defaultValue=''>
-        <option>Economy</option>
-        <option>Premium Economy</option>
-        <option>Business</option>
-        <option>First Class</option>
-      </Select>
-    </Box>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <Select id='cabinClass' name='cabinClass' defaultValue='' ref={dsRef}>
-            <option>Economy</option>
-            <option>Premium Economy</option>
-            <option>Business</option>
-            <option>First Class</option>
-          </Select>
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus select via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+export default {
+  title: 'Select',
+  component: Select,
+}
+
+export const Default = () => (
+  <Box>
+    <Label htmlFor='cabinClass'>Cabin Class</Label>
+    <Select id='cabinClass' name='cabinClass' defaultValue='Premium Economy'>
+      <option>Economy</option>
+      <option>Premium Economy</option>
+      <option>Business</option>
+      <option>First Class</option>
+      <option>
+        With a super long label that does not get clobbered by the chevron
+      </option>
+    </Select>
+  </Box>
+)
+
+Default.story = {
+  name: 'default',
+}
+
+export const LongOptionString = () => (
+  <Box width={[1, 320]}>
+    <Label htmlFor='cabinClass'>Cabin Class</Label>
+    <Select id='cabinClass' name='cabinClass' defaultValue=''>
+      <option>
+        With a super long label that does not collide with the chevron
+      </option>
+    </Select>
+  </Box>
+)
+
+LongOptionString.story = {
+  name: 'long option string',
+}
+
+export const HiddenLabel = () => (
+  <Box width={[1, 320]}>
+    <Label hidden htmlFor='cabinClass'>
+      Cabin Class
+    </Label>
+    <Select id='cabinClass' name='cabinClass' defaultValue=''>
+      <option>Economy</option>
+      <option>Premium Economy</option>
+      <option>Business</option>
+      <option>First Class</option>
+    </Select>
+  </Box>
+)
+
+HiddenLabel.story = {
+  name: 'hidden label',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <Select id='cabinClass' name='cabinClass' defaultValue='' ref={dsRef}>
+          <option>Economy</option>
+          <option>Premium Economy</option>
+          <option>Business</option>
+          <option>First Class</option>
+        </Select>
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus select via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/SrOnly/SrOnly.stories.js
+++ b/packages/core/src/SrOnly/SrOnly.stories.js
@@ -1,11 +1,15 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { SrOnly, Text, BackgroundImage, Box } from '..'
 
 const image =
   'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=aee8a50c86478d935556d865624506e4'
 
-storiesOf('SrOnly', module).add('Screenreader description of content', () => (
+export default {
+  title: 'SrOnly',
+  component: SrOnly,
+}
+
+export const ScreenreaderDescriptionOfContent = () => (
   <Box>
     <SrOnly>
       <Text>
@@ -16,4 +20,8 @@ storiesOf('SrOnly', module).add('Screenreader description of content', () => (
     <BackgroundImage image={image} width='320px' height={'200px'} />
     <Text pt={2}>Turn ON screenreader...</Text>
   </Box>
-))
+)
+
+ScreenreaderDescriptionOfContent.story = {
+  name: 'Screenreader description of content',
+}

--- a/packages/core/src/Stamp/Stamp.js
+++ b/packages/core/src/Stamp/Stamp.js
@@ -76,10 +76,7 @@ Stamp.displayName = 'Stamp'
 Stamp.propTypes = {
   ...space.propTypes,
   ...fontSize.propTypes,
-  size: PropTypes.oneOfType([
-    Object.keys(sizes),
-    PropTypes.arrayOf(Object.keys(sizes)),
-  ]),
+  size: PropTypes.oneOfType([PropTypes.arrayOf(Object.keys(sizes))]),
   variation: PropTypes.oneOf(Object.keys(variations)),
   color: deprecatedColorValue(),
   bg: deprecatedPropType('color'),

--- a/packages/core/src/Stamp/Stamp.stories.js
+++ b/packages/core/src/Stamp/Stamp.stories.js
@@ -1,7 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Cartesian } from '@compositor/kit'
 
 import { Stamp, Text } from '..'
@@ -34,92 +32,102 @@ const BlueStamp = styled(Stamp).attrs({
   mr: 2,
 })``
 
-storiesOf('Stamp', module)
-  .add(
-    'Default Stamp',
-    withInfo({
-      inline: true,
-      text:
-        'Use the <Stamp /> component to subtly display attributes alongside listing cells and on product detail pages. Use it in conjunction with a named `pcln-icons` icon component to give it more context. An icon placed within a Stamp will inherit the assigned Stamp color.',
-    })(() => <Stamp>default stamp</Stamp>)
-  )
-  .add('All', () => (
-    <Cartesian
-      component={Stamp}
-      color={Object.keys(colors)}
-      variation={Object.keys(variations)}
-      size={Object.keys(sizes)}
-      m={3}
+export default {
+  title: 'Stamp',
+  component: Stamp,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Use the <Stamp /> component to subtly display attributes alongside listing cells and on product detail pages. Use it in conjunction with a named `pcln-icons` icon component to give it more context. An icon placed within a Stamp will inherit the assigned Stamp color.',
+      },
+    },
+  },
+}
+
+export const All = () => (
+  <Cartesian
+    component={Stamp}
+    color={Object.keys(colors)}
+    variation={Object.keys(variations)}
+    size={Object.keys(sizes)}
+    m={3}
+  >
+    <>
+      <PinIcon mr={1} /> top location
+    </>
+  </Cartesian>
+)
+
+export const CustomBackgroundAndBorderColor = () => (
+  <div>
+    <Stamp
+      color='background.lightest'
+      bg='primary'
+      borderColor='primary'
+      mr={2}
     >
-      <>
-        <PinIcon mr={1} /> top location
-      </>
-    </Cartesian>
-  ))
-  .add('Custom Background and Border Color', () => (
-    <div>
-      <Stamp
-        color='background.lightest'
-        bg='primary'
-        borderColor='primary'
-        mr={2}
-      >
-        custom border and background
-      </Stamp>
-      <Stamp
-        color='error'
-        bg='background.lightest'
-        borderColor='primary'
-        mr={2}
-      >
-        custom border and background
-      </Stamp>
-    </div>
-  ))
-  .add('Custom Text Size', () => (
-    <div>
-      <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
-        <Text fontSize={0}>Yorkie</Text>
-      </Stamp>
-      <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
-        <Text fontSize={1}>Jack Russell</Text>
-      </Stamp>
-      <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
-        <Text fontSize={2}>Golden Retriever</Text>
-      </Stamp>
-      <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
-        <Text fontSize={3}>Doberman</Text>
-      </Stamp>
-      <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
-        <Text fontSize={4}>Malamute</Text>
-      </Stamp>
-    </div>
-  ))
-  .add('Pass an array of sizes', () => (
-    <div>
-      <BlueStamp size={['medium', null, null, null, null, null]}>
-        <PinIcon pr={1} />
-        <Text>Larger at xs</Text>
-      </BlueStamp>
-      <BlueStamp size={['small', 'medium', null, null, null, null]}>
-        <PinIcon pr={1} />
-        <Text>Larger at sm</Text>
-      </BlueStamp>
-      <BlueStamp size={['small', null, 'medium', null, null, null]}>
-        <PinIcon pr={1} />
-        <Text>Larger at md</Text>
-      </BlueStamp>
-      <BlueStamp size={['small', 'small', null, 'medium', null, null]}>
-        <PinIcon pr={1} />
-        <Text>Larger at lg</Text>
-      </BlueStamp>
-      <BlueStamp size={['small', null, null, null, 'medium', null]}>
-        <PinIcon pr={1} />
-        <Text>Larger at xl</Text>
-      </BlueStamp>
-      <BlueStamp size={['small', null, null, null, null, 'medium']}>
-        <PinIcon pr={1} />
-        <Text>Larger at xxl</Text>
-      </BlueStamp>
-    </div>
-  ))
+      custom border and background
+    </Stamp>
+    <Stamp color='error' bg='background.lightest' borderColor='primary' mr={2}>
+      custom border and background
+    </Stamp>
+  </div>
+)
+
+CustomBackgroundAndBorderColor.story = {
+  name: 'Custom Background and Border Color',
+}
+
+export const CustomTextSize = () => (
+  <div>
+    <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
+      <Text fontSize={0}>Yorkie</Text>
+    </Stamp>
+    <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
+      <Text fontSize={1}>Jack Russell</Text>
+    </Stamp>
+    <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
+      <Text fontSize={2}>Golden Retriever</Text>
+    </Stamp>
+    <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
+      <Text fontSize={3}>Doberman</Text>
+    </Stamp>
+    <Stamp color='white' bg='blue' borderColor='blue' mr={2}>
+      <Text fontSize={4}>Malamute</Text>
+    </Stamp>
+  </div>
+)
+
+export const PassAnArrayOfSizes = () => (
+  <div>
+    <BlueStamp size={['medium', null, null, null, null, null]}>
+      <PinIcon pr={1} />
+      <Text>Larger at xs</Text>
+    </BlueStamp>
+    <BlueStamp size={['small', 'medium', null, null, null, null]}>
+      <PinIcon pr={1} />
+      <Text>Larger at sm</Text>
+    </BlueStamp>
+    <BlueStamp size={['small', null, 'medium', null, null, null]}>
+      <PinIcon pr={1} />
+      <Text>Larger at md</Text>
+    </BlueStamp>
+    <BlueStamp size={['small', 'small', null, 'medium', null, null]}>
+      <PinIcon pr={1} />
+      <Text>Larger at lg</Text>
+    </BlueStamp>
+    <BlueStamp size={['small', null, null, null, 'medium', null]}>
+      <PinIcon pr={1} />
+      <Text>Larger at xl</Text>
+    </BlueStamp>
+    <BlueStamp size={['small', null, null, null, null, 'medium']}>
+      <PinIcon pr={1} />
+      <Text>Larger at xxl</Text>
+    </BlueStamp>
+  </div>
+)
+
+PassAnArrayOfSizes.story = {
+  name: 'Pass an array of sizes',
+}

--- a/packages/core/src/Step/Step.stories.js
+++ b/packages/core/src/Step/Step.stories.js
@@ -1,25 +1,39 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { action } from '@storybook/addon-actions'
 
 import { Step } from '.'
 
 const onClick = action('Step Clicked')
 
-storiesOf('Step', module)
-  .add(
-    'Step component',
-    withInfo({
-      inline: true,
-      text: 'Use the <Stepper.Step /> component to render a step.',
-    })(() => <Step>Step</Step>)
-  )
-  .add('Current Step', () => <Step active>Step</Step>)
-  .add('Completed Step', () => <Step completed>Step</Step>)
-  .add('Current and Completed Step', () => (
-    <Step active completed>
-      Step
-    </Step>
-  ))
-  .add('Clickable Step', () => <Step onClick={onClick}>Step</Step>)
+export default {
+  title: 'Step',
+  component: Step,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Use the <Stepper.Step /> component to render a step.',
+      },
+    },
+  },
+}
+
+export const StepComponent = () => <Step>Step</Step>
+
+StepComponent.story = {
+  name: 'Step component',
+}
+
+export const CurrentStep = () => <Step active>Step</Step>
+export const CompletedStep = () => <Step completed>Step</Step>
+
+export const CurrentAndCompletedStep = () => (
+  <Step active completed>
+    Step
+  </Step>
+)
+
+CurrentAndCompletedStep.story = {
+  name: 'Current and Completed Step',
+}
+
+export const ClickableStep = () => <Step onClick={onClick}>Step</Step>

--- a/packages/core/src/Stepper/Stepper.stories.js
+++ b/packages/core/src/Stepper/Stepper.stories.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { action } from '@storybook/addon-actions'
 import { Stepper } from '..'
 
@@ -16,10 +14,16 @@ const children = (
   </React.Fragment>
 )
 
-storiesOf('Stepper', module).add(
-  'Stepper component',
-  withInfo({
-    inline: true,
-    text: 'Use the <Stepper> component to render a stepper.',
-  })(() => <Stepper>{children}</Stepper>)
-)
+export default {
+  title: 'Stepper',
+  component: Stepper,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Use the <Stepper> component to render a stepper.',
+      },
+    },
+  },
+}
+
+export const Default = () => <Stepper>{children}</Stepper>

--- a/packages/core/src/Text/Text.stories.js
+++ b/packages/core/src/Text/Text.stories.js
@@ -1,73 +1,131 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 import { Text } from '..'
 
-storiesOf('Text', module)
-  .add(
-    'Typography component',
-    withInfo({
-      inline: true,
-      text:
-        'A low-level component for setting font-size, typographic styles, margin, and color',
-    })(() => <Text m={3}>Hello</Text>)
-  )
-  .add('fontSize', () => (
-    <div>
-      <Text fontSize={6}>Hello 6</Text>
-      <Text fontSize={5}>Hello 5</Text>
-      <Text fontSize={4}>Hello 4</Text>
-      <Text fontSize={3}>Hello 3</Text>
-      <Text fontSize={2}>Hello 2</Text>
-      <Text fontSize={1}>Hello 1</Text>
-      <Text fontSize={0}>Hello 0</Text>
-    </div>
-  ))
-  .add('textAlign', () => (
-    <div>
-      <Text textAlign='left'>Hello Left</Text>
-      <Text textAlign='center'>Hello Center</Text>
-      <Text textAlign='right'>Hello Right</Text>
-    </div>
-  ))
-  .add('regular', () => <Text regular>Hello Regular</Text>)
-  .add('bold', () => <Text bold>Hello Bold</Text>)
-  .add('caps', () => <Text caps>Hello Caps</Text>)
-  .add('italic', () => <Text italic>Hello italic</Text>)
-  .add('strikethrough', () => <Text.s>Hello Strikethrough</Text.s>)
-  .add('margin', () => (
-    <Text mt={4} mb={2}>
-      Hello Margin
+export default {
+  title: 'Text',
+  component: Text,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A low-level component for setting font-size, typographic styles, margin, and color',
+      },
+    },
+  },
+}
+
+export const TypographyComponent = () => <Text m={3}>Hello</Text>
+
+export const FontSize = () => (
+  <div>
+    <Text fontSize={6}>Hello 6</Text>
+    <Text fontSize={5}>Hello 5</Text>
+    <Text fontSize={4}>Hello 4</Text>
+    <Text fontSize={3}>Hello 3</Text>
+    <Text fontSize={2}>Hello 2</Text>
+    <Text fontSize={1}>Hello 1</Text>
+    <Text fontSize={0}>Hello 0</Text>
+  </div>
+)
+
+FontSize.story = {
+  name: 'fontSize',
+}
+
+export const TextAlign = () => (
+  <div>
+    <Text textAlign='left'>Hello Left</Text>
+    <Text textAlign='center'>Hello Center</Text>
+    <Text textAlign='right'>Hello Right</Text>
+  </div>
+)
+
+TextAlign.story = {
+  name: 'textAlign',
+}
+
+export const Regular = () => <Text regular>Hello Regular</Text>
+
+Regular.story = {
+  name: 'regular',
+}
+
+export const Bold = () => <Text bold>Hello Bold</Text>
+
+Bold.story = {
+  name: 'bold',
+}
+
+export const Caps = () => <Text caps>Hello Caps</Text>
+
+Caps.story = {
+  name: 'caps',
+}
+
+export const Italic = () => <Text italic>Hello italic</Text>
+
+Italic.story = {
+  name: 'italic',
+}
+
+export const Strikethrough = () => <Text.s>Hello Strikethrough</Text.s>
+
+Strikethrough.story = {
+  name: 'strikethrough',
+}
+
+export const Margin = () => (
+  <Text mt={4} mb={2}>
+    Hello Margin
+  </Text>
+)
+
+Margin.story = {
+  name: 'margin',
+}
+
+export const Color = () => (
+  <div>
+    <Text color='blue'>Hello Blue</Text>
+    <Text color='green'>Hello Green</Text>
+  </div>
+)
+
+Color.story = {
+  name: 'color',
+}
+
+export const MinMaxHeight = () => (
+  <div>
+    <Text color='blue' minHeight={200} minWidth={300} width={1}>
+      Hello Blue
     </Text>
-  ))
-  .add('color', () => (
-    <div>
-      <Text color='blue'>Hello Blue</Text>
-      <Text color='green'>Hello Green</Text>
-    </div>
-  ))
-  .add('min/maxHeight', () => (
-    <div>
-      <Text color='blue' minHeight={200} minWidth={300} width={1}>
-        Hello Blue
-      </Text>
-      <Text color='green' maxHeight={200} maxWidth={300}>
-        Hello Green
-      </Text>
-    </div>
-  ))
-  .add('Hide on > lg breakpoints', () => (
-    <div>
-      <Text
-        color='primary'
-        display={[null, null, null, 'none']}
-        fontSize={4}
-        width={1}
-      >
-        Hidden text on larger screens
-      </Text>
-      <Text color='secondary' fontSize={4} width={1}>
-        I am always show. But the text above, hides on larger screens.
-      </Text>
-    </div>
-  ))
+    <Text color='green' maxHeight={200} maxWidth={300}>
+      Hello Green
+    </Text>
+  </div>
+)
+
+MinMaxHeight.story = {
+  name: 'min/maxHeight',
+}
+
+export const HideOnLgBreakpoints = () => (
+  <div>
+    <Text
+      color='primary'
+      display={[null, null, null, 'none']}
+      fontSize={4}
+      width={1}
+    >
+      Hidden text on larger screens
+    </Text>
+    <Text color='secondary' fontSize={4} width={1}>
+      I am always show. But the text above, hides on larger screens.
+    </Text>
+  </div>
+)
+
+HideOnLgBreakpoints.story = {
+  name: 'Hide on > lg breakpoints',
+}

--- a/packages/core/src/TextArea/TextArea.stories.js
+++ b/packages/core/src/TextArea/TextArea.stories.js
@@ -1,73 +1,79 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 
 import { Box, TextArea, Label, Button } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('TextArea', module)
-  .add(
-    'TextArea component',
-    withInfo({
-      inline: true,
-      text: 'Simple styled textarea component that accepts a color.',
-    })(() => <TextArea id='textarea-default' my={3} />)
-  )
-  .add('Colors', () => (
-    <Box width={400}>
-      <TextArea mb={3} id='textarea-colors-1' placeholder='No color' />
-      <TextArea
-        mb={3}
-        id='textarea-colors-2'
-        color='primary'
-        placeholder='Primary'
-      />
-      <TextArea
-        mb={3}
-        id='textarea-colors-3'
-        color='secondary'
-        placeholder='Secondary'
-      />
-      <TextArea
-        mb={3}
-        id='textarea-colors-4'
-        color='warning'
-        placeholder='Warning'
-      />
-      <TextArea
-        mb={3}
-        id='textarea-colors-5'
-        color='alert'
-        placeholder='Alert'
-      />
-      <TextArea
-        mb={3}
-        id='textarea-colors-6'
-        color='caution'
-        placeholder='Caution'
-      />
-    </Box>
-  ))
-  .add('With external label', () => (
-    <Box width={400}>
-      <Label fontSize={4} htmlFor='sample-textarea'>
-        Label!
-      </Label>
-      <TextArea id='sample-textarea' placeholder='Click the label' />
-    </Box>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <TextArea ref={dsRef} value='Sad Panda :(' />
-          <Button
-            onClick={() => (dsRef.current.value = 'Happy Panda :D')}
-            mt={4}
-          >
-            Click to change input value via ref
-          </Button>
-        </>
-      )}
+export default {
+  title: 'TextArea',
+  component: TextArea,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Simple styled textarea component that accepts a color.',
+      },
+    },
+  },
+}
+
+export const TextAreaComponent = () => <TextArea id='textarea-default' my={3} />
+
+export const Colors = () => (
+  <Box width={400}>
+    <TextArea mb={3} id='textarea-colors-1' placeholder='No color' />
+    <TextArea
+      mb={3}
+      id='textarea-colors-2'
+      color='primary'
+      placeholder='Primary'
     />
-  ))
+    <TextArea
+      mb={3}
+      id='textarea-colors-3'
+      color='secondary'
+      placeholder='Secondary'
+    />
+    <TextArea
+      mb={3}
+      id='textarea-colors-4'
+      color='warning'
+      placeholder='Warning'
+    />
+    <TextArea mb={3} id='textarea-colors-5' color='alert' placeholder='Alert' />
+    <TextArea
+      mb={3}
+      id='textarea-colors-6'
+      color='caution'
+      placeholder='Caution'
+    />
+  </Box>
+)
+
+export const WithExternalLabel = () => (
+  <Box width={400}>
+    <Label fontSize={4} htmlFor='sample-textarea'>
+      Label!
+    </Label>
+    <TextArea id='sample-textarea' placeholder='Click the label' />
+  </Box>
+)
+
+WithExternalLabel.story = {
+  name: 'With external label',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <TextArea ref={dsRef} value='Sad Panda :(' />
+        <Button onClick={() => (dsRef.current.value = 'Happy Panda :D')} mt={4}>
+          Click to change input value via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/ToggleBadge/ToggleBadge.stories.js
+++ b/packages/core/src/ToggleBadge/ToggleBadge.stories.js
@@ -1,44 +1,65 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
-import { withInfo } from '@storybook/addon-info'
 
 import { Button, ToggleBadge } from '..'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 
-storiesOf('ToggleBadge', module)
-  .add(
-    'ToggleBadge component',
-    withInfo({
-      inline: true,
-      text:
-        'Use the <ToggleBadge /> component to render a primitive ToggleBadge.',
-    })(() => <ToggleBadge>ToggleBadge</ToggleBadge>)
-  )
-  .add('Selected', () => <ToggleBadge selected>Selected - Badge</ToggleBadge>)
-  .add('Unselected', () => <ToggleBadge>Un - Selected - Badge</ToggleBadge>)
-  .add('Unselected with different background color', () => (
-    <ToggleBadge unSelectedBg='yellow'>Un - Selected - Badge</ToggleBadge>
-  ))
-  .add('A group', () => (
-    <div>
-      <ToggleBadge selected>Flight + Hotel</ToggleBadge>
-      <ToggleBadge>Flight + Hotel + Car</ToggleBadge>
-      <ToggleBadge>Flight + Car</ToggleBadge>
-    </div>
-  ))
-  .add('Forward refs', () => (
-    <ForwardRefDemo
-      refChild={(dsRef) => (
-        <>
-          <div>
-            <ToggleBadge selected>Flight + Hotel</ToggleBadge>
-            <ToggleBadge ref={dsRef}>Flight + Hotel + Car</ToggleBadge>
-            <ToggleBadge>Flight + Car</ToggleBadge>
-          </div>
-          <Button onClick={() => dsRef.current.focus()} mt={4}>
-            Click to focus second badge via ref
-          </Button>
-        </>
-      )}
-    />
-  ))
+export default {
+  title: 'ToggleBadge',
+  component: ToggleBadge,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Use the <ToggleBadge /> component to render a primitive ToggleBadge.',
+      },
+    },
+  },
+}
+
+export const ToggleBadgeComponent = () => <ToggleBadge>ToggleBadge</ToggleBadge>
+
+export const Selected = () => (
+  <ToggleBadge selected>Selected - Badge</ToggleBadge>
+)
+export const Unselected = () => <ToggleBadge>Un - Selected - Badge</ToggleBadge>
+
+export const UnselectedWithDifferentBackgroundColor = () => (
+  <ToggleBadge unSelectedBg='yellow'>Un - Selected - Badge</ToggleBadge>
+)
+
+UnselectedWithDifferentBackgroundColor.story = {
+  name: 'Unselected with different background color',
+}
+
+export const AGroup = () => (
+  <div>
+    <ToggleBadge selected>Flight + Hotel</ToggleBadge>
+    <ToggleBadge>Flight + Hotel + Car</ToggleBadge>
+    <ToggleBadge>Flight + Car</ToggleBadge>
+  </div>
+)
+
+AGroup.story = {
+  name: 'A group',
+}
+
+export const ForwardRefs = () => (
+  <ForwardRefDemo
+    refChild={(dsRef) => (
+      <>
+        <div>
+          <ToggleBadge selected>Flight + Hotel</ToggleBadge>
+          <ToggleBadge ref={dsRef}>Flight + Hotel + Car</ToggleBadge>
+          <ToggleBadge>Flight + Car</ToggleBadge>
+        </div>
+        <Button onClick={() => dsRef.current.focus()} mt={4}>
+          Click to focus second badge via ref
+        </Button>
+      </>
+    )}
+  />
+)
+
+ForwardRefs.story = {
+  name: 'Forward refs',
+}

--- a/packages/core/src/Tooltip/Tooltip.stories.js
+++ b/packages/core/src/Tooltip/Tooltip.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Tooltip, InputField, Box, Flex } from '..'
 import styled from 'styled-components'
 
@@ -7,121 +6,126 @@ const FlexColumn = styled(Flex)`
   flex-direction: column;
 `
 
-storiesOf('Tooltip', module)
-  .add('Without Anchors', () => (
-    <Box mt={5} width={500}>
-      <Tooltip bg='blue' color='white' top left>
-        left tooltip
+export default {
+  title: 'Tooltip',
+  component: Tooltip,
+}
+
+export const WithoutAnchors = () => (
+  <Box mt={5} width={500}>
+    <Tooltip bg='blue' color='white' top left>
+      left tooltip
+    </Tooltip>
+    <Tooltip bg='black' color='white' top center>
+      centered tooltip
+    </Tooltip>
+    <Tooltip bg='red' color='white' top right>
+      right tooltip
+    </Tooltip>
+    <br />
+    <Tooltip bottom left>
+      left tooltip
+    </Tooltip>
+    <Tooltip bottom center>
+      centered tooltip
+    </Tooltip>
+    <Tooltip bottom right>
+      right tooltip
+    </Tooltip>
+  </Box>
+)
+
+export const WithAnchors = () => (
+  <FlexColumn justifyContent='space-between' wrap='wrap'>
+    <Box width={300} p={2} my={2}>
+      <Tooltip top left bg='blue' color='white'>
+        top left tooltip
       </Tooltip>
-      <Tooltip bg='black' color='white' top center>
-        centered tooltip
-      </Tooltip>
-      <Tooltip bg='red' color='white' top right>
-        right tooltip
-      </Tooltip>
-      <br />
-      <Tooltip bottom left>
-        left tooltip
-      </Tooltip>
-      <Tooltip bottom center>
-        centered tooltip
-      </Tooltip>
-      <Tooltip bottom right>
-        right tooltip
+      <div>some text</div>
+    </Box>
+    <Box width={'300px'} p={2} mb={5}>
+      <div>some text</div>
+      <Tooltip bottom left bg='red' color='white'>
+        bottom left tooltip
       </Tooltip>
     </Box>
-  ))
-  .add('With Anchors', () => (
-    <FlexColumn justifyContent='space-between' wrap='wrap'>
-      <Box width={300} p={2} my={2}>
-        <Tooltip top left bg='blue' color='white'>
-          top left tooltip
-        </Tooltip>
-        <div>some text</div>
-      </Box>
-      <Box width={'300px'} p={2} mb={5}>
-        <div>some text</div>
-        <Tooltip bottom left bg='red' color='white'>
-          bottom left tooltip
-        </Tooltip>
-      </Box>
-      <Box width={'300px'} p={2} mb={55}>
-        <InputField
-          icon='circleInfo'
-          color='blue'
-          label='Email Address'
-          defaultValue='albus.dumbledore@priceline.com'
-          id='form-field-3'
-          placeholder='example@test.com'
-        />
-        <Tooltip bottom left bg='blue' color='white'>
-          bottom left tooltip
-        </Tooltip>
-      </Box>
-      <Box width={'300px'} p={2} mb={5}>
-        <InputField
-          icon='circleInfo'
-          color='blue'
-          label='Email Address'
-          defaultValue='albus.dumbledore@priceline.com'
-          id='form-field-4'
-          placeholder='example@test.com'
-        />
-        <Tooltip bottom center bg='blue' color='white'>
-          bottom center tooltip
-        </Tooltip>
-      </Box>
-      <Box width={'300px'} p={2} mb={'80px'}>
-        <InputField
-          icon='circleInfo'
-          color='red'
-          label='Email Address'
-          defaultValue='albus.dumbledore@pr'
-          id='form-field-5'
-          placeholder='example@test.com'
-        />
-        <Tooltip bottom right bg='red' color='white'>
-          Email Address Invalid
-        </Tooltip>
-      </Box>
-      <Box width={'300px'} p={2} mb={5}>
-        <Tooltip top left bg='blue' color='white'>
-          top left tooltip
-        </Tooltip>
-        <InputField
-          icon='circleInfo'
-          color='blue'
-          label='Email Address'
-          defaultValue='albus.dumbledore@priceline.com'
-          id='form-field-6'
-          placeholder='example@test.com'
-        />
-      </Box>
-      <Box width={'300px'} p={2} mb={5}>
-        <Tooltip top center bg='blue' color='white'>
-          top center tooltip
-        </Tooltip>
-        <InputField
-          icon='circleInfo'
-          color='blue'
-          label='Email Address'
-          defaultValue='albus.dumbledore@priceline.com'
-          id='form-field-7'
-          placeholder='example@test.com'
-        />
-      </Box>
-      <Box width={'300px'} p={2}>
-        <Tooltip top right bg='blue' color='white'>
-          top right tooltip
-        </Tooltip>
-        <InputField
-          icon='circleInfo'
-          color='blue'
-          label='Email Address'
-          defaultValue='albus.dumbledore@priceline.com'
-          id='form-field-8'
-          placeholder='example@test.com'
-        />
-      </Box>
-    </FlexColumn>
-  ))
+    <Box width={'300px'} p={2} mb={55}>
+      <InputField
+        icon='circleInfo'
+        color='blue'
+        label='Email Address'
+        defaultValue='albus.dumbledore@priceline.com'
+        id='form-field-3'
+        placeholder='example@test.com'
+      />
+      <Tooltip bottom left bg='blue' color='white'>
+        bottom left tooltip
+      </Tooltip>
+    </Box>
+    <Box width={'300px'} p={2} mb={5}>
+      <InputField
+        icon='circleInfo'
+        color='blue'
+        label='Email Address'
+        defaultValue='albus.dumbledore@priceline.com'
+        id='form-field-4'
+        placeholder='example@test.com'
+      />
+      <Tooltip bottom center bg='blue' color='white'>
+        bottom center tooltip
+      </Tooltip>
+    </Box>
+    <Box width={'300px'} p={2} mb={'80px'}>
+      <InputField
+        icon='circleInfo'
+        color='red'
+        label='Email Address'
+        defaultValue='albus.dumbledore@pr'
+        id='form-field-5'
+        placeholder='example@test.com'
+      />
+      <Tooltip bottom right bg='red' color='white'>
+        Email Address Invalid
+      </Tooltip>
+    </Box>
+    <Box width={'300px'} p={2} mb={5}>
+      <Tooltip top left bg='blue' color='white'>
+        top left tooltip
+      </Tooltip>
+      <InputField
+        icon='circleInfo'
+        color='blue'
+        label='Email Address'
+        defaultValue='albus.dumbledore@priceline.com'
+        id='form-field-6'
+        placeholder='example@test.com'
+      />
+    </Box>
+    <Box width={'300px'} p={2} mb={5}>
+      <Tooltip top center bg='blue' color='white'>
+        top center tooltip
+      </Tooltip>
+      <InputField
+        icon='circleInfo'
+        color='blue'
+        label='Email Address'
+        defaultValue='albus.dumbledore@priceline.com'
+        id='form-field-7'
+        placeholder='example@test.com'
+      />
+    </Box>
+    <Box width={'300px'} p={2}>
+      <Tooltip top right bg='blue' color='white'>
+        top right tooltip
+      </Tooltip>
+      <InputField
+        icon='circleInfo'
+        color='blue'
+        label='Email Address'
+        defaultValue='albus.dumbledore@priceline.com'
+        id='form-field-8'
+        placeholder='example@test.com'
+      />
+    </Box>
+  </FlexColumn>
+)

--- a/packages/core/src/Truncate/Truncate.stories.js
+++ b/packages/core/src/Truncate/Truncate.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Box, Truncate } from '..'
 
 const loripsum = `
@@ -14,10 +13,15 @@ Equidem, sed audistine modo de Carneade? Confecta res esset. Audeo dicere, inqui
 Duo Reges: constructio interrete. Mihi enim satis est, ipsis non satis. Si enim ita est, vide ne facinus facias, cum mori suadeas. Illud dico, ea, quae dicat, praeclare inter se cohaerere. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.
 `
 
-storiesOf('Truncate', module)
-  .add('Without Container', () => <Truncate width={50}>{loripsum}</Truncate>)
-  .add('With Container', () => (
-    <Box width={3 / 10}>
-      <Truncate>{loripsum}</Truncate>
-    </Box>
-  ))
+export default {
+  title: 'Truncate',
+  component: Truncate,
+}
+
+export const WithoutContainer = () => <Truncate width={50}>{loripsum}</Truncate>
+
+export const WithContainer = () => (
+  <Box width={3 / 10}>
+    <Truncate>{loripsum}</Truncate>
+  </Box>
+)

--- a/packages/core/src/stories/Colors.stories.js
+++ b/packages/core/src/stories/Colors.stories.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { Box, Flex, Text, createTheme } from '..'
 
 const theme = createTheme()
@@ -28,62 +27,62 @@ const ColorCard = (props) => (
   </Box>
 )
 
-storiesOf('Color', module)
-  .add('Colors', () => (
-    <div>
-      <Box p={3}>
-        <h1>Colors</h1>
-      </Box>
+export default {
+  title: 'Color',
+}
+
+export const Colors = () => (
+  <div>
+    <Box p={3}>
+      <h1>Colors</h1>
+    </Box>
+    <Flex wrap>
+      {next.map((color) => (
+        <Box key={color.key} p={3} width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}>
+          <ColorCard name={color.key} color={color.value} />
+        </Box>
+      ))}
+    </Flex>
+  </div>
+)
+
+export const Palette = () => (
+  <div>
+    <Box p={3}>
+      <h1>Palette</h1>
+      <p>The palette allows you to change the color of components.</p>
       <Flex wrap>
-        {next.map((color) => (
-          <Box key={color.key} p={3} width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}>
-            <ColorCard name={color.key} color={color.value} />
-          </Box>
-        ))}
+        {palette.map((pal) => {
+          if (typeof pal.value === 'object') {
+            return (
+              <div style={{ width: '100%' }}>
+                <h4>{pal.key}</h4>
+                <Flex wrap>
+                  {Object.keys(pal.value).map((key) => (
+                    <Box
+                      key={key}
+                      p={3}
+                      width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}
+                    >
+                      <ColorCard
+                        name={key}
+                        color={theme.palette[pal.key][key]}
+                      />
+                    </Box>
+                  ))}
+                </Flex>
+                <hr />
+              </div>
+            )
+          } else {
+            return (
+              <Box key={pal.key} p={3} width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}>
+                <ColorCard name={pal.key} color={pal.value} />
+              </Box>
+            )
+          }
+        })}
       </Flex>
-    </div>
-  ))
-  .add('Palette', () => (
-    <div>
-      <Box p={3}>
-        <h1>Palette</h1>
-        <p>The palette allows you to change the color of components.</p>
-        <Flex wrap>
-          {palette.map((pal) => {
-            if (typeof pal.value === 'object') {
-              return (
-                <div style={{ width: '100%' }}>
-                  <h4>{pal.key}</h4>
-                  <Flex wrap>
-                    {Object.keys(pal.value).map((key) => (
-                      <Box
-                        key={key}
-                        p={3}
-                        width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}
-                      >
-                        <ColorCard
-                          name={key}
-                          color={theme.palette[pal.key][key]}
-                        />
-                      </Box>
-                    ))}
-                  </Flex>
-                  <hr />
-                </div>
-              )
-            } else {
-              return (
-                <Box
-                  key={pal.key}
-                  p={3}
-                  width={[1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]}
-                >
-                  <ColorCard name={pal.key} color={pal.value} />
-                </Box>
-              )
-            }
-          })}
-        </Flex>
-      </Box>
-    </div>
-  ))
+    </Box>
+  </div>
+)

--- a/packages/core/src/stories/Layouts.stories.js
+++ b/packages/core/src/stories/Layouts.stories.js
@@ -1,72 +1,81 @@
 import React from 'react'
 import styled from 'styled-components'
-import { storiesOf } from '@storybook/react'
 
 import { Flex, Box, Text, Image, Heading, getPaletteColor } from '..'
 import { Hotels as HotelsIcon } from 'pcln-icons'
 
-storiesOf('Layout Examples', module)
-  .add('Grid', () => (
-    <Box p={4}>
-      <Flex wrap mx={-3}>
-        <Box width={[1, 1 / 2]} px={3} mb={4}>
-          <Box bg='background.light'>
-            <Text>Hello</Text>
-          </Box>
+export default {
+  title: 'Layout Examples',
+}
+
+export const Grid = () => (
+  <Box p={4}>
+    <Flex wrap mx={-3}>
+      <Box width={[1, 1 / 2]} px={3} mb={4}>
+        <Box bg='background.light'>
+          <Text>Hello</Text>
         </Box>
-        <Box width={[1, 1 / 2]} px={3} mb={4}>
-          <Box bg='background.light'>
-            <Text>Hello</Text>
-          </Box>
+      </Box>
+      <Box width={[1, 1 / 2]} px={3} mb={4}>
+        <Box bg='background.light'>
+          <Text>Hello</Text>
         </Box>
-      </Flex>
+      </Box>
+    </Flex>
+  </Box>
+)
+
+export const TwoColumn = () => (
+  <Flex>
+    <Box px={3} width={1 / 4}>
+      <Box
+        bg='background.light'
+        style={{
+          minHeight: '50vh',
+        }}
+      >
+        <Text>Hello</Text>
+      </Box>
     </Box>
-  ))
-  .add('Two-column', () => (
-    <Flex>
-      <Box px={3} width={1 / 4}>
-        <Box
-          bg='background.light'
-          style={{
-            minHeight: '50vh',
-          }}
-        >
-          <Text>Hello</Text>
-        </Box>
+    <Box px={3} width={3 / 4}>
+      <Box
+        bg='background.light'
+        style={{
+          minHeight: '50vh',
+        }}
+      >
+        <Text>Hello</Text>
       </Box>
-      <Box px={3} width={3 / 4}>
-        <Box
-          bg='background.light'
-          style={{
-            minHeight: '50vh',
-          }}
-        >
-          <Text>Hello</Text>
-        </Box>
+    </Box>
+  </Flex>
+)
+
+TwoColumn.story = {
+  name: 'Two-column',
+}
+
+export const Navbar = () => (
+  <Flex p={2} alignItems='center' color='primary'>
+    <HotelsIcon mr={2} />
+    <Text bold mx={2}>
+      Hello
+    </Text>
+    <Text mx={2}>Navbar</Text>
+    <Text ml='auto' mr={2}>
+      Right Side
+    </Text>
+  </Flex>
+)
+
+export const TiledCards = () => (
+  <Flex wrap>
+    {cards.map((card) => (
+      <Box key={card.id} p={3} width={[1 / 2, 1 / 3, 1 / 4]}>
+        <Card {...card} />
       </Box>
-    </Flex>
-  ))
-  .add('Navbar', () => (
-    <Flex p={2} alignItems='center' color='primary'>
-      <HotelsIcon mr={2} />
-      <Text bold mx={2}>
-        Hello
-      </Text>
-      <Text mx={2}>Navbar</Text>
-      <Text ml='auto' mr={2}>
-        Right Side
-      </Text>
-    </Flex>
-  ))
-  .add('Tiled Cards', () => (
-    <Flex wrap>
-      {cards.map((card) => (
-        <Box key={card.id} p={3} width={[1 / 2, 1 / 3, 1 / 4]}>
-          <Card {...card} />
-        </Box>
-      ))}
-    </Flex>
-  ))
+    ))}
+  </Flex>
+)
 
 const Border = styled(Box)`
   border: 1px solid ${getPaletteColor('background.base')};

--- a/packages/icons/src/Icon.stories.js
+++ b/packages/icons/src/Icon.stories.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 
 import { Box, Flex, Truncate } from 'pcln-design-system'
 
@@ -8,59 +7,69 @@ const { Accessible, Cars, Flights, Hotels } = icons
 
 const keys = Object.keys(icons).filter((icon) => icon !== 'Icon')
 
-storiesOf('pcln-icons / Icon', module)
-  .add('Icons', () => (
-    <Box p={2} color='primary'>
-      <Flex wrap>
-        {keys.map((name) => {
-          const Component = icons[name]
+export default {
+  title: 'pcln-icons / Icon',
+}
 
-          return (
-            <Flex
-              key={name}
-              flexDirection='column'
-              alignItems='center'
-              width={[1 / 3, 1 / 5, 1 / 6, 1 / 8]}
-              mx={2}
-              my={3}
-            >
-              <Component size={48} />
-              <Truncate fontSize={0} mt={1}>
-                {name}
-              </Truncate>
-            </Flex>
-          )
-        })}
-      </Flex>
-    </Box>
-  ))
-  .add('Color', () => (
-    <div>
-      <Flights color='primary' size={48} m={2} />
-      <Hotels color='secondary' size={48} m={2} />
-      <Cars color='alert' size={48} m={2} />
-    </div>
-  ))
-  .add('Responsive', () => (
-    <Flights color='primary' size={[100, 200, 300, 50]} name='Flights' />
-  ))
-  .add('a11y', () => (
-    <Box>
-      <Accessible
-        color='primary'
-        size={[100, 200, 300, 50]}
-        title='Accessible Logo'
-        titleId='titleId'
-        desc='Accessible Logo description'
-        descId='descId'
-      />
-      <Accessible
-        color='primary'
-        size={[100, 200, 300, 50]}
-        title='Accessible Logo'
-        titleId='titleId'
-        desc='Accessible Logo description'
-        descId='descId'
-      />
-    </Box>
-  ))
+export const Icons = () => (
+  <Box p={2} color='primary'>
+    <Flex wrap>
+      {keys.map((name) => {
+        const Component = icons[name]
+
+        return (
+          <Flex
+            key={name}
+            flexDirection='column'
+            alignItems='center'
+            width={[1 / 3, 1 / 5, 1 / 6, 1 / 8]}
+            mx={2}
+            my={3}
+          >
+            <Component size={48} />
+            <Truncate fontSize={0} mt={1}>
+              {name}
+            </Truncate>
+          </Flex>
+        )
+      })}
+    </Flex>
+  </Box>
+)
+
+export const Color = () => (
+  <div>
+    <Flights color='primary' size={48} m={2} />
+    <Hotels color='secondary' size={48} m={2} />
+    <Cars color='alert' size={48} m={2} />
+  </div>
+)
+
+export const Responsive = () => (
+  <Flights color='primary' size={[100, 200, 300, 50]} name='Flights' />
+)
+
+export const A11Y = () => (
+  <Box>
+    <Accessible
+      color='primary'
+      size={[100, 200, 300, 50]}
+      title='Accessible Logo'
+      titleId='titleId'
+      desc='Accessible Logo description'
+      descId='descId'
+    />
+    <Accessible
+      color='primary'
+      size={[100, 200, 300, 50]}
+      title='Accessible Logo'
+      titleId='titleId'
+      desc='Accessible Logo description'
+      descId='descId'
+    />
+  </Box>
+)
+
+A11Y.story = {
+  name: 'a11y',
+}

--- a/packages/modal/src/Modal.stories.js
+++ b/packages/modal/src/Modal.stories.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { storiesOf } from '@storybook/react'
 import { boolean, withKnobs } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
@@ -62,70 +61,93 @@ class ModalStory extends React.Component {
   }
 }
 
-storiesOf('pcln-modal/Modal', module)
-  .addDecorator(withKnobs)
-  .add('Raw', () => (
-    <ModalStory width={['100px', '200px', '500px']} disableCloseButton />
-  ))
-  .add('With SmallModalHeader', () => (
-    <ModalStory
-      header={<SmallModalHeader />}
-      width={['80vw', '400px', '500px']}
-    />
-  ))
-  .add('With ModalHeader (and ScrollLock!)', () => {
-    // Generate content to demonstrate a scrollable <body>
-    const contentLines = [...Array(100).keys()]
+export default {
+  title: 'pcln-modal/Modal',
+  decorators: [withKnobs],
+  component: Modal,
+}
 
-    return (
-      <div>
-        <h1>Scroll down to open modal</h1>
-        {contentLines.map((i, idx) => (
-          <div key={idx}>Line {idx}</div>
-        ))}
-        <ModalStory
-          header={
-            <ModalHeader
-              title='Modal title'
-              onClose={action('Modal closed!')}
-            />
-          }
-          height={['90vh', '460px', '560px']}
-          width={['80vw', '400px', '500px']}
-          lock={true}
-          fullScreen={boolean('fullScreen', false)}
-        />
-      </div>
-    )
-  })
-  .add('With Overflow', () => (
-    <ModalStory
-      header={<SmallModalHeader />}
-      width={['80vw', '400px', '500px']}
-      enableOverflow
-    />
-  ))
-  .add('With imagemode and colorful', () => (
-    <ModalStory
-      bg='orange'
-      header={<SmallModalHeader />}
-      width={['100px', '200px', '500px']}
-      imgMode
-      disableCloseButton
-    />
-  ))
-  .add('With custom animation', () => (
-    <ModalStory
-      header={<SmallModalHeader />}
-      width={['100px', '200px', '500px']}
-      dialogAnimation={CUSTOM_ANIMATION}
-      verticalAlignment='top'
-    />
-  ))
-  .add('Zero Timeout', () => (
-    <ModalStory
-      disableCloseButton
-      width={['100px', '200px', '500px']}
-      timeout={0}
-    />
-  ))
+export const Raw = () => (
+  <ModalStory width={['100px', '200px', '500px']} disableCloseButton />
+)
+
+export const WithSmallModalHeader = () => (
+  <ModalStory
+    header={<SmallModalHeader />}
+    width={['80vw', '400px', '500px']}
+  />
+)
+
+WithSmallModalHeader.story = {
+  name: 'With SmallModalHeader',
+}
+
+export const WithModalHeaderAndScrollLock = () => {
+  // Generate content to demonstrate a scrollable <body>
+  const contentLines = [...Array(100).keys()]
+
+  return (
+    <div>
+      <h1>Scroll down to open modal</h1>
+      {contentLines.map((i, idx) => (
+        <div key={idx}>Line {idx}</div>
+      ))}
+      <ModalStory
+        header={
+          <ModalHeader title='Modal title' onClose={action('Modal closed!')} />
+        }
+        height={['90vh', '460px', '560px']}
+        width={['80vw', '400px', '500px']}
+        lock={true}
+        fullScreen={boolean('fullScreen', false)}
+      />
+    </div>
+  )
+}
+
+WithModalHeaderAndScrollLock.story = {
+  name: 'With ModalHeader (and ScrollLock!)',
+}
+
+export const WithOverflow = () => (
+  <ModalStory
+    header={<SmallModalHeader />}
+    width={['80vw', '400px', '500px']}
+    enableOverflow
+  />
+)
+
+export const WithImagemodeAndColorful = () => (
+  <ModalStory
+    bg='orange'
+    header={<SmallModalHeader />}
+    width={['100px', '200px', '500px']}
+    imgMode
+    disableCloseButton
+  />
+)
+
+WithImagemodeAndColorful.story = {
+  name: 'With imagemode and colorful',
+}
+
+export const WithCustomAnimation = () => (
+  <ModalStory
+    header={<SmallModalHeader />}
+    width={['100px', '200px', '500px']}
+    dialogAnimation={CUSTOM_ANIMATION}
+    verticalAlignment='top'
+  />
+)
+
+WithCustomAnimation.story = {
+  name: 'With custom animation',
+}
+
+export const ZeroTimeout = () => (
+  <ModalStory
+    disableCloseButton
+    width={['100px', '200px', '500px']}
+    timeout={0}
+  />
+)

--- a/packages/slider/src/Slider.stories.js
+++ b/packages/slider/src/Slider.stories.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-children-prop */
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import Component from '@reach/component-component'
 
 import { ThemeProvider } from 'pcln-design-system'
@@ -95,102 +94,111 @@ const untdTheme = {
   },
 }
 
-storiesOf('pcln-slider / Slider', module)
-  .add('Basic', () => (
+export default {
+  title: 'pcln-slider / Slider',
+  component: Slider,
+}
+
+export const Basic = () => (
+  <div>
     <div>
-      <div>
-        <div id='handle_2'>Handle Two</div> is labelled by the text above
-      </div>
-      <Component
-        initialState={{
-          value: [32, 64],
-        }}
-        children={({ state, setState }) => (
-          <RangeSlider
-            ariaLabelGroupForHandles={['Handle One', undefined]}
-            ariaLabelledByGroupForHandles={[undefined, 'handle_2']}
-            ariaValueTextFormattersForHandles={[
-              formatValueText,
-              formatValueText,
-            ]}
-            value={state.value}
-            onChange={(value) => {
-              setState({ value })
-            }}
-          />
-        )}
-      />
+      <div id='handle_2'>Handle Two</div> is labelled by the text above
     </div>
-  ))
-  .add('RangeSlider with Single value', () => (
-    <RangeSlider ariaLabelGroupForHandles={['Handle One']} value={[32]} />
-  ))
-  .add('Slider', () => <Slider ariaLabelForHandle='Handle' value={[32]} />)
-  .add('Multiple values', () => (
-    <RangeSlider
-      ariaLabelGroupForHandles={[
-        'handle_1',
-        'handle_2',
-        'handle_3',
-        'handle_4',
-      ]}
-      value={[16, 32, 64, 128]}
-      max={256}
+    <Component
+      initialState={{
+        value: [32, 64],
+      }}
+      children={({ state, setState }) => (
+        <RangeSlider
+          ariaLabelGroupForHandles={['Handle One', undefined]}
+          ariaLabelledByGroupForHandles={[undefined, 'handle_2']}
+          ariaValueTextFormattersForHandles={[formatValueText, formatValueText]}
+          value={state.value}
+          onChange={(value) => {
+            setState({ value })
+          }}
+        />
+      )}
     />
-  ))
-  .add('Colors', () => (
-    <div>
-      <RangeSlider
-        value={[8, 16]}
-        color='primary'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[16, 32]}
-        color='secondary'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[32, 64]}
-        color='alert'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[64, 96]}
-        color='error'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-    </div>
-  ))
-  .add('Themed Colors', () => (
-    <ThemeProvider theme={untdTheme}>
-      <RangeSlider
-        value={[8, 16]}
-        color='primary'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[16, 32]}
-        color='secondary'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[32, 64]}
-        color='alert'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-      <RangeSlider
-        value={[64, 96]}
-        color='error'
-        mb={2}
-        ariaLabelGroupForHandles={['handle_1', 'handle_2']}
-      />
-    </ThemeProvider>
-  ))
+  </div>
+)
+
+export const RangeSliderWithSingleValue = () => (
+  <RangeSlider ariaLabelGroupForHandles={['Handle One']} value={[32]} />
+)
+
+RangeSliderWithSingleValue.story = {
+  name: 'RangeSlider with Single value',
+}
+
+export const _Slider = () => <Slider ariaLabelForHandle='Handle' value={[32]} />
+
+export const MultipleValues = () => (
+  <RangeSlider
+    ariaLabelGroupForHandles={['handle_1', 'handle_2', 'handle_3', 'handle_4']}
+    value={[16, 32, 64, 128]}
+    max={256}
+  />
+)
+
+MultipleValues.story = {
+  name: 'Multiple values',
+}
+
+export const Colors = () => (
+  <div>
+    <RangeSlider
+      value={[8, 16]}
+      color='primary'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[16, 32]}
+      color='secondary'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[32, 64]}
+      color='alert'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[64, 96]}
+      color='error'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+  </div>
+)
+
+export const ThemedColors = () => (
+  <ThemeProvider theme={untdTheme}>
+    <RangeSlider
+      value={[8, 16]}
+      color='primary'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[16, 32]}
+      color='secondary'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[32, 64]}
+      color='alert'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+    <RangeSlider
+      value={[64, 96]}
+      color='error'
+      mb={2}
+      ariaLabelGroupForHandles={['handle_1', 'handle_2']}
+    />
+  </ThemeProvider>
+)


### PR DESCRIPTION
This PR is prep for #970 to make it easier to review. Long story short, the easiest way to add support for TypeScript in the `core` package requires upgrading to Storybook 6 because it provides zero-config TS support. In order to do that, we need to remove usages of the deprecated `@storybook/addon-info`, and we do that by replacing those usages with `parameters.docs.description.component` in the default export for CSF story files. Obviously, this requires refactoring all stories to CSF, hence this PR.

This PR **does not** upgrade to SB6, it's just prep and will not change any functionality. The docs pages of all stories are still broken.

- [x] run `rush change`