### PR TITLE
Fix bug when passing aria-label to Button and related components

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,7 @@
     "@mdx-js/tag": "^0.15.0",
     "is-absolute-url": "^2.1.0",
     "mdx-docs": "^1.0.0-9",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "pcln-icons": "^4.0.0",
     "pcln-modal": "^4.0.0",
     "pcln-slider": "^4.0.0",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -32,7 +32,7 @@
     "chromatic": "^5.2.0",
     "eslint": "^7.9.0",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-draggable-playground": "^1.0.0",

--- a/common/changes/pcln-popover/fix-button-aria-label_2020-12-04-19-34.json
+++ b/common/changes/pcln-popover/fix-button-aria-label_2020-12-04-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-popover",
+  "email": "email@craigp.me"
+}

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -45,7 +45,7 @@
     "jest-standard-reporter": "^1.1.1",
     "jest-styled-components": "^6.3.4",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "pcln-icons": "^4.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -54,7 +54,7 @@
     "us": "^2.0.0"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "styled-components": ">=4.4.1"
   }
 }

--- a/packages/core/CHANGELOG.json
+++ b/packages/core/CHANGELOG.json
@@ -2,6 +2,20 @@
   "name": "pcln-design-system",
   "entries": [
     {
+      "version": "4.1.2",
+      "tag": "pcln-design-system_v4.1.2",
+      "date": "Fri, 04 Dec 2020 20:01:32 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Forward aria-label prop to Button and components that extend Button",
+            "author": "Craig Palermo <email@craigp.me>",
+            "commit": "76488304d488ffd757fe6fbeb54b5c1e978e8ef1"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.1.1",
       "tag": "pcln-design-system_v4.1.1",
       "date": "Fri, 04 Dec 2020 01:33:19 GMT",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - pcln-design-system
 
-This log was last generated on Fri, 04 Dec 2020 01:33:19 GMT and should not be manually modified.
+This log was last generated on Fri, 04 Dec 2020 20:01:32 GMT and should not be manually modified.
+
+## 4.1.2
+Fri, 04 Dec 2020 20:01:32 GMT
+
+### Patches
+
+- Forward aria-label prop to Button and components that extend Button
 
 ## 4.1.1
 Fri, 04 Dec 2020 01:33:19 GMT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Priceline Design System",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/Button/Button.js
+++ b/packages/core/src/Button/Button.js
@@ -113,7 +113,7 @@ export const buttonStyles = css`
  */
 const Button = styled.button.attrs({
   width: ({ fullWidth, width }) => (fullWidth ? 1 : width),
-  'aria-label': ({ title }) => title,
+  'aria-label': ({ title, 'aria-label': ariaLabel }) => ariaLabel || title,
 })`
   ${buttonStyles}
 `

--- a/packages/core/src/Button/Button.spec.js
+++ b/packages/core/src/Button/Button.spec.js
@@ -116,6 +116,16 @@ describe('Button', () => {
       'button title'
     )
   })
+
+  it('should forward the "aria-label" prop', () => {
+    const label = 'i am an aria label'
+    const { getByLabelText } = render(
+      <Button aria-label={label}>BUTTON</Button>
+    )
+
+    expect(getByLabelText(label)).toHaveAttribute('aria-label', label)
+  })
+
   describe('variations', () => {
     describe('fill variation', () => {
       it('should render correctly', () => {

--- a/packages/core/src/IconButton/IconButton.stories.js
+++ b/packages/core/src/IconButton/IconButton.stories.js
@@ -13,6 +13,7 @@ export default {
 export const Default = () => (
   <IconButton
     onClick={action('Clicked IconButton')}
+    aria-label={'Click to choose date'}
     icon={<Calendar title='Choose date' />}
   />
 )

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -36,7 +36,7 @@
     "jest-standard-reporter": "^1.1.1",
     "jest-styled-components": "^6.3.4",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "pcln-icons": "^4.0.0",
     "pcln-popover": "^4.0.0",
     "prop-types": "^15.7.2",
@@ -47,7 +47,7 @@
     "styled-system": "^4.2.4"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "pcln-icons": "^4.0.0",
     "pcln-popover": "^4.0.0",
     "styled-components": ">=4.4.1",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -41,7 +41,7 @@
     "jest-standard-reporter": "^1.1.1",
     "jest-styled-components": "^6.3.4",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -50,7 +50,7 @@
     "styled-system": "^4.2.4"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "react": "^16.10.0",
     "react-dom": "^16.10.0",
     "styled-components": ">=4.4.1",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -44,7 +44,7 @@
     "jest-standard-reporter": "^1.1.1",
     "jest-styled-components": "^6.3.4",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "pcln-icons": "^4.0.0",
     "pcln-slider": "^4.0.0",
     "prop-types": "^15.7.2",
@@ -56,7 +56,7 @@
     "styled-system": "^4.2.4"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "styled-components": ">=4.4.1",
     "react": "^16.10.0",
     "react-dom": "^16.10.0"

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -53,6 +53,7 @@ exports[`Popover Trigger Element Renders trigger element and appends action prop
     class="c1"
   >
     <button
+      aria-label="Top Popover"
       class="c2"
       color="primary"
     >

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -53,7 +53,7 @@
     "jest-standard-reporter": "^1.1.1",
     "jest-styled-components": "^6.3.4",
     "npm-run-all": "^4.1.5",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "rc-tools": "^8.4.5",
     "rc-trigger": "^2.6.5",
     "react": "^16.13.1",
@@ -62,7 +62,7 @@
     "styled-components": "^4.4.1"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "styled-components": ">=4.4.1",
     "react": "^16.10.0",
     "react-dom": "^16.10.0"

--- a/tools/types/package.json
+++ b/tools/types/package.json
@@ -42,7 +42,7 @@
     "csstype": "^2.6.7",
     "dtslint": "^4.0.0",
     "eslint": "^7.9.0",
-    "pcln-design-system": "^4.1.1",
+    "pcln-design-system": "^4.1.2",
     "prettier": "^2.1.1"
   }
 }


### PR DESCRIPTION
This was an unintended regression in DS4. Both the `title` and `aria-label` props will now set the `aria-label` on the rendered `<button>` (`aria-label` prop takes precedence).