### PR TITLE
Fix bug when using RatingBadge without bg prop

### DIFF
--- a/common/changes/pcln-design-system/840-rating-badge-bug_2020-12-29-15-51.json
+++ b/common/changes/pcln-design-system/840-rating-badge-bug_2020-12-29-15-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix bug when using RatingBadge with color but not bg prop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-modal/840-rating-badge-bug_2020-12-29-15-51.json
+++ b/common/changes/pcln-modal/840-rating-badge-bug_2020-12-29-15-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-modal",
+  "email": "email@craigp.me"
+}

--- a/packages/core/src/RatingBadge/RatingBadge.js
+++ b/packages/core/src/RatingBadge/RatingBadge.js
@@ -1,13 +1,15 @@
 import styled from 'styled-components'
-import { fontWeight, borderRadius } from 'styled-system'
+import PropTypes from 'prop-types'
+import { fontWeight, borderRadius, } from 'styled-system';
 import { Box } from '../Box'
-import { applyVariations, deprecatedPropType } from '../utils'
+import { deprecatedPropType } from '../utils';
 
-const RatingBadge = styled(Box)`
+const RatingBadge = styled(Box).attrs(({color, bg}) => ({
+  bg: color ? "" : bg // TODO delete once we remove the bg prop
+}))`
   display: inline-block;
   line-height: 1.5;
   ${fontWeight} ${borderRadius};
-  ${applyVariations('RatingBadge')}
 `
 
 RatingBadge.defaultProps = {
@@ -22,6 +24,7 @@ RatingBadge.propTypes = {
   ...fontWeight.propTypes,
   ...borderRadius.propTypes,
   bg: deprecatedPropType('color'),
+  color: PropTypes.string
 }
 
 export default RatingBadge

--- a/packages/core/src/RatingBadge/RatingBadge.spec.js
+++ b/packages/core/src/RatingBadge/RatingBadge.spec.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { render } from 'testing-library'
 
 import { RatingBadge } from '..'
 
@@ -13,5 +14,19 @@ describe('RatingBadge', () => {
   test('renders', () => {
     const json = rendererCreateWithTheme(<RatingBadge />).toJSON()
     expect(json).toMatchSnapshot()
+  })
+
+  test('has correct background and text colors', () => {
+    const text = "123"
+    const color = 'secondary'
+
+    const { getByText } = render(<RatingBadge color={color}>{text}</RatingBadge>)
+
+    const badge = getByText(text)
+
+    // Need to check the computed styles because .toHaveStyleRule(..) doesn't evaluate the functions
+    const computedStyles = window.getComputedStyle(badge)
+    expect(computedStyles.color).toEqual('rgb(255, 255, 255)')
+    expect(computedStyles.backgroundColor).toEqual('rgb(0, 170, 0)')
   })
 })

--- a/packages/core/src/RatingBadge/RatingBadge.stories.js
+++ b/packages/core/src/RatingBadge/RatingBadge.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { RatingBadge } from '..'
+import { RatingBadge, Flex } from '..'
 
 export default {
   title: 'RatingBadge',
@@ -8,6 +8,11 @@ export default {
 
 export const Default = () => <RatingBadge>9.0</RatingBadge>
 
-Default.story = {
-  name: 'default',
-}
+export const Colors = () => (
+  <Flex width="150px" justifyContent="space-between">
+    <RatingBadge color="primary">7.6</RatingBadge>
+    <RatingBadge color="secondary">8.1</RatingBadge>
+    <RatingBadge color="alert">9.0</RatingBadge>
+  </Flex>
+)
+

--- a/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
+++ b/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
@@ -4,7 +4,6 @@ exports[`RatingBadge renders 1`] = `
 .c0 {
   padding-left: 8px;
   padding-right: 8px;
-  background-color: #f68013;
   color: #fff;
   display: inline-block;
   line-height: 1.5;

--- a/packages/core/src/ShadowEffect/ShadowEffect.spec.js
+++ b/packages/core/src/ShadowEffect/ShadowEffect.spec.js
@@ -168,6 +168,6 @@ describe('ShadowEffect', () => {
           <Input />
         </ShadowEffect>
       )
-    }).toThrowError()
+    }).toThrow()
   })
 })


### PR DESCRIPTION
Resolves #840 

<img width="356" alt="Screen Shot 2020-12-29 at 10 52 38 AM" src="https://user-images.githubusercontent.com/3260642/103296382-e3a12e00-49ed-11eb-8d21-8886a2bd2ce0.png">
