### PR TITLE
Update Text Extension Display Names

### DIFF
--- a/common/changes/pcln-design-system/update-text-extension-display-names_2020-12-29-20-56.json
+++ b/common/changes/pcln-design-system/update-text-extension-display-names_2020-12-29-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update Text Extension Display Names",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "james.stewart@priceline.com"
+}

--- a/packages/core/src/Text/Text.js
+++ b/packages/core/src/Text/Text.js
@@ -114,20 +114,20 @@ Text.span = ({ children, ...props }) => (
     {children}
   </Text>
 )
-Text.span.displayName = 'Span'
+Text.span.displayName = 'Text.span'
 
 Text.p = ({ children, ...props }) => (
   <Text as='p' {...props}>
     {children}
   </Text>
 )
-Text.p.displayName = 'Paragraph'
+Text.p.displayName = 'Text.p'
 
 Text.s = ({ children, ...props }) => (
   <Text as='s' {...props}>
     {children}
   </Text>
 )
-Text.s.displayName = 'Strikethrough'
+Text.s.displayName = 'Text.s'
 
 export default Text


### PR DESCRIPTION
Changing the text display names for the extended components (span, s, p) to be the same as the component name.