### PR TITLE
Fix syntax on GenericBanner page that broke docsite build

### DIFF
--- a/apps/docs/pages/Banner.md
+++ b/apps/docs/pages/Banner.md
@@ -87,3 +87,7 @@ Uses the color from `theme.palette.warning.base`.
   text='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. '
 />
 ```
+
+### Related
+
+- [GenericBanner](/GenericBanner)

--- a/apps/docs/pages/GenericBanner.md
+++ b/apps/docs/pages/GenericBanner.md
@@ -1,21 +1,22 @@
 # GenericBanner
 
-The `GenericBanner` component is an actionable `<banner>` element with an option to pass a left or right icon, a heading, text or a leftImage. When the intent is for the call to action to use a native <a> tag, URLProps and ctaText can be used. When the intent is for the call to action to be a native <button>, buttonClick and ctaText can be used. When using a link it can be styled to appear as a link or a button. When using a button, it can be styled to appear as a link or a button. By default the call to action is styled to look like a link in both cases.
+The `GenericBanner` component is an actionable `<banner>` element with an option to pass a left or right icon, a `heading`, `text`, or a `leftImage`. When the intent is for the call to action to use a native `<a>` tag, `URLProps` and `ctaText` can be used. When the intent is for the call to action to be a native `<button>`, `buttonClick` and `ctaText` can be used. When using a link, it can be styled to appear as a link or a button. Similarly, when using a button, it can be styled to appear as a link or a button. By default, the call to action is styled to look like a link in both cases.
 
 ```.jsx
  <GenericBanner
     p={2}
     heading={
-      <Text.span fontWeight='bold' textColor='primary.base'>
-        COVID-19&nbsp;
+      <Text.span fontWeight='bold' textColor='primary.base' mr={1}>
+        COVID-19
       </Text.span>
     }
     text={
       <Text.span
         textColor='primary.base'
+        mr={1}
       >
         Update: Your travel may be impacted. Please review this important
-        info.&nbsp;
+        info.
       </Text.span>
     }
     ctaText={
@@ -26,66 +27,30 @@ The `GenericBanner` component is an actionable `<banner>` element with an option
         Read More
       </Text.span>
     }
-    buttonClick={console.log('clicked')}
+    buttonClick={() => console.log('clicked')}
     color='caution.light'
   />
 ```
 
 ## Props
 
-| Prop              | Type                                  | Description                                          |
-| ----------------- | ------------------------------------- | ---------------------------------------------------- |
-| `alignItems`      | `baseline`,`end`,`center`,`flex-end`, | Applies the desired align-items styling to the       |
-|                   | `flex-start`,`self-end` `self-start`, | flex items within the banner. The default is set to  |
-|                   | `start`,`stretch`                     | `center`                                             |
-|                   |                                       |                                                      |
-| `buttonClick`     | function                              | If using a button for the call to action, ie         |
-|                   |                                       | the intended action is to trigger new content        |
-|                   |                                       | in the same context, then the onClick function can   |
-|                   |                                       | be used to trigger this desired action               |
-|                   |                                       |                                                      |
-| `buttonSize `     | `small`, `medium`, `large`            | When using ctaText and buttonClick and passing in    |
-|                   |                                       | a buttonVariation of fill or outline, buttonSize     |
-|                   |                                       | controls the size of the button                      |
-|                   |                                       |                                                      |
-| `buttonVariation` | `fill`, `outline`, `link`             | When using ctaText and buttonClick, buttonVariation  |  
-|                   |                                       | can be used to alter the appearance of the button    |
-|                   |                                       | element. `link` makes the button look like a link    |
-|                   |                                       | `link` is the default value                          |
-|                   |                                       |                                                      |
-| `ctaText`         | node                                  | This is the call to action text node to be passed    |
-|                   |                                       | in which should be paired with either URLProps or    |
-|                   |                                       | buttonClick                                          |
-|                   |                                       |                                                      |
-| `fontSize`        | string, number or array of either     | Used to control the font-size of heading, text       |
-|                   |                                       | and the ctaText. `[0, null, null, 1]` is the default |
-|                   |                                       |                                                      |
-| `heading`         | node                                  | Used to pass in the heading type text                |
-|                   |                                       |                                                      |
-| `iconLeft`        | node                                  | Used to pass in an icon on the left side             |
-|                   |                                       |                                                      |
-| `iconRight`       | node                                  | Used to pass in an icon on the right side            |
-|                   |                                       |                                                      |
-| `imageLeft`       | node                                  | Used to pass in an image on the left side            |
-|                   |                                       |                                                      |
-| `justifyContent`  | `end`,`center`,`left`, `right`,       | Applies the desired justify-content styling to       |
-|                   | `flex-end`, `flex-start`,             | the flex items within the banner. The default        |
-|                   | `space-around`, `space-evenly`,       | is set to `center`                                   |
-|                   | `space-between`, `start`, `stretch`,  |                                                      |
-|                   |                                       |                                                      |
-| `linkColor`       | string                                | When using URLProps and ctaText, linkColor can be    |
-|                   |                                       | used to customize link color. Default is `primary`   |
-|                   |                                       |                                                      |
-| `linkVariation`   | `fill`, `outline`, `link`             | When using ctaText and URLProps, linkVariation can   |
-|                   |                                       | be used to alter the appearance of the link element. |
-|                   |                                       | `fill` and `outline` make the link element look like |
-|                   |                                       | a button. `link` is the default value                |
-|                   |                                       |                                                      |
-| `text`            | node                                  | Used to pass in the body text                        |
-|                   |                                       |                                                      |
-| `URLProps`        | object containing an href(string)     | If the call to action should be a link, ie the       |
-|                   | and a target(string)                  | intended action navigates the user to a new page     |
-|                   |                                       | then href and target should be provided in URLProps  |
+| Prop              | Type                                                                                                                            | Description                                                                                                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alignItems`      | `baseline`, `end`, `center`, `flex-end`, `flex-start`, `self-end`, `self-start`, `start`, `stretch`                             | Applies the desired align-items styling to the flex items within the banner. The default is set to `center`.                                                                                        |
+| `buttonClick`     | function                                                                                                                        | If using a button for the call to action, ie the intended action is to trigger new content in the same context, then the onClick function can be used to trigger this desired action.               |
+| `buttonSize `     | `small`, `medium`, `large`                                                                                                      | When using ctaText and buttonClick and passing in a buttonVariation of fill or outline, buttonSize controls the size of the button.                                                                 |
+| `buttonVariation` | `fill`, `outline`, `link`                                                                                                       | When using ctaText and buttonClick, buttonVariation can be used to alter the appearance of the button element. `link` makes the button look like a link. `link` is the default value.               |
+| `ctaText`         | node                                                                                                                            | This is the call to action text node to be passed in which should be paired with either URLProps or buttonClick.                                                                                    |
+| `fontSize`        | string, number or array of either                                                                                               | Used to control the font-size of heading, text and the ctaText. `[0, null, null, 1]` is the default.                                                                                                |
+| `heading`         | node                                                                                                                            | Used to pass in the heading type text                                                                                                                                                               |
+| `iconLeft`        | node                                                                                                                            | Used to pass in an icon on the left side                                                                                                                                                            |
+| `iconRight`       | node                                                                                                                            | Used to pass in an icon on the right side                                                                                                                                                           |
+| `imageLeft`       | node                                                                                                                            | Used to pass in an image on the left side                                                                                                                                                           |
+| `justifyContent`  | `end`, `center`, `left`, `right`, `flex-end`, `flex-start`, `space-around`, `space-evenly`, `space-between`, `start`, `stretch` | Applies the desired justify-content styling to the flex items within the banner. The default is set to `center`.                                                                                    |
+| `linkColor`       | string                                                                                                                          | When using URLProps and ctaText, linkColor can be used to customize link color. Default is `primary`.                                                                                               |
+| `linkVariation`   | `fill`, `outline`, `link`                                                                                                       | When using ctaText and URLProps, linkVariation can be used to alter the appearance of the link element. `fill` and `outline` make the link element look like a button. `link` is the default value. |
+| `text`            | node                                                                                                                            | Used to pass in the body text                                                                                                                                                                       |
+| `URLProps`        | object containing an href(string), and a target(string)                                                                         | If the call to action should be a link, ie the intended action navigates the user to a new page then href and target should be provided in URLProps                                                 |
 
 ### Related
 

--- a/apps/docs/src/components.js
+++ b/apps/docs/src/components.js
@@ -9,6 +9,7 @@ import { components as mdxDocsComponents } from 'mdx-docs'
 
 import {
   Button,
+  GenericBanner,
   Heading,
   Link,
   Text,
@@ -157,6 +158,7 @@ const components = {
   a: RouterLink,
   p: Paragraph,
   table: Table,
+  GenericBanner,
   RangeSlider,
   Slider,
   Modal,

--- a/apps/docs/src/navigation.js
+++ b/apps/docs/src/navigation.js
@@ -29,6 +29,7 @@ export default [
       { name: 'Flag', path: '/Flag' },
       { name: 'Flex', path: '/Flex' },
       { name: 'FormField', path: '/FormField' },
+      { name: 'GenericBanner', path: '/GenericBanner' },
       { name: 'Heading', path: '/Heading' },
       { name: 'Hide', path: '/Hide' },
       { name: 'Hug', path: '/Hug' },


### PR DESCRIPTION
The actual issue was that `<button>` and `<a>` weren't wrapped in back-ticks, so MDX thought they were code. I also reformatted the props table because it included a bunch of empty lines. The rest is just cleanup. I also added `GenericBanner` to the side-nav.