### PR TITLE
Fix create-release-notes command

### DIFF
--- a/common/changes/pcln-autocomplete/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-autocomplete/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-autocomplete",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-autocomplete",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-design-system/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-design-system/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-icons/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-icons/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-icons",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-menu/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-menu/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-menu",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-modal/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-modal/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-modal",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-popover/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-popover/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-popover",
+  "email": "email@craigp.me"
+}

--- a/common/changes/pcln-slider/fix-create-release-notes_2021-01-12-15-47.json
+++ b/common/changes/pcln-slider/fix-create-release-notes_2021-01-12-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-slider",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-slider",
+  "email": "email@craigp.me"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -128,7 +128,7 @@
       "summary": "Create release notes from changelogs",
       "description": "Create release notes from changelogs",
       "safeForSimultaneousRushProcesses": false,
-      "shellCommand": "cd tools/create-release-notes && ts-node src/cli/releaseNotes.ts"
+      "shellCommand": "cd tools/create-release-notes && node dist/cli/releaseNotes.js"
     }
 
     // {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -36,6 +36,7 @@
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
     "@reach/component-component": "^0.7.0",
+    "@rushstack/eslint-config": "^2.3.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "cat-names": "^2.0.0",
@@ -51,8 +52,7 @@
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
     "styled-components": "^4.4.1",
-    "us": "^2.0.0",
-    "@rushstack/eslint-config": "^2.3.1"
+    "us": "^2.0.0"
   },
   "peerDependencies": {
     "pcln-design-system": "^4.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,7 @@
     "@compositor/kit": "^1.0.47",
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
+    "@rushstack/eslint-config": "^2.3.1",
     "@storybook/addon-actions": "^5.3.21",
     "@storybook/addon-info": "^5.3.21",
     "@storybook/react": "^5.3.21",
@@ -99,9 +100,8 @@
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.2",
-    "stylis": "^3.5.4",
     "styled-components": "^4.4.1",
-    "@rushstack/eslint-config": "^2.3.1"
+    "stylis": "^3.5.4"
   },
   "peerDependencies": {
     "react": "^16.10.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -41,6 +41,7 @@
     "@babel/plugin-syntax-jsx": "^7.10.4",
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
+    "@rushstack/eslint-config": "^2.3.1",
     "@svgr/cli": "^4.3.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
@@ -55,8 +56,7 @@
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.13.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^4.4.1",
-    "@rushstack/eslint-config": "^2.3.1"
+    "styled-components": "^4.4.1"
   },
   "peerDependencies": {
     "pcln-design-system": "^3.6.1 || ^4.0.0",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -28,6 +28,7 @@
     "@babel/cli": "^7.11.6",
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
+    "@rushstack/eslint-config": "^2.3.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "cross-env": "^7.0.2",
@@ -44,15 +45,14 @@
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
     "styled-components": "^4.4.1",
-    "styled-system": "^4.2.4",
-    "@rushstack/eslint-config": "^2.3.1"
+    "styled-system": "^4.2.4"
   },
   "peerDependencies": {
     "pcln-design-system": "^4.3.0",
     "pcln-icons": "^4.0.1",
     "pcln-popover": "^4.0.2",
-    "styled-components": ">=4.4.1",
     "react": "^16.10.0",
-    "react-dom": "^16.10.0"
+    "react-dom": "^16.10.0",
+    "styled-components": ">=4.4.1"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -33,6 +33,7 @@
     "@babel/cli": "^7.11.6",
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
+    "@rushstack/eslint-config": "^2.3.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "cross-env": "^7.0.2",
@@ -47,8 +48,7 @@
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
     "styled-components": "^4.4.1",
-    "styled-system": "^4.2.4",
-    "@rushstack/eslint-config": "^2.3.1"
+    "styled-system": "^4.2.4"
   },
   "peerDependencies": {
     "pcln-design-system": "^4.3.0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -36,6 +36,7 @@
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
     "@reach/component-component": "^0.7.0",
+    "@rushstack/eslint-config": "^2.3.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "cross-env": "^7.0.2",
@@ -53,13 +54,12 @@
     "react-focus-lock": "^2.2.1",
     "rimraf": "^3.0.2",
     "styled-components": "^4.4.1",
-    "styled-system": "^4.2.4",
-    "@rushstack/eslint-config": "^2.3.1"
+    "styled-system": "^4.2.4"
   },
   "peerDependencies": {
     "pcln-design-system": "^4.3.0",
-    "styled-components": ">=4.4.1",
     "react": "^16.10.0",
-    "react-dom": "^16.10.0"
+    "react-dom": "^16.10.0",
+    "styled-components": ">=4.4.1"
   }
 }

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -43,6 +43,7 @@
     "@priceline/babel-preset": "workspace:*",
     "@priceline/eslint-config": "workspace:*",
     "@reach/component-component": "^0.7.0",
+    "@rushstack/eslint-config": "^2.3.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "cross-env": "^7.0.2",
@@ -59,13 +60,12 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^4.4.1",
-    "@rushstack/eslint-config": "^2.3.1"
+    "styled-components": "^4.4.1"
   },
   "peerDependencies": {
     "pcln-design-system": "^4.3.0",
-    "styled-components": ">=4.4.1",
     "react": "^16.10.0",
-    "react-dom": "^16.10.0"
+    "react-dom": "^16.10.0",
+    "styled-components": ">=4.4.1"
   }
 }


### PR DESCRIPTION
I noticed that the GH Action that creates release notes failed because `ts-node` was missing. This change should make it more reliable.

<img width="868" alt="Screen Shot 2021-01-12 at 11 06 26 AM" src="https://user-images.githubusercontent.com/3260642/104340193-7057eb80-54c6-11eb-9c87-9dd9f6666558.png">


This PR also includes alphabetized dependencies from the latest `rush publish`.