### PR TITLE
add check for ctaText

### DIFF
--- a/common/changes/pcln-design-system/generic-banner-fix_2021-02-08-17-16.json
+++ b/common/changes/pcln-design-system/generic-banner-fix_2021-02-08-17-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add cta check and ability to pass in a diff heading font size",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "gabrielle.bellini@priceline.com"
+}

--- a/packages/core/src/GenericBanner/GenericBanner.js
+++ b/packages/core/src/GenericBanner/GenericBanner.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { alignItems, justifyContent } from 'styled-system'
+import { alignItems, fontSize, justifyContent } from 'styled-system'
 import PropTypes from 'prop-types'
 import { Banner } from '../Banner'
 import { Box } from '../Box'
@@ -65,14 +65,14 @@ const GenericBanner = ({
           <Box px={2} fontSize={fontSize}>
             {!!heading &&
               React.cloneElement(heading, {
-                fontSize,
+                fontSize: heading.props.fontSize || fontSize,
               })}
             {!!text &&
               React.cloneElement(text, {
                 fontSize,
               })}
 
-            {URLProps && (
+            {URLProps && ctaText && (
               <CustomLink
                 p={
                   linkVariation === 'fill' || linkVariation === 'outline'
@@ -84,14 +84,13 @@ const GenericBanner = ({
                 fontSize={fontSize}
                 {...URLProps}
               >
-                {ctaText &&
-                  React.cloneElement(ctaText, {
-                    fontSize,
-                    zIndex: 2,
-                  })}
+                {React.cloneElement(ctaText, {
+                  fontSize,
+                  zIndex: 2,
+                })}
               </CustomLink>
             )}
-            {Boolean(buttonClick) && (
+            {buttonClick && typeof buttonClick === 'function' && ctaText && (
               <CustomButton
                 size={buttonSize}
                 buttonTextUnderline={buttonVariation === 'link'}
@@ -101,10 +100,9 @@ const GenericBanner = ({
                   buttonClick()
                 }}
               >
-                {ctaText &&
-                  React.cloneElement(ctaText, {
-                    fontSize,
-                  })}
+                {React.cloneElement(ctaText, {
+                  fontSize,
+                })}
               </CustomButton>
             )}
           </Box>
@@ -118,17 +116,11 @@ const GenericBanner = ({
 GenericBanner.propTypes = {
   ...alignItems.propTypes,
   ...justifyContent.propTypes,
+  ...fontSize.propTypes,
   buttonClick: PropTypes.func,
   buttonSize: PropTypes.oneOf(['small', 'medium', 'large']),
   buttonVariation: PropTypes.oneOf(['fill', 'outline', 'link']),
   ctaText: PropTypes.node,
-  fontSize: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-    ),
-  ]),
   heading: PropTypes.node,
   iconLeft: PropTypes.node,
   iconRight: PropTypes.node,

--- a/packages/core/src/GenericBanner/GenericBanner.spec.js
+++ b/packages/core/src/GenericBanner/GenericBanner.spec.js
@@ -29,6 +29,15 @@ const props = {
   color: 'caution.light',
 }
 
+const propsUpdatedHeading = {
+  ...props,
+  heading: (
+    <Text.span fontWeight='bold' textColor='primary.base' mr={1} fontSize={4}>
+      COVID-19
+    </Text.span>
+  ),
+}
+
 describe('GenericBanner', () => {
   test('renders', () => {
     const json = rendererCreateWithTheme(<GenericBanner />).toJSON()
@@ -75,6 +84,30 @@ describe('GenericBanner', () => {
     fireEvent.click(readMoreButton)
     expect(readMoreButton).toHaveStyleRule('font-size', '12px')
     expect(header).toHaveStyleRule('font-size', '12px')
+    expect(text).toHaveStyleRule('font-size', '12px')
+  })
+  test('Renders as expected- with different heading size', () => {
+    const { getByText, getByRole } = render(
+      <GenericBanner
+        {...propsUpdatedHeading}
+        URLProps={{
+          href: 'https://www.priceline.com',
+          target: '_blank',
+        }}
+      />
+    )
+    const header = getByText('COVID-19')
+    const text = getByText(
+      'Update: Your travel may be impacted. Please review this hotels important info.'
+    )
+    expect(getByRole('img')).toBeTruthy()
+    expect(header).toBeTruthy()
+    expect(text).toBeTruthy()
+    const readMoreButton = getByText('Read More')
+    expect(readMoreButton).toBeTruthy()
+    fireEvent.click(readMoreButton)
+    expect(readMoreButton).toHaveStyleRule('font-size', '12px')
+    expect(header).toHaveStyleRule('font-size', '24px')
     expect(text).toHaveStyleRule('font-size', '12px')
   })
 })

--- a/packages/core/src/GenericBanner/GenericBanner.stories.js
+++ b/packages/core/src/GenericBanner/GenericBanner.stories.js
@@ -217,6 +217,29 @@ export const bannerWithURLProps = () => (
   />
 )
 
+export const bannerWithURLPropsAndCustomHeadingSize = () => (
+  <GenericBanner
+    p={2}
+    heading={
+      <Text.span fontWeight='bold' textColor='primary.base' mr={1} fontSize={4}>
+        This is a Heading
+      </Text.span>
+    }
+    text={
+      <Text.span color='warning' mr={1}>
+        This is some text. Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit. Nunc at lacus vel dolor fringilla rhoncus.
+      </Text.span>
+    }
+    URLProps={{
+      href: 'https://www.priceline.com',
+      target: '_blank',
+    }}
+    iconLeft={<Emoticon />}
+    color='alert.light'
+  />
+)
+
 export const bannerWithURLPropsButtonStyleCta = () => (
   <GenericBanner
     p={2}


### PR DESCRIPTION
In GenericBanner:
- allow the heading size to be different than the rest of the text fontSize
-Move the check for the ctaText prop into a better spot so an empty Button or Link doesn't render