### PR TITLE
Fix incorrect default color of RatingBadge

### DIFF
--- a/common/changes/pcln-design-system/ratingbadge-default-color_2021-02-17-15-18.json
+++ b/common/changes/pcln-design-system/ratingbadge-default-color_2021-02-17-15-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix incorrect default color of RatingBadge",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/core/src/RatingBadge/RatingBadge.js
+++ b/packages/core/src/RatingBadge/RatingBadge.js
@@ -15,7 +15,7 @@ const RatingBadge = styled(Box).attrs(({color, bg}) => ({
 RatingBadge.defaultProps = {
   fontWeight: 'bold',
   px: 2,
-  color: 'white',
+  color: 'alert',
   bg: 'orange',
   borderRadius: 1,
 }

--- a/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
+++ b/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
@@ -4,6 +4,7 @@ exports[`RatingBadge renders 1`] = `
 .c0 {
   padding-left: 8px;
   padding-right: 8px;
+  background-color: #f68013;
   color: #fff;
   display: inline-block;
   line-height: 1.5;
@@ -13,7 +14,7 @@ exports[`RatingBadge renders 1`] = `
 
 <div
   className="c0"
-  color="white"
+  color="alert"
   fontWeight="bold"
 />
 `;


### PR DESCRIPTION
This broke inadvertently as a result of https://github.com/priceline/design-system/pull/998.