### PR TITLE
Fix backward compatibility issue in RatingBadge

### DIFF
--- a/common/changes/pcln-autocomplete/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-autocomplete/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-autocomplete",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-autocomplete",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-design-system/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-design-system/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix backward compatibility for props in RatingBadge",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-icons/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-icons/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-icons",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-menu/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-menu/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-menu",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-modal/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-modal/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-modal",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-popover/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-popover/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-popover",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-slider/ratingbadge-color-fix_2021-02-19-18-20.json
+++ b/common/changes/pcln-slider/ratingbadge-color-fix_2021-02-19-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-slider",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-slider",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/core/src/RatingBadge/RatingBadge.js
+++ b/packages/core/src/RatingBadge/RatingBadge.js
@@ -4,8 +4,26 @@ import { fontWeight, borderRadius, } from 'styled-system';
 import { Box } from '../Box'
 import { deprecatedPropType } from '../utils';
 
+// TODO remove once we delete deprecated bg prop
+function getBgAndColorProps(color, bg) {
+  const { bg: defaultBg, color: defaultColor} = RatingBadge.defaultProps
+  if (bg && color && bg !== defaultBg && color !== defaultColor) {
+    // bg and color
+    return {bg, color}
+  } else if (bg === defaultBg && color === defaultColor ) {
+    // no bg, no color
+    return {bg: undefined, color}
+  } else if (bg === defaultBg && color !== defaultColor) {
+    // color, no bg
+    return { bg: undefined, color}
+  } else if (bg !== defaultBg && color === defaultColor) {
+    // bg, no color
+    return {color: bg, bg: undefined}
+  }
+}
+
 const RatingBadge = styled(Box).attrs(({color, bg}) => ({
-  bg: color ? "" : bg // TODO delete once we remove the bg prop
+  ...getBgAndColorProps(color, bg)
 }))`
   display: inline-block;
   line-height: 1.5;

--- a/packages/core/src/RatingBadge/RatingBadge.spec.js
+++ b/packages/core/src/RatingBadge/RatingBadge.spec.js
@@ -3,6 +3,8 @@ import { render } from 'testing-library'
 
 import { RatingBadge } from '..'
 
+const text = "123"
+
 describe('RatingBadge', () => {
   let consoleError
   beforeEach(() => {
@@ -12,12 +14,11 @@ describe('RatingBadge', () => {
   afterEach(() => (console.error = consoleError))
 
   test('renders', () => {
-    const json = rendererCreateWithTheme(<RatingBadge />).toJSON()
-    expect(json).toMatchSnapshot()
+    const { asFragment } = render(<RatingBadge>5</RatingBadge>)
+    expect(asFragment()).toMatchSnapshot()
   })
 
   test('has correct background and text colors', () => {
-    const text = "123"
     const color = 'secondary'
 
     const { getByText } = render(<RatingBadge color={color}>{text}</RatingBadge>)
@@ -28,5 +29,53 @@ describe('RatingBadge', () => {
     const computedStyles = window.getComputedStyle(badge)
     expect(computedStyles.color).toEqual('rgb(255, 255, 255)')
     expect(computedStyles.backgroundColor).toEqual('rgb(0, 170, 0)')
+  })
+
+  test('renders with bg and color', () => {
+    const color = 'secondary'
+    const bg = 'primary'
+
+    const { getByText } = render(<RatingBadge bg={bg} color={color}>{text}</RatingBadge>)
+
+    const badge = getByText(text)
+
+    const computedStyles = window.getComputedStyle(badge)
+    expect(computedStyles.color).toEqual('rgb(0, 170, 0)')
+    expect(computedStyles.backgroundColor).toEqual('rgb(0, 122, 255)')
+  })
+
+  test('renders bg and no color', () => {
+    const bg = 'secondary'
+
+    const { getByText } = render(<RatingBadge bg={bg}>{text}</RatingBadge>)
+
+    const badge = getByText(text)
+
+    const computedStyles = window.getComputedStyle(badge)
+    expect(computedStyles.backgroundColor).toEqual('rgb(0, 170, 0)')
+    expect(computedStyles.color).toEqual('rgb(255, 255, 255)')
+  })
+
+
+  test('renders with no bg and color', () => {
+    const color = 'secondary'
+
+    const { getByText } = render(<RatingBadge color={color}>{text}</RatingBadge>)
+
+    const badge = getByText(text)
+
+    const computedStyles = window.getComputedStyle(badge)
+    expect(computedStyles.backgroundColor).toEqual('rgb(0, 170, 0)')
+    expect(computedStyles.color).toEqual('rgb(255, 255, 255)')
+  })
+
+  test('renders default color with no props', () => {
+    const { getByText } = render(<RatingBadge >{text}</RatingBadge>)
+
+    const badge = getByText(text)
+
+    const computedStyles = window.getComputedStyle(badge)
+    expect(computedStyles.color).toEqual('rgb(255, 255, 255)')
+    expect(computedStyles.backgroundColor).toEqual('rgb(246, 128, 19)')
   })
 })

--- a/packages/core/src/RatingBadge/RatingBadge.stories.js
+++ b/packages/core/src/RatingBadge/RatingBadge.stories.js
@@ -7,12 +7,23 @@ export default {
 }
 
 export const Default = () => <RatingBadge>9.0</RatingBadge>
+export const DeprecatedBgProp = () => <RatingBadge bg='primary.base'>9.0</RatingBadge>
 
-export const Colors = () => (
-  <Flex width="150px" justifyContent="space-between">
-    <RatingBadge color="primary">7.6</RatingBadge>
-    <RatingBadge color="secondary">8.1</RatingBadge>
-    <RatingBadge color="alert">9.0</RatingBadge>
+export const MixBgAndColorProps = () => (
+  <Flex width='150px' justifyContent='space-between'>
+    <RatingBadge color='text.lightest' bg='alert.base'>
+      9.0
+    </RatingBadge>
+    <RatingBadge color='text.dark' bg='secondary.base'>
+      9.0
+    </RatingBadge>
   </Flex>
 )
 
+export const Colors = () => (
+  <Flex width='150px' justifyContent='space-between'>
+    <RatingBadge color='primary'>7.6</RatingBadge>
+    <RatingBadge color='secondary'>8.1</RatingBadge>
+    <RatingBadge color='alert'>9.0</RatingBadge>
+  </Flex>
+)

--- a/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
+++ b/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RatingBadge renders 1`] = `
-.c0 {
+<DocumentFragment>
+  .c1 {
   padding-left: 8px;
   padding-right: 8px;
   background-color: #f68013;
@@ -12,9 +13,26 @@ exports[`RatingBadge renders 1`] = `
   border-radius: 2px;
 }
 
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+  font-weight: 500;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
 <div
-  className="c0"
-  color="alert"
-  fontWeight="bold"
-/>
+    class="c0"
+  >
+    <div
+      class="c1"
+      color="alert"
+      font-weight="bold"
+    >
+      5
+    </div>
+  </div>
+</DocumentFragment>
 `;


### PR DESCRIPTION
We noticed inconsistent behavior when combining the deprecated `bg` prop with `color`.