### PR TITLE
feat(RC-17925): hide popover overlay

### DIFF
--- a/packages/popover/CHANGELOG.json
+++ b/packages/popover/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "pcln-popover",
   "entries": [
     {
+      "version": "4.2.0",
+      "tag": "pcln-popover_v4.2.0",
+      "date": "Wed, 24 Feb 2021 15:59:40 GMT",
+      "comments": {
+        "minor": [
+          {
+            "comment": "adds hideOverlay prop"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.1.0",
       "tag": "pcln-popover_v4.1.0",
       "date": "Tue, 23 Feb 2021 15:06:30 GMT",

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - pcln-popover
 
-This log was last generated on Tue, 23 Feb 2021 15:06:30 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Feb 2021 15:59:40 GMT and should not be manually modified.
+
+## 4.2.0
+Wed, 24 Feb 2021 15:59:40 GMT
+
+### Minor changes
+
+- adds hideOverlay prop
 
 ## 4.1.0
 Tue, 23 Feb 2021 15:06:30 GMT

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-popover",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "React component for popover",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/popover/src/Popover/Popover.js
+++ b/packages/popover/src/Popover/Popover.js
@@ -113,6 +113,8 @@ Popover.propTypes = {
   children: PropTypes.node,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
+  hideArrow: PropTypes.bool,
+  hideOverlay: PropTypes.bool,
 }
 
 Popover.defaultProps = {

--- a/packages/popover/src/Popover/Popover.stories.js
+++ b/packages/popover/src/Popover/Popover.stories.js
@@ -153,6 +153,19 @@ export const bottom = () => (
   </Popover>
 )
 
+export const hideOverlay = () => (
+  <Popover
+    renderContent={InnerContent}
+    placement='bottom'
+    ariaLabel='Bottom Popover'
+    hideOverlay
+    idx={2}
+    width={400}
+  >
+    <Link>Open Popover</Link>
+  </Popover>
+)
+
 export const rightWithOverlayOnScrollPosition = () => (
   <Flex flexDirection='column'>
     <Text mb='2000px'>Scroll down, popover trigger is at the end</Text>

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -76,6 +76,7 @@ class PopoverContent extends Component {
       renderContent,
       trapFocus,
       hideArrow,
+      hideOverlay,
     } = this.props
     const styleProps = {
       borderColor: this.getBorderColorName(
@@ -149,11 +150,13 @@ class PopoverContent extends Component {
             </PopperGuide>
           )}
         </Popper>
-        <Overlay
-          handleClick={onCloseRequest}
-          zIndex={styleProps.zIndex - 1}
-          overlayOpacity={overlayOpacity}
-        />
+        {!hideOverlay && (
+          <Overlay
+            handleClick={onCloseRequest}
+            zIndex={styleProps.zIndex - 1}
+            overlayOpacity={overlayOpacity}
+          />
+        )}
       </React.Fragment>,
       // Append each instance of the Popover as portal directly to the body
       document.querySelector('body')
@@ -201,6 +204,7 @@ PopoverContent.propTypes = {
   overlayOpacity: PropTypes.number,
   trapFocus: PropTypes.bool,
   hideArrow: PropTypes.bool,
+  hideOverlay: PropTypes.bool,
 }
 
 PopoverContent.defaultProps = {

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -32,4 +32,18 @@ describe('PopoverContent', () => {
     )
     expect(getByRole('dialog')).toHaveStyleRule('z-index', zIndex)
   })
+
+  it('renders with overlay', () => {
+    const { queryByTestId } = render(
+      <PopoverContent renderContent={() => 'Content'} />
+    )
+    expect(queryByTestId('__pcln-popover_Overlay')).toBeInTheDocument()
+  })
+
+  it('does not render with overlay', () => {
+    const { queryByTestId } = render(
+      <PopoverContent hideOverlay renderContent={() => 'Content'} />
+    )
+    expect(queryByTestId('__pcln-popover_Overlay')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Added new optional prop hideOverlay to Popover component - so that when opened, popover has the option to not be closed by clicking on overlay (e.g. only by clicking on X (close) button inside popover content.