### PR TITLE
Don't fail other jobs if one CI job fails

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
 


### PR DESCRIPTION
This will create a storybook in Chromatic even if one CI job fails