### PR TITLE
Uxpt/1162: password input component

### DIFF
--- a/common/changes/pcln-design-system/UXPT-1162-password-input-component_2021-03-09-21-58.json
+++ b/common/changes/pcln-design-system/UXPT-1162-password-input-component_2021-03-09-21-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "created a new passwordInput component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "jon.choi@priceline.com"
+}

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { space, fontSize, themeGet } from 'styled-system'
+import { space, fontSize, themeGet, style } from 'styled-system'
 import PropTypes from 'prop-types'
 import { Text } from '../Text'
 import {
@@ -9,6 +9,8 @@ import {
   borders,
   deprecatedColorValue,
 } from '../utils'
+import { IconField } from '../IconField'
+import { Visibility } from 'pcln-icons'
 
 const StyledInput = styled.input`
   appearance: none;
@@ -43,7 +45,7 @@ const StyledInput = styled.input`
 const INPUT_ERROR_TEXT = 'InputHelperText'
 
 export const Input = React.forwardRef((props, ref) => {
-  const { helperText, color, ...restProps } = props
+  const { helperText, color, icon, ...restProps } = props
 
   return (
     <>

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { space, fontSize, themeGet, style } from 'styled-system'
+import { space, fontSize, themeGet } from 'styled-system'
 import PropTypes from 'prop-types'
 import { Text } from '../Text'
 import {
@@ -43,7 +43,7 @@ const StyledInput = styled.input`
 const INPUT_ERROR_TEXT = 'InputHelperText'
 
 export const Input = React.forwardRef((props, ref) => {
-  const { helperText, color, icon, ...restProps } = props
+  const { helperText, color, ...restProps } = props
   return (
     <>
       <StyledInput {...restProps} color={color} ref={ref} />

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -9,8 +9,6 @@ import {
   borders,
   deprecatedColorValue,
 } from '../utils'
-import { IconField } from '../IconField'
-import { Visibility } from 'pcln-icons'
 
 const StyledInput = styled.input`
   appearance: none;
@@ -46,7 +44,6 @@ const INPUT_ERROR_TEXT = 'InputHelperText'
 
 export const Input = React.forwardRef((props, ref) => {
   const { helperText, color, icon, ...restProps } = props
-
   return (
     <>
       <StyledInput {...restProps} color={color} ref={ref} />

--- a/packages/core/src/Input/Input.stories.js
+++ b/packages/core/src/Input/Input.stories.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 import { Box, Input, Label, Divider, Button } from '..'
-import { Visibility } from 'pcln-icons'
 
 export default {
   title: 'Input',

--- a/packages/core/src/Input/Input.stories.js
+++ b/packages/core/src/Input/Input.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ForwardRefDemo from '../../storybook/utils/ForwardRefsDemo'
 import { Box, Input, Label, Divider, Button } from '..'
+import { Visibility } from 'pcln-icons'
 
 export default {
   title: 'Input',
@@ -79,10 +80,7 @@ export const ForwardsRefs = () => (
     refChild={(dsRef) => (
       <>
         <Input ref={dsRef} placeholder='Priceline!' />
-        <Button
-          onClick={() => dsRef.current.focus()}
-          mt={3}
-        >
+        <Button onClick={() => dsRef.current.focus()} mt={3}>
           Click to focus the input via ref
         </Button>
       </>

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -1,24 +1,48 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { Flex, Text, Input, IconField, Badge } from '../../src'
-import { Visibility, Check } from 'pcln-icons'
-import { ProgressBar } from '../ProgressBar'
+import {
+  Flex,
+  Text,
+  Input,
+  IconField,
+  Badge,
+  ProgressBar,
+  IconButton,
+} from '../../src'
+import { Visibility, VisibilityOff, Check } from 'pcln-icons'
 
 function PasswordInput({
-  inputBoxTitle,
+  label,
   hasProgressBar,
   progressBarSteps,
   progressBarCurrentStep,
 }) {
+  const [visibility, setVisibility] = useState(false)
+  const [visibilityIcon, setVisibilityIcon] = useState(
+    <Visibility color='text.light' />
+  )
+  const [inputType, setInputType] = useState('password')
+
+  const changeVisibility = () => {
+    visibility
+      ? setVisibilityIcon(<Visibility color='text.light' />)
+      : setVisibilityIcon(<VisibilityOff color='text.light' />)
+    visibility ? setVisibility(false) : setVisibility(true)
+    visibility ? setInputType('password') : setInputType('text')
+  }
+
   return (
     <Flex flexDirection='column'>
       <Text bold color='text.light' mb={2}>
-        {inputBoxTitle}
+        {label}
       </Text>
       <IconField>
-        <Input />
-        <Check color='secondary' />
+        <Input type={inputType} />
+        <IconButton
+          title='visibility button'
+          icon={visibilityIcon}
+          onClick={changeVisibility}
+        />
       </IconField>
       {hasProgressBar && (
         <Flex flexDirection='column'>
@@ -57,7 +81,7 @@ PasswordInput.defaultProps = {
 }
 
 PasswordInput.prototype = {
-  inputBoxTitle: PropTypes.string,
+  label: PropTypes.string,
   hasProgressBar: PropTypes.bool,
   progressBarSteps: PropTypes.arrayOf(
     PropTypes.shape({ color: PropTypes.string })

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -21,96 +21,51 @@ import {
   mediaQueries,
 } from '../../src'
 
-const CustomFlex = styled(Flex)`
-  margin-top: ${themeGet('space.2')}px;
-  ${mediaQueries[1]} {
-    margin-top: 0;
-  }
-`
-
 const CustomText = styled(Text)`
-  font-size: ${themeGet('fontSizes.0')}px;
+  white-space: nowrap;
 `
 
-const FlexDesktopOnly = styled(Flex)`
-  flex-direction: column;
-  ${mediaQueries[1]} {
-    flex-direction: row;
-    margin-bottom: ${themeGet('space.2')}px;
-  }
-`
+const maxProgressBarLength = 4
 
 function PasswordInput({
   label,
   hasProgressBar,
   progressBarSteps,
-  progressBarDefaultStep,
   regexChecks,
   value,
+  onChange,
 }) {
   const [showPassword, setShowPassword] = useState(false)
-  const inputType = showPassword ? 'text' : 'password'
-  const visibilityIcon = showPassword ? (
-    <VisibilityOff color='text.light' />
-  ) : (
-    <Visibility color='text.light' />
-  )
+  const [passedChecks, setPassedChecks] = useState([])
+
   const changeVisibility = () => setShowPassword(!showPassword)
-
-  const [inputPassword, setInputPassword] = useState('')
-  const [strengthLevel, setStrengthLevel] = useState(progressBarDefaultStep)
-  const [showCheckIcon, setShowCheckIcon] = useState(false)
-  const [hasNumOrSpecial, setHasNumOrSpecial] = useState(false)
-  const [hasMinEightChar, setHasMinEightChar] = useState(false)
-
-  const successIconOn = (
-    <Success
-      size='16px'
-      color={'secondary'}
-      mr={1}
-      data-testid='check-icon-on'
-    />
-  )
-  const successIconOff = (
-    <SuccessOutline
-      size='16px'
-      color={'text.light'}
-      mr={1}
-      data-testid='check-icon-off'
-    />
-  )
-
-  const successIconOne = hasNumOrSpecial ? successIconOn : successIconOff
-  const successIconTwo = hasMinEightChar ? successIconOn : successIconOff
-  const requirementOneColor = hasNumOrSpecial ? 'secondary' : 'text.light'
-  const requirementTwoColor = hasMinEightChar ? 'secondary' : 'text.light'
 
   const handleChange = (event) => {
     const currentInput = event.target.value
-    const progressBarLength = 4
-    const hasNumberOrSpecial =
-      regexChecks[2].regex.test(currentInput) ||
-      regexChecks[3].regex.test(currentInput)
-    const hasMinimumEight = regexChecks[4].regex.test(currentInput)
-    let strengthPoint = 0
-    setInputPassword(currentInput)
+    const passedChecks = []
 
-    regexChecks.forEach((element) => {
-      element.regex.test(currentInput) && strengthPoint++
+    regexChecks.forEach((element, index) => {
+      element.regex.test(currentInput) && passedChecks.push(index)
     })
 
-    strengthPoint < regexChecks.length - 2
-      ? setStrengthLevel(1)
-      : setStrengthLevel(
-          progressBarLength - (regexChecks.length - strengthPoint)
-        )
+    setPassedChecks(passedChecks)
 
-    hasNumberOrSpecial ? setHasNumOrSpecial(true) : setHasNumOrSpecial(false)
-    hasMinimumEight ? setHasMinEightChar(true) : setHasMinEightChar(false)
-    hasNumberOrSpecial && hasMinimumEight
-      ? setShowCheckIcon(true)
-      : setShowCheckIcon(false)
+    const isValid = passedChecks.length === regexChecks.length
+
+    onChange && onChange({ isValid, value: currentInput })
   }
+
+  const inputType = showPassword ? 'text' : 'password'
+  const VisibilityIcon = showPassword ? VisibilityOff : Visibility
+
+  const strengthLevel = Math.max(
+    Math.floor(
+      (maxProgressBarLength / regexChecks.length) * passedChecks.length
+    ),
+    1
+  )
+  const currentStep = progressBarSteps[strengthLevel - 1]
+  const showCheckIcon = strengthLevel === maxProgressBarLength
 
   return (
     <Flex flexDirection='column'>
@@ -120,6 +75,7 @@ function PasswordInput({
       <IconField>
         <Input
           type={inputType}
+          value={value}
           onChange={handleChange}
           data-testid='input-field'
         />
@@ -128,41 +84,47 @@ function PasswordInput({
         )}
         <IconButton
           title='visibility-button'
-          icon={visibilityIcon}
+          icon={<VisibilityIcon color='text.light' />}
           onClick={changeVisibility}
         />
       </IconField>
       {hasProgressBar && (
         <Flex flexDirection='column'>
           <Flex alignItems='center' mt={2} mb={2}>
-            <CustomText color='text.light' mr={2}>
+            <CustomText fontSize={0} color='text.light' mr={2}>
               Password Strength:{' '}
             </CustomText>
-            <Badge
-              color={progressBarSteps[strengthLevel - 1].color}
-              size='small'
-            >
-              {progressBarSteps[strengthLevel - 1].text}
+            <Badge color={currentStep.color} size='small'>
+              {currentStep.text}
             </Badge>
           </Flex>
           <ProgressBar steps={progressBarSteps} currentStep={strengthLevel} />
-          <FlexDesktopOnly align-items='center' mt={2}>
-            <CustomText color='text.light' mr={3}>
+          <Flex
+            flexDirection={['column', null, 'row']}
+            mt={2}
+            mb={[2, null, 0]}
+          >
+            <CustomText fontSize={0} color='text.light' mr={3}>
               Must contain:
             </CustomText>
-            <CustomFlex alignItems='center'>
-              {successIconOne}
-              <CustomText color={requirementOneColor} mr={3}>
-                1 number or special character
-              </CustomText>
-            </CustomFlex>
-            <CustomFlex alignItems='center'>
-              {successIconTwo}
-              <CustomText color={requirementTwoColor}>
-                8 characters minimum
-              </CustomText>
-            </CustomFlex>
-          </FlexDesktopOnly>
+            <Flex flexDirection={['column', null, 'row']} wrap>
+              {regexChecks.map((check, index) => {
+                const didPass =
+                  passedChecks.findIndex((value) => index === value) !== -1
+                const Icon = didPass ? Success : SuccessOutline
+                const color = didPass ? 'success' : 'text.light'
+
+                return (
+                  <Flex alignItems='center' mt={[2, null, 0]} mb={[0, null, 2]}>
+                    <Icon size='16px' color={color} mr={1} />
+                    <CustomText fontSize={0} color={color} mr={3}>
+                      {check.label}
+                    </CustomText>
+                  </Flex>
+                )
+              })}
+            </Flex>
+          </Flex>
         </Flex>
       )}
     </Flex>

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -15,20 +15,30 @@ function PasswordInput({
   label,
   hasProgressBar,
   progressBarSteps,
-  progressBarCurrentStep,
+  progressBarDefaultStep,
+  regexChecks,
 }) {
-  const [visibility, setVisibility] = useState(false)
-  const [visibilityIcon, setVisibilityIcon] = useState(
+  const [showPassword, setShowPassword] = useState(false)
+  const inputType = showPassword ? 'text' : 'password'
+  const visibilityIcon = showPassword ? (
+    <VisibilityOff color='text.light' />
+  ) : (
     <Visibility color='text.light' />
   )
-  const [inputType, setInputType] = useState('password')
+  const changeVisibility = () => setShowPassword(!showPassword)
 
-  const changeVisibility = () => {
-    visibility
-      ? setVisibilityIcon(<Visibility color='text.light' />)
-      : setVisibilityIcon(<VisibilityOff color='text.light' />)
-    visibility ? setVisibility(false) : setVisibility(true)
-    visibility ? setInputType('password') : setInputType('text')
+  const [inputPassword, setInputPassword] = useState('')
+  const [strengthLevel, setStrengthLevel] = useState(progressBarDefaultStep)
+
+  const handleChange = (event) => {
+    const currentInput = event.target.value
+    setInputPassword(currentInput)
+
+    let strengthPoint = 0
+    regexChecks.forEach((element) => {
+      element.regex.test(currentInput) && strengthPoint++
+    })
+    strengthPoint == 0 ? setStrengthLevel(1) : setStrengthLevel(strengthPoint)
   }
 
   return (
@@ -37,7 +47,7 @@ function PasswordInput({
         {label}
       </Text>
       <IconField>
-        <Input type={inputType} />
+        <Input type={inputType} onChange={handleChange} />
         <IconButton
           title='visibility button'
           icon={visibilityIcon}
@@ -51,18 +61,14 @@ function PasswordInput({
               Password Strength:{' '}
             </Text>
             <Badge
-              bg={progressBarSteps[progressBarCurrentStep - 1].color}
-              color='white'
+              color={progressBarSteps[strengthLevel - 1].color}
               mt={2}
               ml={2}
             >
-              {progressBarSteps[progressBarCurrentStep - 1].text}
+              {progressBarSteps[strengthLevel - 1].text}
             </Badge>
           </Flex>
-          <ProgressBar
-            steps={progressBarSteps}
-            currentStep={progressBarCurrentStep}
-          />
+          <ProgressBar steps={progressBarSteps} currentStep={strengthLevel} />
         </Flex>
       )}
     </Flex>
@@ -77,7 +83,13 @@ PasswordInput.defaultProps = {
     { color: 'primary', text: 'GOOD' },
     { color: 'success', text: 'STRONG' },
   ],
-  progressBarCurrentStep: 1,
+  progressBarDefaultStep: 1,
+  regexChecks: [
+    { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },
+    { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
+    { label: '1 Number', regex: /(?=.*[0-9])/ },
+    { label: '1 Special Charater', regex: /(?=.*[!@#$%^&*()])/ },
+  ],
 }
 
 PasswordInput.prototype = {
@@ -86,7 +98,10 @@ PasswordInput.prototype = {
   progressBarSteps: PropTypes.arrayOf(
     PropTypes.shape({ color: PropTypes.string })
   ),
-  progressBarCurrentStep: PropTypes.number,
+  progressBarDefaultStep: PropTypes.number,
+  regexChecks: PropTypes.arrayOf(
+    PropTypes.shape({ label: PropTypes.string, regex: PropTypes.string })
+  ),
 }
 
 export default PasswordInput

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -42,9 +42,11 @@ function PasswordInput({
     const currentInput = event.target.value
     const passedChecks = []
 
-    regexChecks.forEach((element, index) => {
-      element.regex.test(currentInput) && passedChecks.push(index)
-    })
+    regexChecks.reduce(
+      (acc, element, index) =>
+        element.regex.test(currentInput) && passedChecks.push(index),
+      passedChecks
+    )
 
     setPassedChecks(passedChecks)
 

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -1,5 +1,14 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { themeGet } from 'styled-system'
+import {
+  Visibility,
+  VisibilityOff,
+  Check,
+  Success,
+  SuccessOutline,
+} from 'pcln-icons'
 import {
   Flex,
   Text,
@@ -10,11 +19,13 @@ import {
   ProgressBar,
   IconButton,
 } from '../../src'
-import { Visibility, VisibilityOff, Check } from 'pcln-icons'
-import styled from 'styled-components'
-import { themeGet } from 'styled-system'
 
-const CustomLabel = styled(Label)`
+const CustomFlex = styled(Flex)`
+  margin-left: ${themeGet('space.3')}px;
+  align-contents: center;
+`
+
+const CustomText = styled(Text)`
   font-size: ${themeGet('fontSizes.0')}px;
 `
 
@@ -37,28 +48,51 @@ function PasswordInput({
   const [inputPassword, setInputPassword] = useState('')
   const [strengthLevel, setStrengthLevel] = useState(progressBarDefaultStep)
   const [showCheckIcon, setShowCheckIcon] = useState(false)
+  const [hasNumOrSpecial, setHasNumOrSpecial] = useState(false)
+  const [hasMinEightChar, setHasMinEightChar] = useState(false)
+
+  const successIconOn = <Success size='12px' color={'secondary'} mr={1} />
+  const successIconOff = (
+    <SuccessOutline size='12px' color={'text.light'} mr={1} />
+  )
+
+  const successIconOne = hasNumOrSpecial ? successIconOn : successIconOff
+  const successIconTwo = hasMinEightChar ? successIconOn : successIconOff
+  const requirementOneColor = hasNumOrSpecial ? 'secondary' : 'text.light'
+  const requirementTwoColor = hasMinEightChar ? 'secondary' : 'text.light'
+
   const handleChange = (event) => {
     const currentInput = event.target.value
     const progressBarLength = 4
+    const hasNumberOrSpecial =
+      regexChecks[2].regex.test(currentInput) ||
+      regexChecks[3].regex.test(currentInput)
+    const hasMinimumEight = regexChecks[4].regex.test(currentInput)
     let strengthPoint = 0
     setInputPassword(currentInput)
 
     regexChecks.forEach((element) => {
       element.regex.test(currentInput) && strengthPoint++
     })
+
     strengthPoint < regexChecks.length - 2
       ? setStrengthLevel(1)
       : setStrengthLevel(
           progressBarLength - (regexChecks.length - strengthPoint)
         )
-    strengthPoint == regexChecks.length
+
+    hasNumberOrSpecial ? setHasNumOrSpecial(true) : setHasNumOrSpecial(false)
+    hasMinimumEight ? setHasMinEightChar(true) : setHasMinEightChar(false)
+    hasNumberOrSpecial && hasMinimumEight
       ? setShowCheckIcon(true)
       : setShowCheckIcon(false)
   }
 
   return (
     <Flex flexDirection='column'>
-      <CustomLabel mb={2}>{label}</CustomLabel>
+      <Label fontSize={0} mb={2}>
+        {label}
+      </Label>
       <IconField>
         <Input type={inputType} onChange={handleChange} />
         {showCheckIcon && <Check color='secondary' />}
@@ -70,19 +104,33 @@ function PasswordInput({
       </IconField>
       {hasProgressBar && (
         <Flex flexDirection='column'>
-          <Flex alignContent='center' mb={2}>
-            <Text color='text.light' mt={2}>
+          <Flex alignItems='center' mt={2} mb={2}>
+            <CustomText color='text.light' mr={2}>
               Password Strength:{' '}
-            </Text>
+            </CustomText>
             <Badge
               color={progressBarSteps[strengthLevel - 1].color}
-              mt={2}
-              ml={2}
+              size='small'
             >
               {progressBarSteps[strengthLevel - 1].text}
             </Badge>
           </Flex>
           <ProgressBar steps={progressBarSteps} currentStep={strengthLevel} />
+          <Flex align-items='center' mt={2}>
+            <CustomText color='text.light'>Must contain:</CustomText>
+            <CustomFlex alignItems='center'>
+              {successIconOne}
+              <CustomText color={requirementOneColor}>
+                1 number or special character
+              </CustomText>
+            </CustomFlex>
+            <CustomFlex alignItems='center'>
+              {successIconTwo}
+              <CustomText color={requirementTwoColor}>
+                8 characters minimum
+              </CustomText>
+            </CustomFlex>
+          </Flex>
         </Flex>
       )}
     </Flex>

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -4,12 +4,19 @@ import {
   Flex,
   Text,
   Input,
+  Label,
   IconField,
   Badge,
   ProgressBar,
   IconButton,
 } from '../../src'
 import { Visibility, VisibilityOff, Check } from 'pcln-icons'
+import styled from 'styled-components'
+import { themeGet } from 'styled-system'
+
+const CustomLabel = styled(Label)`
+  font-size: ${themeGet('fontSizes.0')}px;
+`
 
 function PasswordInput({
   label,
@@ -29,25 +36,32 @@ function PasswordInput({
 
   const [inputPassword, setInputPassword] = useState('')
   const [strengthLevel, setStrengthLevel] = useState(progressBarDefaultStep)
-
+  const [showCheckIcon, setShowCheckIcon] = useState(false)
   const handleChange = (event) => {
     const currentInput = event.target.value
+    const progressBarLength = 4
+    let strengthPoint = 0
     setInputPassword(currentInput)
 
-    let strengthPoint = 0
     regexChecks.forEach((element) => {
       element.regex.test(currentInput) && strengthPoint++
     })
-    strengthPoint == 0 ? setStrengthLevel(1) : setStrengthLevel(strengthPoint)
+    strengthPoint < regexChecks.length - 2
+      ? setStrengthLevel(1)
+      : setStrengthLevel(
+          progressBarLength - (regexChecks.length - strengthPoint)
+        )
+    strengthPoint == regexChecks.length
+      ? setShowCheckIcon(true)
+      : setShowCheckIcon(false)
   }
 
   return (
     <Flex flexDirection='column'>
-      <Text bold color='text.light' mb={2}>
-        {label}
-      </Text>
+      <CustomLabel mb={2}>{label}</CustomLabel>
       <IconField>
         <Input type={inputType} onChange={handleChange} />
+        {showCheckIcon && <Check color='secondary' />}
         <IconButton
           title='visibility button'
           icon={visibilityIcon}
@@ -88,7 +102,8 @@ PasswordInput.defaultProps = {
     { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },
     { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
     { label: '1 Number', regex: /(?=.*[0-9])/ },
-    { label: '1 Special Charater', regex: /(?=.*[!@#$%^&*()])/ },
+    { label: '1 Special Character', regex: /(?=.*[!@#$%^&*()])/ },
+    { label: 'at least 8 Characters', regex: /.{8,}/ },
   ],
 }
 

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { themeGet } from 'styled-system'
 import {
   Visibility,
   VisibilityOff,
@@ -18,7 +17,6 @@ import {
   Badge,
   ProgressBar,
   IconButton,
-  mediaQueries,
 } from '../../src'
 
 const CustomText = styled(Text)`
@@ -51,7 +49,6 @@ function PasswordInput({
     setPassedChecks(passedChecks)
 
     const isValid = passedChecks.length === regexChecks.length
-
     onChange && onChange({ isValid, value: currentInput })
   }
 
@@ -116,7 +113,14 @@ function PasswordInput({
 
                 return (
                   <Flex alignItems='center' mt={[2, null, 0]} mb={[0, null, 2]}>
-                    <Icon size='16px' color={color} mr={1} />
+                    <Icon
+                      size='16px'
+                      color={color}
+                      mr={1}
+                      data-testid={
+                        Icon == Success ? 'check-icon-on' : 'check-icon-off'
+                      }
+                    />
                     <CustomText fontSize={0} color={color} mr={3}>
                       {check.label}
                     </CustomText>

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Flex, Text, Input, IconField, Badge } from '../../src'
+import { Visibility, Check } from 'pcln-icons'
+import { ProgressBar } from '../ProgressBar'
+
+function PasswordInput({
+  inputBoxTitle,
+  hasProgressBar,
+  progressBarSteps,
+  progressBarCurrentStep,
+}) {
+  return (
+    <Flex flexDirection='column'>
+      <Text bold color='text.light' mb={2}>
+        {inputBoxTitle}
+      </Text>
+      <IconField>
+        <Input />
+        <Check color='secondary' />
+      </IconField>
+      {hasProgressBar && (
+        <Flex flexDirection='column'>
+          <Flex alignContent='center' mb={2}>
+            <Text color='text.light' mt={2}>
+              Password Strength:{' '}
+            </Text>
+            <Badge
+              bg={progressBarSteps[progressBarCurrentStep - 1].color}
+              color='white'
+              mt={2}
+              ml={2}
+            >
+              {progressBarSteps[progressBarCurrentStep - 1].text}
+            </Badge>
+          </Flex>
+          <ProgressBar
+            steps={progressBarSteps}
+            currentStep={progressBarCurrentStep}
+          />
+        </Flex>
+      )}
+    </Flex>
+  )
+}
+
+PasswordInput.defaultProps = {
+  hasProgressBar: false,
+  progressBarSteps: [
+    { color: 'warning', text: 'WEAK' },
+    { color: 'caution', text: 'FAIR' },
+    { color: 'primary', text: 'GOOD' },
+    { color: 'success', text: 'STRONG' },
+  ],
+  progressBarCurrentStep: 1,
+}
+
+PasswordInput.prototype = {
+  inputBoxTitle: PropTypes.string,
+  hasProgressBar: PropTypes.bool,
+  progressBarSteps: PropTypes.arrayOf(
+    PropTypes.shape({ color: PropTypes.string })
+  ),
+  progressBarCurrentStep: PropTypes.number,
+}
+
+export default PasswordInput

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -112,7 +112,12 @@ function PasswordInput({
                 const color = didPass ? 'success' : 'text.light'
 
                 return (
-                  <Flex alignItems='center' mt={[2, null, 0]} mb={[0, null, 2]}>
+                  <Flex
+                    alignItems='center'
+                    mt={[2, null, 0]}
+                    mb={[0, null, 2]}
+                    key={'regex-label-' + index}
+                  >
                     <Icon
                       size='16px'
                       color={color}
@@ -157,7 +162,7 @@ PasswordInput.propTypes = {
   label: PropTypes.string,
   hasProgressBar: PropTypes.bool,
   progressBarSteps: PropTypes.arrayOf(
-    PropTypes.shape({ color: PropTypes.string })
+    PropTypes.shape({ color: PropTypes.string, text: PropTypes.string })
   ),
   progressBarDefaultStep: PropTypes.number,
   regexChecks: PropTypes.arrayOf(

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -153,7 +153,7 @@ PasswordInput.defaultProps = {
   ],
 }
 
-PasswordInput.prototype = {
+PasswordInput.propTypes = {
   label: PropTypes.string,
   hasProgressBar: PropTypes.bool,
   progressBarSteps: PropTypes.arrayOf(
@@ -163,6 +163,8 @@ PasswordInput.prototype = {
   regexChecks: PropTypes.arrayOf(
     PropTypes.shape({ label: PropTypes.string, regex: PropTypes.string })
   ),
+  value: PropTypes.string,
+  onChange: PropTypes.func,
 }
 
 export default PasswordInput

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -46,6 +46,7 @@ function PasswordInput({
   progressBarSteps,
   progressBarDefaultStep,
   regexChecks,
+  value,
 }) {
   const [showPassword, setShowPassword] = useState(false)
   const inputType = showPassword ? 'text' : 'password'
@@ -62,9 +63,21 @@ function PasswordInput({
   const [hasNumOrSpecial, setHasNumOrSpecial] = useState(false)
   const [hasMinEightChar, setHasMinEightChar] = useState(false)
 
-  const successIconOn = <Success size='16px' color={'secondary'} mr={1} />
+  const successIconOn = (
+    <Success
+      size='16px'
+      color={'secondary'}
+      mr={1}
+      data-testid='check-icon-on'
+    />
+  )
   const successIconOff = (
-    <SuccessOutline size='16px' color={'text.light'} mr={1} />
+    <SuccessOutline
+      size='16px'
+      color={'text.light'}
+      mr={1}
+      data-testid='check-icon-off'
+    />
   )
 
   const successIconOne = hasNumOrSpecial ? successIconOn : successIconOff
@@ -105,10 +118,16 @@ function PasswordInput({
         {label}
       </Label>
       <IconField>
-        <Input type={inputType} onChange={handleChange} />
-        {showCheckIcon && <Check color='secondary' />}
+        <Input
+          type={inputType}
+          onChange={handleChange}
+          data-testid='input-field'
+        />
+        {showCheckIcon && (
+          <Check color='secondary' data-testid='check-mark-icon' />
+        )}
         <IconButton
-          title='visibility button'
+          title='visibility-button'
           icon={visibilityIcon}
           onClick={changeVisibility}
         />

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -32,6 +32,7 @@ function PasswordInput({
   regexChecks,
   value,
   onChange,
+  autoComplete,
 }) {
   const [showPassword, setShowPassword] = useState(false)
   const [passedChecks, setPassedChecks] = useState([])
@@ -77,6 +78,7 @@ function PasswordInput({
           value={value}
           onChange={handleChange}
           data-testid='input-field'
+          autoComplete={autoComplete}
         />
         {showCheckIcon && (
           <Check color='secondary' data-testid='check-mark-icon' />
@@ -172,6 +174,7 @@ PasswordInput.propTypes = {
   ),
   value: PropTypes.string,
   onChange: PropTypes.func,
+  autoComplete: PropTypes.string,
 }
 
 export default PasswordInput

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -18,15 +18,26 @@ import {
   Badge,
   ProgressBar,
   IconButton,
+  mediaQueries,
 } from '../../src'
 
 const CustomFlex = styled(Flex)`
-  margin-left: ${themeGet('space.3')}px;
-  align-contents: center;
+  margin-top: ${themeGet('space.2')}px;
+  ${mediaQueries[1]} {
+    margin-top: 0;
+  }
 `
 
 const CustomText = styled(Text)`
   font-size: ${themeGet('fontSizes.0')}px;
+`
+
+const FlexDesktopOnly = styled(Flex)`
+  flex-direction: column;
+  ${mediaQueries[1]} {
+    flex-direction: row;
+    margin-bottom: ${themeGet('space.2')}px;
+  }
 `
 
 function PasswordInput({
@@ -51,9 +62,9 @@ function PasswordInput({
   const [hasNumOrSpecial, setHasNumOrSpecial] = useState(false)
   const [hasMinEightChar, setHasMinEightChar] = useState(false)
 
-  const successIconOn = <Success size='12px' color={'secondary'} mr={1} />
+  const successIconOn = <Success size='16px' color={'secondary'} mr={1} />
   const successIconOff = (
-    <SuccessOutline size='12px' color={'text.light'} mr={1} />
+    <SuccessOutline size='16px' color={'text.light'} mr={1} />
   )
 
   const successIconOne = hasNumOrSpecial ? successIconOn : successIconOff
@@ -116,11 +127,13 @@ function PasswordInput({
             </Badge>
           </Flex>
           <ProgressBar steps={progressBarSteps} currentStep={strengthLevel} />
-          <Flex align-items='center' mt={2}>
-            <CustomText color='text.light'>Must contain:</CustomText>
+          <FlexDesktopOnly align-items='center' mt={2}>
+            <CustomText color='text.light' mr={3}>
+              Must contain:
+            </CustomText>
             <CustomFlex alignItems='center'>
               {successIconOne}
-              <CustomText color={requirementOneColor}>
+              <CustomText color={requirementOneColor} mr={3}>
                 1 number or special character
               </CustomText>
             </CustomFlex>
@@ -130,7 +143,7 @@ function PasswordInput({
                 8 characters minimum
               </CustomText>
             </CustomFlex>
-          </Flex>
+          </FlexDesktopOnly>
         </Flex>
       )}
     </Flex>

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -118,7 +118,7 @@ function PasswordInput({
                       color={color}
                       mr={1}
                       data-testid={
-                        Icon == Success ? 'check-icon-on' : 'check-icon-off'
+                        Icon === Success ? 'check-icon-on' : 'check-icon-off'
                       }
                     />
                     <CustomText fontSize={0} color={color} mr={3}>

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -5,12 +5,18 @@ import PasswordInput from './PasswordInput'
 
 describe('PasswordInput', () => {
   it('test show/hide password options', () => {
-    render(<PasswordInput hasProgressBar />)
+    const mockOnChange = jest.fn()
+    render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
     const inputField = screen.getByTestId('input-field')
     const visibilityButton = screen.getByTitle('visibility-button')
     expect(inputField).toHaveAttribute('type', 'password')
     fireEvent.click(visibilityButton)
+    fireEvent.change(inputField), { target: { value: 'Password1!' } }
     expect(inputField).toHaveAttribute('type', 'text')
+    expect(mockOnChange).toHaveBeenCalledWith({
+      isValid: true,
+      value: 'Password1!',
+    })
   })
 
   it('test with a strong password', () => {

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -15,7 +15,6 @@ describe('PasswordInput', () => {
     const visibilityButton = screen.getByTitle('visibility-button')
     expect(inputField).toHaveAttribute('type', 'password')
     fireEvent.click(visibilityButton)
-    fireEvent.change(inputField), { target: { value: 'Password1!' } }
     expect(inputField).toHaveAttribute('type', 'text')
   })
 

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, screen, fireEvent } from 'testing-library'
+import userEvent from '@testing-library/user-event'
+import PasswordInput from './PasswordInput'
+
+describe('PasswordInput', () => {
+  it('test show/hide password options', () => {
+    render(<PasswordInput hasProgressBar />)
+    const inputField = screen.getByTestId('input-field')
+    const visibilityButton = screen.getByTitle('visibility-button')
+    expect(inputField).toHaveAttribute('type', 'password')
+    fireEvent.click(visibilityButton)
+    expect(inputField).toHaveAttribute('type', 'text')
+  })
+
+  it('test with a strong password', () => {
+    render(<PasswordInput hasProgressBar />)
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'GoodPassword1!')
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(2)
+    expect(checkIconOff.length).toBe(0)
+    expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(1)
+
+    const progressBarFour = screen.getByTestId('test-id-3')
+    expect(progressBarFour).toHaveStyleRule('background-color', '#0a0')
+  })
+
+  it('test with a no number or special character password', () => {
+    render(<PasswordInput hasProgressBar />)
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'SamplePassword')
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(1)
+    expect(checkIconOff.length).toBe(1)
+    expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
+    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(0)
+
+    const progressBarTwo = screen.getByTestId('test-id-1')
+    const progressBarThree = screen.getByTestId('test-id-2')
+    expect(progressBarTwo).toHaveStyleRule('background-color', '#fedc2a')
+    expect(progressBarThree).toHaveStyleRule('background-color', '#f4f6f8')
+  })
+
+  it('test with a weak password', () => {
+    render(<PasswordInput hasProgressBar />)
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'bad')
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(0)
+    expect(checkIconOff.length).toBe(2)
+    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(0)
+
+    const progressBarOne = screen.getByTestId('test-id-0')
+    const progressBarTwo = screen.getByTestId('test-id-1')
+    expect(progressBarOne).toHaveStyleRule('background-color', '#c00')
+    expect(progressBarTwo).toHaveStyleRule('background-color', '#f4f6f8')
+  })
+})

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { render, screen, fireEvent } from 'testing-library'
-import userEvent from '@testing-library/user-event'
 import PasswordInput from './PasswordInput'
 
 const sampleRegexCheckx = [
@@ -22,7 +21,7 @@ describe('PasswordInput', () => {
     const mockOnChange = jest.fn()
     render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
     const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'GoodPassword1!')
+    fireEvent.change(inputField, { target: { value: 'GoodPassword1!' } })
 
     expect(mockOnChange).toHaveBeenLastCalledWith({
       isValid: true,
@@ -43,7 +42,7 @@ describe('PasswordInput', () => {
     const mockOnChange = jest.fn()
     render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
     const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'SamplePassword')
+    fireEvent.change(inputField, { target: { value: 'SamplePassword' } })
 
     expect(mockOnChange).toHaveBeenLastCalledWith({
       isValid: false,
@@ -65,7 +64,7 @@ describe('PasswordInput', () => {
     const mockOnChange = jest.fn()
     render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
     const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'bad')
+    fireEvent.change(inputField, { target: { value: 'bad' } })
 
     expect(mockOnChange).toHaveBeenLastCalledWith({
       isValid: false,
@@ -92,7 +91,7 @@ describe('PasswordInput', () => {
       />
     )
     const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'Password')
+    fireEvent.change(inputField, { target: { value: 'Password' } })
 
     expect(mockOnChange).toHaveBeenLastCalledWith({
       isValid: true,

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -30,12 +30,12 @@ describe('PasswordInput', () => {
 
     const checkIconOn = screen.queryAllByTestId('check-icon-on')
     const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(5)
-    expect(checkIconOff.length).toBe(0)
+    expect(checkIconOn).toHaveLength(5)
+    expect(checkIconOff).toHaveLength(0)
     expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(1)
+    expect(checkMark).toHaveLength(1)
   })
 
   it('test with a no number and special character password', () => {
@@ -51,13 +51,13 @@ describe('PasswordInput', () => {
 
     const checkIconOn = screen.queryAllByTestId('check-icon-on')
     const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(3)
-    expect(checkIconOff.length).toBe(2)
+    expect(checkIconOn).toHaveLength(3)
+    expect(checkIconOff).toHaveLength(2)
     expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
     expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(0)
+    expect(checkMark).toHaveLength(0)
   })
 
   it('test with a weak password', () => {
@@ -73,12 +73,12 @@ describe('PasswordInput', () => {
 
     const checkIconOn = screen.queryAllByTestId('check-icon-on')
     const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(1)
-    expect(checkIconOff.length).toBe(4)
+    expect(checkIconOn).toHaveLength(1)
+    expect(checkIconOff).toHaveLength(4)
     expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(0)
+    expect(checkMark).toHaveLength(0)
   })
 
   it('test with a manual regex checks', () => {
@@ -100,11 +100,11 @@ describe('PasswordInput', () => {
 
     const checkIconOn = screen.queryAllByTestId('check-icon-on')
     const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(2)
-    expect(checkIconOff.length).toBe(0)
+    expect(checkIconOn).toHaveLength(2)
+    expect(checkIconOff).toHaveLength(0)
     expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(1)
+    expect(checkMark).toHaveLength(1)
   })
 })

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -3,26 +3,102 @@ import { render, screen, fireEvent } from 'testing-library'
 import userEvent from '@testing-library/user-event'
 import PasswordInput from './PasswordInput'
 
+const sampleRegexCheckx = [
+  { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },
+  { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
+]
+
 describe('PasswordInput', () => {
   it('test show/hide password options', () => {
-    const mockOnChange = jest.fn()
-    render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
+    render(<PasswordInput hasProgressBar />)
     const inputField = screen.getByTestId('input-field')
     const visibilityButton = screen.getByTitle('visibility-button')
     expect(inputField).toHaveAttribute('type', 'password')
     fireEvent.click(visibilityButton)
     fireEvent.change(inputField), { target: { value: 'Password1!' } }
     expect(inputField).toHaveAttribute('type', 'text')
-    expect(mockOnChange).toHaveBeenCalledWith({
-      isValid: true,
-      value: 'Password1!',
-    })
   })
 
   it('test with a strong password', () => {
-    render(<PasswordInput hasProgressBar />)
+    const mockOnChange = jest.fn()
+    render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
     const inputField = screen.getByTestId('input-field')
     userEvent.type(inputField, 'GoodPassword1!')
+
+    expect(mockOnChange).toHaveBeenLastCalledWith({
+      isValid: true,
+      value: 'GoodPassword1!',
+    })
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(5)
+    expect(checkIconOff.length).toBe(0)
+    expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(1)
+  })
+
+  it('test with a no number and special character password', () => {
+    const mockOnChange = jest.fn()
+    render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'SamplePassword')
+
+    expect(mockOnChange).toHaveBeenLastCalledWith({
+      isValid: false,
+      value: 'SamplePassword',
+    })
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(3)
+    expect(checkIconOff.length).toBe(2)
+    expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
+    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(0)
+  })
+
+  it('test with a weak password', () => {
+    const mockOnChange = jest.fn()
+    render(<PasswordInput hasProgressBar onChange={mockOnChange} />)
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'bad')
+
+    expect(mockOnChange).toHaveBeenLastCalledWith({
+      isValid: false,
+      value: 'bad',
+    })
+
+    const checkIconOn = screen.queryAllByTestId('check-icon-on')
+    const checkIconOff = screen.queryAllByTestId('check-icon-off')
+    expect(checkIconOn.length).toBe(1)
+    expect(checkIconOff.length).toBe(4)
+    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
+
+    const checkMark = screen.queryAllByTestId('check-mark-icon')
+    expect(checkMark.length).toBe(0)
+  })
+
+  it('test with a manual regex checks', () => {
+    const mockOnChange = jest.fn()
+    render(
+      <PasswordInput
+        hasProgressBar
+        regexChecks={sampleRegexCheckx}
+        onChange={mockOnChange}
+      />
+    )
+    const inputField = screen.getByTestId('input-field')
+    userEvent.type(inputField, 'Password')
+
+    expect(mockOnChange).toHaveBeenLastCalledWith({
+      isValid: true,
+      value: 'Password',
+    })
 
     const checkIconOn = screen.queryAllByTestId('check-icon-on')
     const checkIconOff = screen.queryAllByTestId('check-icon-off')
@@ -32,49 +108,5 @@ describe('PasswordInput', () => {
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
     expect(checkMark.length).toBe(1)
-
-    const progressBarFour = screen.getByTestId('test-id-3')
-    expect(progressBarFour).toHaveStyleRule('background-color', '#0a0')
-  })
-
-  it('test with a no number or special character password', () => {
-    render(<PasswordInput hasProgressBar />)
-    const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'SamplePassword')
-
-    const checkIconOn = screen.queryAllByTestId('check-icon-on')
-    const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(1)
-    expect(checkIconOff.length).toBe(1)
-    expect(checkIconOn[0]).toHaveStyleRule('color', '#0a0')
-    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
-
-    const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(0)
-
-    const progressBarTwo = screen.getByTestId('test-id-1')
-    const progressBarThree = screen.getByTestId('test-id-2')
-    expect(progressBarTwo).toHaveStyleRule('background-color', '#fedc2a')
-    expect(progressBarThree).toHaveStyleRule('background-color', '#f4f6f8')
-  })
-
-  it('test with a weak password', () => {
-    render(<PasswordInput hasProgressBar />)
-    const inputField = screen.getByTestId('input-field')
-    userEvent.type(inputField, 'bad')
-
-    const checkIconOn = screen.queryAllByTestId('check-icon-on')
-    const checkIconOff = screen.queryAllByTestId('check-icon-off')
-    expect(checkIconOn.length).toBe(0)
-    expect(checkIconOff.length).toBe(2)
-    expect(checkIconOff[0]).toHaveStyleRule('color', '#4f6f8f')
-
-    const checkMark = screen.queryAllByTestId('check-mark-icon')
-    expect(checkMark.length).toBe(0)
-
-    const progressBarOne = screen.getByTestId('test-id-0')
-    const progressBarTwo = screen.getByTestId('test-id-1')
-    expect(progressBarOne).toHaveStyleRule('background-color', '#c00')
-    expect(progressBarTwo).toHaveStyleRule('background-color', '#f4f6f8')
   })
 })

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -6,15 +6,14 @@ export default {
   component: PasswordInput,
 }
 
-export const Basic = () => <PasswordInput></PasswordInput>
+export const Basic = () => <PasswordInput />
 
-export const WithTitle = () => (
-  <PasswordInput inputBoxTitle='New Password'></PasswordInput>
-)
+export const WithTitle = () => <PasswordInput label='New Password' />
 
 export const WithProgressBar = () => (
   <PasswordInput
-    inputBoxTitle='New Password'
+    label='New Password'
     hasProgressBar={true}
-  ></PasswordInput>
+    progressBarCurrentStep={3}
+  />
 )

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import PasswordInput from './PasswordInput'
+
+export default {
+  title: 'PasswordInput',
+  component: PasswordInput,
+}
+
+export const Basic = () => <PasswordInput></PasswordInput>
+
+export const WithTitle = () => (
+  <PasswordInput inputBoxTitle='New Password'></PasswordInput>
+)
+
+export const WithProgressBar = () => (
+  <PasswordInput
+    inputBoxTitle='New Password'
+    hasProgressBar={true}
+  ></PasswordInput>
+)

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -16,11 +16,7 @@ export const Basic = () => <PasswordInput />
 export const WithTitle = () => <PasswordInput label='New Password' />
 
 export const WithProgressBar = () => (
-  <PasswordInput
-    label='New Password'
-    hasProgressBar
-    onChange={({ isValid, value }) => console.log(isValid, value)}
-  />
+  <PasswordInput label='New Password' hasProgressBar />
 )
 
 export const WithCustomRegex = () => (

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -6,10 +6,27 @@ export default {
   component: PasswordInput,
 }
 
+const customRegexChecks = [
+  { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },
+  { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
+]
+
 export const Basic = () => <PasswordInput />
 
 export const WithTitle = () => <PasswordInput label='New Password' />
 
 export const WithProgressBar = () => (
-  <PasswordInput label='New Password' hasProgressBar />
+  <PasswordInput
+    label='New Password'
+    hasProgressBar
+    onChange={({ isValid, value }) => console.log(isValid, value)}
+  />
+)
+
+export const WithCustomRegex = () => (
+  <PasswordInput
+    label='New Password'
+    hasProgressBar
+    regexChecks={customRegexChecks}
+  />
 )

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -11,9 +11,5 @@ export const Basic = () => <PasswordInput />
 export const WithTitle = () => <PasswordInput label='New Password' />
 
 export const WithProgressBar = () => (
-  <PasswordInput
-    label='New Password'
-    hasProgressBar={true}
-    progressBarCurrentStep={3}
-  />
+  <PasswordInput label='New Password' hasProgressBar />
 )

--- a/packages/core/src/PasswordInput/index.js
+++ b/packages/core/src/PasswordInput/index.js
@@ -1,0 +1,1 @@
+export { default as PasswordInput } from './PasswordInput'


### PR DESCRIPTION
A password input component with a visibility option and regex checks.

https://priceline.atlassian.net/browse/UXPT-1162

Basic:
<img width="1479" alt="Screen Shot 2021-03-04 at 3 46 25 PM" src="https://user-images.githubusercontent.com/77304994/110035312-1c68c680-7d01-11eb-8826-683b24200ecc.png">

With a regex check progress bar:
<img width="1467" alt="Screen Shot 2021-03-04 at 3 47 27 PM" src="https://user-images.githubusercontent.com/77304994/110035371-330f1d80-7d01-11eb-9876-4f5f9a0d8680.png">
<img width="1475" alt="Screen Shot 2021-03-04 at 3 47 42 PM" src="https://user-images.githubusercontent.com/77304994/110035444-4f12bf00-7d01-11eb-8061-f46976325ff3.png">

Mobile:
<img width="408" alt="Screen Shot 2021-03-04 at 3 48 18 PM" src="https://user-images.githubusercontent.com/77304994/110035484-5d60db00-7d01-11eb-8121-bea5a1b50ccc.png">
