### PR TITLE
Update default password requirements

### DIFF
--- a/common/changes/pcln-design-system/update-default-password-requirements_2021-03-22-16-44.json
+++ b/common/changes/pcln-design-system/update-default-password-requirements_2021-03-22-16-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update Password Input Default Requirements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "james.stewart@priceline.com"
+}

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -158,7 +158,7 @@ PasswordInput.defaultProps = {
     { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
     { label: '1 Number', regex: /(?=.*[0-9])/ },
     { label: '1 Special Character', regex: /(?=.*[!@#$%^&*()])/ },
-    { label: 'at least 8 Characters', regex: /.{8,}/ },
+    { label: 'at least 12 Characters', regex: /.{12,}/ },
   ],
 }
 


### PR DESCRIPTION
This update bring parity to the default requirements for Priceline users which is nice + 12 characters is between than 8.