### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -1,11 +1,11 @@
-name: On Master Merge - Build Static Docsite and Storybook
+name: On Main Merge - Build Static Docsite and Storybook
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
-  on-master-docsite-storybook:
+  on-main-docsite-storybook:
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,28 +139,28 @@ rush docsite
 ### GitHub Flow
 
 We follow a loose version of [GitHub Flow][github-flow] where feature branches
-are created from master, submitted as pull requests, given time for review and
-discussion, then merged into master.
+are created from main, submitted as pull requests, given time for review and
+discussion, then merged into main.
 
-All merges into master should be ready to be published. The Design System Working Group will batch releases as appropriate.
+All merges into main should be ready to be published. The Design System Working Group will batch releases as appropriate.
 
 Generally, the workflow looks like this:
 
-1. Pull the latest changes from master
+1. Pull the latest changes from main
 1. Create a new feature branch (pick a name that clearly describes the feature)
 1. Commit changes to your feature branch (smaller commits with clear messages are best)
 1. Run `rush change` to document your changes
 1. Push your branch to origin
 1. Open a Pull Request with a clear description of the change (Answering _what_, _why_, and _how_ is a good place to start)
 1. Allow for some time for discussion
-1. (optional) If your PR has merge conflicts, pull the latest from master, then merge those changes into your PR branch, resolving conflicts in the process
-1. Once there is consensus on the changes and all tests have passed, merge the PR into master
+1. (optional) If your PR has merge conflicts, pull the latest from main, then merge those changes into your PR branch, resolving conflicts in the process
+1. Once there is consensus on the changes and all tests have passed, merge the PR into main
 
 ### Pull Requests
 
 All changes to the code base must be submitted as a Pull Request (PR) and approved
 by at least two members of the team before it can be merged to
-master. This gives contributors and the team a chance to review and discuss
+main. This gives contributors and the team a chance to review and discuss
 changes and helps create a record of the project's history.
 
 If you're unsure about your change, feel free to open a PR for discussion or

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -24,7 +24,7 @@ npm run build
 
 ## Automatic deploys
 
-The docs site is automatically built with GitHub Actions on all merges into master.
+The docs site is automatically built with GitHub Actions on all merges into main.
 
 ## Adding Routes & Navigation
 

--- a/apps/docs/src/navigation.js
+++ b/apps/docs/src/navigation.js
@@ -91,7 +91,7 @@ export default [
         name: 'Contributing',
         isExternal: true,
         path:
-          'https://github.com/priceline/design-system/blob/master/CONTRIBUTING.md',
+          'https://github.com/priceline/design-system/blob/main/CONTRIBUTING.md',
       },
       {
         name: 'GitHub',

--- a/rush.json
+++ b/rush.json
@@ -243,23 +243,23 @@
      * The URL of this Git repository, used by "rush change" to determine the base branch for your PR.
      *
      * The "rush change" command needs to determine which files are affected by your PR diff.
-     * If you merged or cherry-picked commits from the master branch into your PR branch, those commits
+     * If you merged or cherry-picked commits from the main branch into your PR branch, those commits
      * should be excluded from this diff (since they belong to some other PR).  In order to do that,
      * Rush needs to know where to find the base branch for your PR.  This information cannot be
      * determined from Git alone, since the "pull request" feature is not a Git concept.  Ideally
      * Rush would use a vendor-specific protocol to query the information from GitHub, Azure DevOps, etc.
-     * But to keep things simple, "rush change" simply assumes that your PR is against the "master" branch
+     * But to keep things simple, "rush change" simply assumes that your PR is against the "main" branch
      * of the Git remote indicated by the repository.url setting in rush.json.  If you are working in
      * a GitHub "fork" of the real repo, this setting will be different from the repository URL of your
      * your PR branch, and in this situation "rush change" will also automatically invoke "git fetch"
-     * to retrieve the latest activity for the remote master branch.
+     * to retrieve the latest activity for the remote main branch.
      */
     "url": "https://github.com/priceline/design-system"
     /**
      * The default branch name. This tells "rush change" which remote branch to compare against.
-     * The default value is "master"
+     * The default value is "main"
      */
-    // "defaultBranch": "master",
+    // "defaultBranch": "main",
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is
      * not set or if a remote matching the provided remote URL is not found.


### PR DESCRIPTION
This PR does not need to be merged, it's just for comparison against current `master`.

For more info on the reasoning behind this change, see https://github.com/github/renaming.