### PR TITLE
PasswordInput is valid without progress bar

### DIFF
--- a/common/changes/pcln-design-system/password-input-valid-without-progress-bar_2021-04-13-00-41.json
+++ b/common/changes/pcln-design-system/password-input-valid-without-progress-bar_2021-04-13-00-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "PasswordInput controlled isValid props and start the progress bar empty",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "james.stewart@priceline.com"
+}

--- a/packages/core/src/PasswordInput/PasswordInput.js
+++ b/packages/core/src/PasswordInput/PasswordInput.js
@@ -26,6 +26,7 @@ const NoWrapText = styled(Text)`
 const maxProgressBarLength = 4
 
 function PasswordInput({
+  id,
   isValid,
   label,
   hasProgressBar,
@@ -74,11 +75,12 @@ function PasswordInput({
 
   return (
     <Flex flexDirection='column' {...props}>
-      <Label fontSize={0} mb={2}>
+      <Label htmlFor={id} fontSize={0} mb={2}>
         {label}
       </Label>
       <IconField>
         <Input
+          id={id}
           type={inputType}
           value={value}
           onChange={handleChange}
@@ -115,7 +117,7 @@ function PasswordInput({
             <NoWrapText fontSize={0} color='text.light' mr={3}>
               Must contain:
             </NoWrapText>
-            <Flex wrap>
+            <Flex flexWrap='wrap'>
               {regexChecks.map((check, index) => {
                 const didPass =
                   passedChecks.findIndex((value) => index === value) !== -1
@@ -170,6 +172,7 @@ PasswordInput.defaultProps = {
 }
 
 PasswordInput.propTypes = {
+  id: PropTypes.string,
   isValid: PropTypes.bool,
   label: PropTypes.string,
   hasProgressBar: PropTypes.bool,
@@ -178,7 +181,7 @@ PasswordInput.propTypes = {
   ),
   progressBarDefaultStep: PropTypes.number,
   regexChecks: PropTypes.arrayOf(
-    PropTypes.shape({ label: PropTypes.string, regex: PropTypes.string })
+    PropTypes.shape({ label: PropTypes.string, regex: PropTypes.regex })
   ),
   value: PropTypes.string,
   onChange: PropTypes.func,

--- a/packages/core/src/PasswordInput/PasswordInput.spec.js
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen, fireEvent } from 'testing-library'
 import PasswordInput from './PasswordInput'
 
-const sampleRegexCheckx = [
+const sampleRegexChecks = [
   { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },
   { label: '1 Lowercase Letter', regex: /(?=.*[a-z])/ },
 ]
@@ -86,7 +86,7 @@ describe('PasswordInput', () => {
     render(
       <PasswordInput
         hasProgressBar
-        regexChecks={sampleRegexCheckx}
+        regexChecks={sampleRegexChecks}
         onChange={mockOnChange}
       />
     )
@@ -106,5 +106,14 @@ describe('PasswordInput', () => {
 
     const checkMark = screen.queryAllByTestId('check-mark-icon')
     expect(checkMark).toHaveLength(1)
+  })
+
+  it('ignores regex checks and returns valid if no progress bar', () => {
+    const mockOnChange = jest.fn()
+    render(<PasswordInput label='Password' onChange={mockOnChange} />)
+
+    const inputField = screen.getByTestId('input-field')
+    fireEvent.change(inputField, { target: { value: 'test' } })
+    expect(mockOnChange).toHaveBeenCalledWith({ isValid: true, value: 'test' })
   })
 })

--- a/packages/core/src/PasswordInput/PasswordInput.stories.js
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.js
@@ -1,4 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { action } from '@storybook/addon-actions'
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { Text } from '../Text'
 import PasswordInput from './PasswordInput'
 
 export default {
@@ -26,3 +30,59 @@ export const WithCustomRegex = () => (
     regexChecks={customRegexChecks}
   />
 )
+
+export const UpdatePasswordForm = () => {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [isNewPasswordValid, setNewPasswordValid] = useState(false)
+
+  const onCurrentPasswordChange = ({ value }) => setCurrentPassword(value)
+  const onConfirmPasswordChange = ({ value }) => setConfirmPassword(value)
+
+  const onNewPasswordChange = ({ isValid, value }) => {
+    setNewPassword(value)
+    setNewPasswordValid(isValid)
+  }
+
+  const currentPasswordMatches =
+    !!currentPassword && currentPassword === newPassword
+  const newPasswordsMatch =
+    newPassword === confirmPassword && isNewPasswordValid
+  const isSaveEnabled = !currentPasswordMatches && newPasswordsMatch
+  const onClick = action({
+    currentPassword,
+    newPassword,
+    confirmPassword,
+    isNewPasswordValid,
+  })
+
+  return (
+    <Box width={[1, null, 500]}>
+      <PasswordInput
+        label='Current Password'
+        onChange={onCurrentPasswordChange}
+        mb={3}
+      />
+      <PasswordInput
+        label='New Password'
+        hasProgressBar
+        onChange={onNewPasswordChange}
+        mb={3}
+      />
+      <PasswordInput
+        isValid={newPasswordsMatch}
+        label='Confirm Password'
+        onChange={onConfirmPasswordChange}
+      />
+      <Button disabled={!isSaveEnabled} onClick={onClick} mt={3}>
+        Save
+      </Button>
+      {currentPasswordMatches && (
+        <Text color='error' fontSize={0} mt={2}>
+          New Password must be different from your current password
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/core/src/ProgressBar/ProgressBar.stories.js
+++ b/packages/core/src/ProgressBar/ProgressBar.stories.js
@@ -14,6 +14,10 @@ const steps = [
   { color: 'success' },
 ]
 
+export const emptyProgressBar = () => (
+  <ProgressBar steps={steps} currentStep={0} />
+)
+
 export const basicProgressBar = () => (
   <ProgressBar steps={steps} currentStep={3} />
 )


### PR DESCRIPTION
* Added the isValid prop
* Start the progress bar empty instead of at step one
* Added a password update form example to the storybook
* Added an empty progress bar example to the storybook
* Added an id prop for connecting the label to the input
* Changed regex prop type from string to regex