### PR TITLE
Improve Text Extensions

### DIFF
--- a/common/changes/pcln-design-system/improve-text-extensions_2021-04-15-19-26.json
+++ b/common/changes/pcln-design-system/improve-text-extensions_2021-04-15-19-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Improve Text Extension components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "james.stewart@priceline.com"
+}

--- a/packages/core/src/Banner/__snapshots__/Banner.spec.js.snap
+++ b/packages/core/src/Banner/__snapshots__/Banner.spec.js.snap
@@ -982,14 +982,14 @@ exports[`Banner renders with text node 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
-  font-size: 14px;
-}
-
 .c5 {
   font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
+}
+
+.c6 {
+  font-size: 14px;
 }
 
 .c2 {
@@ -1079,14 +1079,14 @@ exports[`Banner renders with text string 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
-  font-size: 14px;
-}
-
 .c5 {
   font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
+}
+
+.c6 {
+  font-size: 14px;
 }
 
 .c2 {

--- a/packages/core/src/Text/Text.js
+++ b/packages/core/src/Text/Text.js
@@ -1,5 +1,4 @@
-import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import {
   display,
@@ -48,10 +47,7 @@ export const textShadow = (props) => {
     : null
 }
 
-const Text = styled.div.attrs(({ align, ...props }) => ({
-  textAlign: align,
-  ...props,
-}))`
+const textProps = css`
   ${applyVariations('Text')}
   color: ${getPaletteColor('base')};
   ${(props) =>
@@ -82,6 +78,33 @@ const Text = styled.div.attrs(({ align, ...props }) => ({
   ${zIndex}
 `
 
+const Text = styled.div.attrs(({ align, ...props }) => ({
+  textAlign: align,
+  ...props,
+}))`
+  ${textProps}
+`
+const Span = styled.span.attrs(({ align, ...props }) => ({
+  textAlign: align,
+  ...props,
+}))`
+  ${textProps}
+`
+
+const Paragraph = styled.p.attrs(({ align, ...props }) => ({
+  textAlign: align,
+  ...props,
+}))`
+  ${textProps}
+`
+
+const Strike = styled.s.attrs(({ align, ...props }) => ({
+  textAlign: align,
+  ...props,
+}))`
+  ${textProps}
+`
+
 Text.displayName = 'Text'
 
 Text.propTypes = {
@@ -109,25 +132,13 @@ Text.propTypes = {
   textShadowSize: PropTypes.oneOf(['sm', 'md']),
 }
 
-Text.span = ({ children, ...props }) => (
-  <Text as='span' {...props}>
-    {children}
-  </Text>
-)
+Text.span = Span
 Text.span.displayName = 'Text.span'
 
-Text.p = ({ children, ...props }) => (
-  <Text as='p' {...props}>
-    {children}
-  </Text>
-)
+Text.p = Paragraph
 Text.p.displayName = 'Text.p'
 
-Text.s = ({ children, ...props }) => (
-  <Text as='s' {...props}>
-    {children}
-  </Text>
-)
+Text.s = Strike
 Text.s.displayName = 'Text.s'
 
 export default Text


### PR DESCRIPTION
For some reason this is breaking CI for my other PR: https://github.com/priceline/design-system/pull/1063 

Simple change that I quite like anyway, simplifies the implementation of Strikethrough and our other Text extensions.

Nothing actually changes here functionally, purely code quality.