### PR TITLE
fix(): Allow for menu list font to be inherited

### DIFF
--- a/common/changes/pcln-menu/fix-pcln-menu-use-theme-font_2021-12-20-21-47.json
+++ b/common/changes/pcln-menu/fix-pcln-menu-use-theme-font_2021-12-20-21-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Grab font family from theme with fallback",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/packages/menu/src/MenuList/MenuList.js
+++ b/packages/menu/src/MenuList/MenuList.js
@@ -18,7 +18,8 @@ const sizes = {
 }
 
 const MenuContainer = styled(Flex)`
-  font-family: 'Montserrat', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: ${themeGet('font') ||
+  "'Montserrat', 'Helvetica Neue', Helvetica, Arial, sans-serif"};
   overflow-y: scroll;
 
   & > * {

--- a/packages/menu/src/MenuList/MenuList.spec.js
+++ b/packages/menu/src/MenuList/MenuList.spec.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { fireEvent, render, screen } from 'testing-library'
 import MenuList from './MenuList'
 import MenuItem from '../MenuItem'
+import { ThemeProvider } from 'styled-components'
 
 describe('MenuList', () => {
   it('renders a menu list', () => {
@@ -20,6 +21,11 @@ describe('MenuList', () => {
 
     fireEvent.click(screen.getByText('Item Two'))
     expect(onItemTwoClick).toHaveBeenCalledTimes(1)
+
+    expect(screen.getByRole('listbox')).toHaveStyleRule(
+      'font-family',
+      "'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif"
+    )
   })
 
   it('is a11y friendly', () => {
@@ -46,5 +52,21 @@ describe('MenuList', () => {
       code: 'ArrowRight',
     })
     expect(screen.getByText('Item One').parentNode).toHaveFocus()
+  })
+  it('grabs font family from theme', () => {
+    const mockTheme = {
+      font: "'Source Sans Pro',Verdana,sans-serif",
+    }
+    render(
+      <ThemeProvider theme={mockTheme}>
+        <MenuList id='test-menu'>
+          <MenuItem selected>Item One</MenuItem>
+        </MenuList>
+      </ThemeProvider>
+    )
+    expect(screen.getByRole('listbox')).toHaveStyleRule(
+      'font-family',
+      mockTheme.font
+    )
   })
 })


### PR DESCRIPTION
- Use hardcoded font only if no font detected from theme context
- Add tests for both conditions