### PR TITLE
Update MenuList overflow to auto

### DIFF
--- a/common/changes/pcln-menu/chore-HTL-77781-menulist-overflow-auto_2022-01-28-18-38.json
+++ b/common/changes/pcln-menu/chore-HTL-77781-menulist-overflow-auto_2022-01-28-18-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Update MenuList overflow from scroll to auto",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/packages/menu/src/MenuList/MenuList.js
+++ b/packages/menu/src/MenuList/MenuList.js
@@ -19,7 +19,7 @@ const sizes = {
 
 const MenuContainer = styled(Flex)`
   font-family: ${themeGet('font') || "'Montserrat', 'Helvetica Neue', Helvetica, Arial, sans-serif"};
-  overflow-y: scroll;
+  overflow-y: auto;
 
   & > * {
     margin-right: ${themeGet('space.1')}px;


### PR DESCRIPTION
The Menu component current shows scrollbars all the time on Windows browsers.
![menu-scroll](https://user-images.githubusercontent.com/24528156/151608390-f296bad0-3ffb-425e-b777-323695d7ed0c.png)
Ideal behavior would be to only appear when needed, as seen on OSX.

Updating the overflow-y style in MenuList to 'auto' rather than 'scroll' to accomplish this.
