### PR TITLE
Remove duplicate info from release notes markdown

### DIFF
--- a/tools/create-release-notes/src/actions/createReleaseNotes.ts
+++ b/tools/create-release-notes/src/actions/createReleaseNotes.ts
@@ -64,11 +64,7 @@ export const _transformRushComments = (comments): Change[] => {
 }
 
 export const formatNotesMarkdown = (notes: Release): string => {
-  return `# \`${notes.packageName}\` v${notes.version}
-
-> Created ${notes.date}
-
-|Type | Change | Author | Commit |
+  return `|Type | Change | Author | Commit |
 |-----|--------|--------|--------|
 ${notes.changes.map(_formatChangeRow).join('\n')}
 `


### PR DESCRIPTION
The same info is already included in our GH releases. This should make release previews on Slack look nicer.