### PR TITLE
Update focus styling for ButtonChip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,17 @@
 # Contributing
 
-- [Contributing](#contributing)
-
-  - [Local Development](#local-development)
-  - [Clone the repo](#clone-the-repo)
-  - [Lerna](#lerna)
-  - [Install dependencies](#install-dependencies)
-  - [Running tests](#running-tests)
-  - [Storybook](#storybook)
-  - [Publishing](#publishing)
-  - [Static Docs Site](#static-docs-site)
-  - [Troubleshooting](#troubleshooting)
-  - [GitHub Flow](#github-flow)
-  - [Beta Version](#beta-version)
-  - [Pull Requests](#pull-requests)
-
-  - [Creating Components](COMPONENT_GUIDANCE.md)
+ - [Clone the repo](#clone-the-repo)
+ - [Preparation](#preparation)
+ - [Running tests](#running-tests)
+ - [Linting and formatting](#linting-and-formatting)
+ - [Creating new components](#creating-new-components)
+ - [Storybook](#storybook)
+ - [Publishing](#publishing)
+ - [Static Docs Site](#static-docs-site)
+ - [Troubleshooting](#troubleshooting)
+ - [GitHub Flow](#github-flow)
+ - [Pull Requests](#pull-requests)
+ 
 
 If you'd like to contribute to the Design System, we'd love to have your help. As with any open source project, we ask that you be kind, professional, and courteous towards others.
 
@@ -27,13 +23,7 @@ Contributing doesn't necessarily mean committing code; we also encourage you to:
 - Use the Design System in your project and provide feedback
 - Add yourself to our Contributors list using `npm run contributors:add` then enter your username and type of contribution.
 
-## Local Development
 
-The Design System is a [Rush](https://rushjs.io/) Monorepo. Install `rush` globally:
-
-```bash
-npm i -g @microsoft/rush
-```
 
 ### Clone the repo
 
@@ -43,6 +33,12 @@ cd design-system
 ```
 
 ### Preparation
+
+The Design System is a [Rush](https://rushjs.io/) Monorepo. Install `rush` globally:
+
+```bash
+npm i -g @microsoft/rush
+```
 
 To install dependencies:
 
@@ -103,6 +99,8 @@ Follow the steps below to create a new component:
 3. Run `rush update` to update dependencies
 4. If creating a core component, add an import & an export for the new core component in `packages/core/src/index.js` file
 
+Additional Guidance: [Creating Components](COMPONENT_GUIDANCE.md)
+
 ### Storybook
 
 We use [Storybook][storybook] for isolated UI component development.
@@ -120,7 +118,7 @@ An updated publishing process will be documented in detail at the time of the ne
 
 To publish the packages to npm, you have to be an owner of the packages you're publishing on the NPM registry. Priceline employees should use the `#design-system` Slack channel for more information.
 
-#### Before Publishing:
+**Before Publishing:**
 
 - Publishing is very easy once you have access to the NPM package. **Please Be Careful** 🤗
 - Use `npm login` to authenticate against the public NPM registry. If your local environment requires multiple NPM registries, the [npmrc](https://www.npmjs.com/package/npmrc) tool is useful to toggle between registries.

--- a/common/changes/pcln-design-system/button-chip-accessibility_2022-02-16-14-45.json
+++ b/common/changes/pcln-design-system/button-chip-accessibility_2022-02-16-14-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update focus styling for ButtonChip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-popover/button-chip-accessibility_2022-02-16-14-45.json
+++ b/common/changes/pcln-popover/button-chip-accessibility_2022-02-16-14-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Fix tab-index/focus-trap accessibility issue within PopoverContent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.spec.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.spec.tsx
@@ -26,7 +26,7 @@ describe('ButtonChip', () => {
     expect(getByTestId('testId')).not.toHaveAttribute('disabled')
 
     //style
-    expect(buttonChip).toHaveStyleRule('margin', '8px')
+    expect(buttonChip).toHaveStyleRule('margin', '3px')
   })
 
   test('Disabled', () => {

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -9,14 +9,18 @@ import { Button } from '../../Button'
 import { getPaletteColor } from '../../utils'
 
 const ChipButton = styled(Button)`
+  background-color: transparent;
   border: none;
-  padding: 0;
+  margin: 3px;
+  padding: 2px;
+  &:hover {
+    background-color: transparent;
+  }
   &:focus {
-    box-shadow: none;
+    box-shadow: 0 0 0 5px ${getPaletteColor('base')};
     outline: none;
   }
   &:focus > ${ChipContentWrapper} {
-    box-shadow: 0 0 0 1px ${getPaletteColor('base')};
     border-color: ${getPaletteColor('base')};
   }
 `

--- a/packages/popover/src/Popover/Popover.stories.js
+++ b/packages/popover/src/Popover/Popover.stories.js
@@ -14,6 +14,7 @@ import {
   Link,
   Text,
   ThemeProvider,
+  FilterChip,
 } from 'pcln-design-system'
 import Component from '@reach/component-component'
 import Slider from 'pcln-slider'
@@ -97,6 +98,23 @@ export const colors = () => (
     >
       <Button color='error' variation='outline' mx={2}>
         Error Popover
+      </Button>
+    </Popover>
+  </Flex>
+)
+
+const FilterChipContent = () => (
+  <Box p={2}>
+    <FilterChip>Hello</FilterChip>
+    <FilterChip>World</FilterChip>
+  </Box>
+)
+
+export const filterChips = () => (
+  <Flex>
+    <Popover renderContent={FilterChipContent} placement='bottom' ariaLabel='Default Popover' width={130}>
+      <Button color='primary' variation='outline' mx={2}>
+        Popover with Filter Chips
       </Button>
     </Popover>
   </Flex>

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -221,6 +221,7 @@ exports[`Popover UI Positioning Bottom 1`] = `
         color="background.lightest"
         data-testid="dialog-content"
         id="popover-description-1"
+        tabindex="-1"
       >
         <div
           class=""
@@ -367,6 +368,7 @@ exports[`Popover UI Positioning Bottom End 1`] = `
         color="background.lightest"
         data-testid="dialog-content"
         id="popover-description-1"
+        tabindex="-1"
       >
         <div
           class=""
@@ -513,6 +515,7 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
         color="background.lightest"
         data-testid="dialog-content"
         id="popover-description-1"
+        tabindex="-1"
       >
         <div
           class=""

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -121,6 +121,7 @@ class PopoverContent extends Component {
                         data-testid='dialog-content'
                         id={`popover-description-${idx}`}
                         borderRadius='xl'
+                        tabIndex='-1'
                       >
                         {content}
                       </Box>


### PR DESCRIPTION
This PR addresses this [ticket](https://priceline.atlassian.net/browse/UXPT-2517)

Before:
![image](https://user-images.githubusercontent.com/23641048/154292426-c1a5611e-f1c2-4c0e-a36a-255c6535f7b9.png)


After:
![image](https://user-images.githubusercontent.com/23641048/154292481-c12a0056-a2f0-422c-a3cc-4c652e5b9515.png)

ALSO: Fixed tab-index/focus-trap issue for PopoverContent, see relevant Popover Story (titled "Filter Chips")