### PR TITLE
change ButtonChip focus styling to use outline

### DIFF
--- a/common/changes/pcln-design-system/buttonchip-focus-styling_2022-02-23-16-22.json
+++ b/common/changes/pcln-design-system/buttonchip-focus-styling_2022-02-23-16-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "change focus styling to use outline instead of box-shadow",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.spec.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.spec.tsx
@@ -26,7 +26,7 @@ describe('ButtonChip', () => {
     expect(getByTestId('testId')).not.toHaveAttribute('disabled')
 
     //style
-    expect(buttonChip).toHaveStyleRule('margin', '3px')
+    expect(buttonChip).toHaveStyleRule('margin', '8px')
   })
 
   test('Disabled', () => {

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -11,14 +11,14 @@ import { getPaletteColor } from '../../utils'
 const ChipButton = styled(Button)`
   background-color: transparent;
   border: none;
-  margin: 3px;
-  padding: 2px;
+  padding: 0;
   &:hover {
     background-color: transparent;
   }
   &:focus {
-    box-shadow: 0 0 0 5px ${getPaletteColor('base')};
-    outline: none;
+    box-shadow: none;
+    outline-offset: 2px;
+    outline: 3px solid ${getPaletteColor('base')};
   }
   &:focus > ${ChipContentWrapper} {
     border-color: ${getPaletteColor('base')};

--- a/packages/core/src/Chip/ChipLabel/index.tsx
+++ b/packages/core/src/Chip/ChipLabel/index.tsx
@@ -11,8 +11,9 @@ const ChipLabel = styled(Label)`
   margin: 0;
   > input:focus ~ ${ChipContentWrapper} {
     background-color: ${getPaletteColor('light')};
-    box-shadow: 0 0 0 1px ${getPaletteColor('base')};
     border-color: ${getPaletteColor('base')};
+    outline-offset: 2px;
+    outline: 3px solid ${getPaletteColor('base')};
   }
 `
 


### PR DESCRIPTION
The floating outer-border effect that is applied when a ~~Button~~Chip is focused now utilizes `outline` css styling, instead of `box-shadow`

Edit: now applies to all Chips (ButtonChip, FilterChip, and ChoiceChip), not just ButtonChip