### PR TITLE
Improve styling for popover/filterchip story

### DIFF
--- a/common/changes/pcln-popover/update-filterchips-story_2022-03-07-23-09.json
+++ b/common/changes/pcln-popover/update-filterchips-story_2022-03-07-23-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "update filter chip story styling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/Popover/Popover.stories.js
+++ b/packages/popover/src/Popover/Popover.stories.js
@@ -103,21 +103,22 @@ export const colors = () => (
   </Flex>
 )
 
-const FilterChipContent = () => (
-  <Box p={2}>
-    <FilterChip>Hello</FilterChip>
-    <FilterChip>World</FilterChip>
+const FilterChipContent = ({ handleClose }) => (
+  <Box p={3}>
+    <Flex justifyContent='center' mb={3}>
+      <FilterChip mr={2}>Filter Chip</FilterChip>
+      <FilterChip>Filter Chip</FilterChip>
+    </Flex>
+    <Flex justifyContent='right'>
+      <Button onClick={handleClose}>Done</Button>
+    </Flex>
   </Box>
 )
 
 export const filterChips = () => (
-  <Flex>
-    <Popover renderContent={FilterChipContent} placement='bottom' ariaLabel='Default Popover' width={130}>
-      <Button color='primary' variation='outline' mx={2}>
-        Popover with Filter Chips
-      </Button>
-    </Popover>
-  </Flex>
+  <Popover renderContent={FilterChipContent} placement='bottom' ariaLabel='Default Popover' width={300}>
+    <Button color='primary'>Popover with Filter Chips</Button>
+  </Popover>
 )
 
 export const forcedOpenViaProp = () => (


### PR DESCRIPTION
Simple updating of styles to more clearly demonstrate the fact that `FilterChip` components render inside a `Popover` without stealing focus immediately

Before:
![image](https://user-images.githubusercontent.com/23641048/157133950-e2999c27-c511-4f02-a527-ca849412bf10.png)

After:
![image](https://user-images.githubusercontent.com/23641048/157133980-5c85d8fc-d522-4546-a4a7-6236288634a4.png)
