### PR TITLE
Add handler to Carousel when current slide changes

### DIFF
--- a/common/changes/pcln-carousel/carousel-click-handlers_2022-03-17-18-44.json
+++ b/common/changes/pcln-carousel/carousel-click-handlers_2022-03-17-18-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Add onSlideChange prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { CarouselProvider, Slide } from 'pure-react-carousel'
+import { CarouselProvider, Slide, CarouselContext } from 'pure-react-carousel'
 import { layoutToFlexWidths } from './layoutToFlexWidths'
 import { CarouselWrapper } from './Carousel.styles'
 import { Flex, Relative, Box } from 'pcln-design-system'
@@ -8,6 +8,26 @@ import { Dots } from './Dots'
 import { ArrowButton } from './ArrowButton'
 import { Slider } from './Slider'
 import { getSlideKey, getVisibleSlidesArray, useResponsiveVisibleSlides } from './helpers'
+
+const ChangeDetector = ({ onSlideChange }) => {
+  const carouselContext = useContext(CarouselContext)
+  // eslint-disable-next-line no-unused-vars
+  const [_currentSlide, setCurrentSlide] = useState(carouselContext.state.currentSlide)
+
+  useEffect(() => {
+    function onChange() {
+      setCurrentSlide(carouselContext.state.currentSlide)
+
+      if (typeof onSlideChange === 'function') {
+        onSlideChange(carouselContext.state.currentSlide)
+      }
+    }
+    carouselContext.subscribe(onChange)
+    return () => carouselContext.unsubscribe(onChange)
+  }, [carouselContext])
+
+  return null
+}
 
 export const Carousel = ({
   children,
@@ -24,6 +44,7 @@ export const Carousel = ({
   arrowsPosition = 'side',
   slideSpacing = 2,
   buttonColorProps,
+  onSlideChange,
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
   const layoutSize = layout?.split('-').length
@@ -45,6 +66,7 @@ export const Carousel = ({
         orientation={orientation}
         infinite={infinite}
       >
+        <ChangeDetector onSlideChange={onSlideChange} />
         {arrowsPosition === 'top' ? (
           <Flex justifyContent='flex-end' mb={2} mr={slideSpacing}>
             <ArrowButton type='prev' position='top' setPosition={arrowsPosition} {...buttonColorProps} />
@@ -155,4 +177,6 @@ Carousel.propTypes = {
     buttonHoverBackground: PropTypes.string,
     buttonHoverColor: PropTypes.string,
   }),
+  /** Called each time the current slide changes, passed the new currentSlide (zero-indexed) */
+  onSlideChange: PropTypes.func,
 }

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from 'testing-library'
+import { render, fireEvent } from 'testing-library'
 import { Flex } from 'pcln-design-system'
 import { Carousel } from './Carousel'
 
@@ -19,8 +19,10 @@ describe('Carousel', () => {
   })
 
   it('should render a carousel', () => {
-    const { getByText, getByTestId } = render(
-      <Carousel showDots arrowsPosition='side'>
+    const onSlideChange = jest.fn()
+
+    const { getByText, getByTestId, getByLabelText } = render(
+      <Carousel showDots arrowsPosition='side' onSlideChange={onSlideChange}>
         <Flex>Slide 1</Flex>
         <Flex>Slide 2</Flex>
         <Flex>Slide 3</Flex>
@@ -31,6 +33,11 @@ describe('Carousel', () => {
     expect(getByTestId('dot_group')).toBeInTheDocument()
     expect(getByTestId('prev-side')).toBeInTheDocument()
     expect(getByTestId('next-side')).toBeInTheDocument()
+
+    fireEvent.click(getByLabelText('next'))
+    expect(onSlideChange).toHaveBeenCalledWith(1)
+    fireEvent.click(getByLabelText('previous'))
+    expect(onSlideChange).toHaveBeenCalledWith(0)
   })
 
   it('should set slide widths if layout is set', () => {

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -42,6 +42,9 @@ export default {
     isIntrinsicHeight: {
       defaultValue: true,
     },
+    onSlideChange: {
+      action: 'Current slide changed',
+    },
   },
 }
 


### PR DESCRIPTION
This enables consumers to react to the current slide changing, either from clicking next/prev, scrolling, or using the dots.