### PR TITLE
feat(cu): rename buttonColorProps to buttonStyles and some additional props

### DIFF
--- a/common/changes/pcln-carousel/feature-carousel-updates_2022-03-21-17-28.json
+++ b/common/changes/pcln-carousel/feature-carousel-updates_2022-03-21-17-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "change buttonColorProps to buttonStyles and some additional props",
+      "type": "major"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/ArrowButton/ArrowButton.js
+++ b/packages/carousel/src/ArrowButton/ArrowButton.js
@@ -27,6 +27,8 @@ ArrowButton.defaultProps = {
   buttonColor: 'primary.base',
   buttonHoverBackground: 'background.base',
   buttonHoverColor: 'primary.dark',
+  buttonHeight: '60px',
+  buttonWidth: '60px',
 }
 
 ArrowButton.propTypes = {
@@ -41,6 +43,8 @@ ArrowButton.propTypes = {
   buttonHoverBackground: PropTypes.string,
   /** color.shade pattern to be passed to getPaletteColor */
   buttonHoverColor: PropTypes.string,
+  buttonHeight: PropTypes.string,
+  buttonWidth: PropTypes.string,
 }
 
 export { ArrowButton }

--- a/packages/carousel/src/ArrowButton/ArrowButton.styles.js
+++ b/packages/carousel/src/ArrowButton/ArrowButton.styles.js
@@ -29,8 +29,8 @@ const sideStyles = (props) =>
   props.position === 'side'
     ? `
     ${props.type == 'prev' ? 'left' : 'right'}: 0px;
-    height: 60px;
-    width: 60px;
+    height: ${props.buttonHeight};
+    width: ${props.buttonWidth};
     &:disabled {
       display: none;
     }

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -43,8 +43,12 @@ export const Carousel = ({
   visibleSlides = 1,
   arrowsPosition = 'side',
   slideSpacing = 2,
+<<<<<<< HEAD
   buttonColorProps,
   onSlideChange,
+=======
+  buttonStyles,
+>>>>>>> 79352593 (feat(cu): add button width, height props, change buttonColorProps name to buttonStyles)
   isTwoColumnLayout = false,
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
@@ -70,14 +74,8 @@ export const Carousel = ({
         <ChangeDetector onSlideChange={onSlideChange} />
         {arrowsPosition === 'top' ? (
           <Flex justifyContent='flex-end' mb={2} mr={slideSpacing}>
-            <ArrowButton type='prev' position='top' setPosition={arrowsPosition} {...buttonColorProps} />
-            <ArrowButton
-              type='next'
-              position='top'
-              ml={3}
-              setPosition={arrowsPosition}
-              {...buttonColorProps}
-            />
+            <ArrowButton type='prev' position='top' setPosition={arrowsPosition} {...buttonStyles} />
+            <ArrowButton type='next' position='top' ml={3} setPosition={arrowsPosition} {...buttonStyles} />
           </Flex>
         ) : null}
         <Relative>
@@ -87,7 +85,7 @@ export const Carousel = ({
             type='prev'
             position='side'
             setPosition={arrowsPosition}
-            {...buttonColorProps}
+            {...buttonStyles}
           />
           <Slider>
             {React.Children.map(children, (item, index) => {
@@ -110,7 +108,7 @@ export const Carousel = ({
             type='next'
             position='side'
             setPosition={arrowsPosition}
-            {...buttonColorProps}
+            {...buttonStyles}
           />
         </Relative>
         {arrowsPosition === 'bottom' || showDots ? (
@@ -120,7 +118,7 @@ export const Carousel = ({
               type='prev'
               position='bottom'
               setPosition={arrowsPosition}
-              {...buttonColorProps}
+              {...buttonStyles}
             />
             {showDots && <Dots />}
             <ArrowButton
@@ -128,7 +126,7 @@ export const Carousel = ({
               type='next'
               position='bottom'
               setPosition={arrowsPosition}
-              {...buttonColorProps}
+              {...buttonStyles}
             />
           </Flex>
         ) : null}
@@ -171,12 +169,14 @@ Carousel.propTypes = {
   arrowsPosition: PropTypes.oneOf(['side', 'top', 'bottom', 'hide']),
   /** Padding around the slides */
   slideSpacing: PropTypes.number,
-  /** Option to specify arrow button colors based on color.shade palette color */
-  buttonColorProps: PropTypes.shape({
+  /** Custom button styles width, height, color based on color.shade palette color */
+  buttonStyles: PropTypes.shape({
     buttonBackground: PropTypes.string,
     buttonColor: PropTypes.string,
     buttonHoverBackground: PropTypes.string,
     buttonHoverColor: PropTypes.string,
+    buttonWidth: PropTypes.string,
+    buttonHeight: PropTypes.string,
   }),
   /** Called each time the current slide changes, passed the new currentSlide (zero-indexed) */
   onSlideChange: PropTypes.func,

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -43,12 +43,9 @@ export const Carousel = ({
   visibleSlides = 1,
   arrowsPosition = 'side',
   slideSpacing = 2,
-<<<<<<< HEAD
-  buttonColorProps,
   onSlideChange,
-=======
+  sideButtonMargin = '-30px',
   buttonStyles,
->>>>>>> 79352593 (feat(cu): add button width, height props, change buttonColorProps name to buttonStyles)
   isTwoColumnLayout = false,
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
@@ -81,7 +78,7 @@ export const Carousel = ({
         <Relative>
           <ArrowButton
             pl={slideSpacing}
-            ml='-30px'
+            ml={sideButtonMargin}
             type='prev'
             position='side'
             setPosition={arrowsPosition}
@@ -103,7 +100,7 @@ export const Carousel = ({
             })}
           </Slider>
           <ArrowButton
-            mr='-30px'
+            mr={sideButtonMargin}
             pr={slideSpacing}
             type='next'
             position='side'
@@ -169,6 +166,8 @@ Carousel.propTypes = {
   arrowsPosition: PropTypes.oneOf(['side', 'top', 'bottom', 'hide']),
   /** Padding around the slides */
   slideSpacing: PropTypes.number,
+  /** Custom arrow button margin for side position/horizontal orientation */
+  sideButtonMargin: PropTypes.string,
   /** Custom button styles width, height, color based on color.shade palette color */
   buttonStyles: PropTypes.shape({
     buttonBackground: PropTypes.string,

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -45,11 +45,12 @@ export const Carousel = ({
   slideSpacing = 2,
   buttonColorProps,
   onSlideChange,
+  isTwoColumnLayout = false,
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
   const layoutSize = layout?.split('-').length
   const visibleSlidesArray = getVisibleSlidesArray(visibleSlides)
-  const responsiveVisibleSlides = useResponsiveVisibleSlides(visibleSlidesArray)
+  const responsiveVisibleSlides = useResponsiveVisibleSlides(visibleSlidesArray, isTwoColumnLayout)
 
   return (
     <CarouselWrapper>
@@ -179,4 +180,6 @@ Carousel.propTypes = {
   }),
   /** Called each time the current slide changes, passed the new currentSlide (zero-indexed) */
   onSlideChange: PropTypes.func,
+  /** When true, carousel does not span the entire width of parent container, rather it is adjacent to another element with width */
+  isTwoColumnLayout: PropTypes.bool,
 }

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Flex, Card, Image, Text, Box, BackgroundImage } from 'pcln-design-system'
+import { Flex, Card, Container, Image, Text, Box, BackgroundImage } from 'pcln-design-system'
 import styled from 'styled-components'
 import { Carousel } from './Carousel'
 
@@ -9,6 +9,11 @@ const SLIDE_COUNT = 10
 const ToutCard = styled(Card)`
   overflow: hidden;
 `
+
+const StyledMockBox = styled(Box)`
+  border: 1px solid black;
+`
+
 export default {
   title: 'pcln-carousel / Carousel',
   component: Carousel,
@@ -185,4 +190,29 @@ AlternateButtonColors.args = {
     buttonHoverBackground: 'primary.dark',
     buttonHoverColor: 'text.lightest',
   },
+}
+
+const TwoColumLayoutTemplate = (args) => (
+  <Container maxWidth={1280}>
+    <Flex width={1} flexDirection={['column', null, null, 'row']}>
+      <Box width={[1, null, null, 2 / 3]}>
+        <Carousel {...args}>{renderCards()}</Carousel>
+      </Box>
+      <StyledMockBox width={[1, null, null, 1 / 3]} textAlign='center'>
+        MOCK SUMMARY OF CHARGES
+      </StyledMockBox>
+    </Flex>
+  </Container>
+)
+export const TwoColumnLayout = TwoColumLayoutTemplate.bind({})
+TwoColumnLayout.args = {
+  showDots: false,
+  showForwardBackBtns: true,
+  buttonColorProps: {
+    buttonBackground: 'primary.base',
+    buttonColor: 'text.lightest',
+    buttonHoverBackground: 'primary.dark',
+    buttonHoverColor: 'text.lightest',
+  },
+  isTwoColumnLayout: true,
 }

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -208,6 +208,7 @@ export const TwoColumnLayout = TwoColumLayoutTemplate.bind({})
 TwoColumnLayout.args = {
   showDots: false,
   showForwardBackBtns: true,
+  sideButtonMargin: '-23px',
   buttonStyles: {
     buttonBackground: 'primary.base',
     buttonColor: 'text.lightest',

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -184,7 +184,7 @@ AlternateButtonColors.args = {
   visibleSlides: 3,
   showDots: false,
   showForwardBackBtns: true,
-  buttonColorProps: {
+  buttonStyles: {
     buttonBackground: 'primary.base',
     buttonColor: 'text.lightest',
     buttonHoverBackground: 'primary.dark',
@@ -208,11 +208,13 @@ export const TwoColumnLayout = TwoColumLayoutTemplate.bind({})
 TwoColumnLayout.args = {
   showDots: false,
   showForwardBackBtns: true,
-  buttonColorProps: {
+  buttonStyles: {
     buttonBackground: 'primary.base',
     buttonColor: 'text.lightest',
     buttonHoverBackground: 'primary.dark',
     buttonHoverColor: 'text.lightest',
+    buttonWidth: '48px',
+    buttonHeight: '48px',
   },
   isTwoColumnLayout: true,
 }

--- a/packages/carousel/src/helpers.js
+++ b/packages/carousel/src/helpers.js
@@ -14,14 +14,14 @@ const getSlideKey = moize(uuidv4)
 const getVisibleSlidesArray = (visibleSlides) =>
   Array.isArray(visibleSlides) ? visibleSlides : [XS_VISIBLE_SLIDES, SM_VISIBLE_SLIDES, visibleSlides]
 
-const getVisibleSlides = (visibleSlides, windowWidth) =>
+const getVisibleSlides = (visibleSlides, windowWidth, isTwoColumnLayout) =>
   windowWidth < XS_VISIBLE_SLIDES_WIDTH
     ? visibleSlides[0]
-    : windowWidth < SM_VISIBLE_SLIDES_WIDTH
+    : windowWidth < SM_VISIBLE_SLIDES_WIDTH && !isTwoColumnLayout
     ? visibleSlides[1]
     : visibleSlides[2]
 
-const useResponsiveVisibleSlides = (visibleSlides) => {
+const useResponsiveVisibleSlides = (visibleSlides, isTwoColumnLayout) => {
   const [width, setWidth] = useState(window.innerWidth)
   const handleResize = () => {
     setWidth(window.innerWidth)
@@ -33,7 +33,7 @@ const useResponsiveVisibleSlides = (visibleSlides) => {
       media.removeEventListener('change', handleResize)
     }
   })
-  return getVisibleSlides(visibleSlides, width)
+  return getVisibleSlides(visibleSlides, width, isTwoColumnLayout)
 }
 
 export { getSlideKey, getVisibleSlidesArray, useResponsiveVisibleSlides }


### PR DESCRIPTION
* renaming a prop so opted for a major version change
* buttonHeight, buttonWidth, sideButtonMargin props to allow for custom rules from consumer
* isTwoColumnLayout prop avoids responsive issue where carousel cards will be scrunched up if adjacent to a sibling element

