### PR TITLE
Pass zIndex prop to Layout children wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+**/.storybook/node_modules
 
 # Optional npm cache directory
 .npm

--- a/common/changes/pcln-design-system/layout-z-index_2022-03-28-14-46.json
+++ b/common/changes/pcln-design-system/layout-z-index_2022-03-28-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Pass zIndex prop to Layout children wrappers",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Card/Card.stories.tsx
+++ b/packages/core/src/Card/Card.stories.tsx
@@ -8,7 +8,16 @@ export default {
 
 export const BoxShadowsWithDefaultBorder = () => (
   <Box>
-    <Card boxShadowSize='sm' m={4} p={4} width={1 / 2} color='black' bg='white' borderWidth={1}>
+    <Card
+      borderRadius={6}
+      boxShadowSize='sm'
+      m={4}
+      p={4}
+      width={1 / 2}
+      color='black'
+      bg='white'
+      borderWidth={1}
+    >
       Small Shadow
     </Card>
     <Card boxShadowSize='md' m={4} p={4} width={1 / 2} color='text' bg='white' borderWidth={1}>

--- a/packages/core/src/Layout/Layout.stories.tsx
+++ b/packages/core/src/Layout/Layout.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Flex, Container, Box, Layout } from '..'
+import { Flex, Container, Box, Layout, Relative, Absolute } from '..'
 
 export default {
   title: 'Layout',
@@ -43,4 +43,24 @@ Responsive.args = {
   variation: ['100', '50-50', null, '60-40'],
   gap: 'sm',
   rowGap: ['sm', 'md'],
+}
+
+const OverlapTemplate = (args) => (
+  <Flex width='100%' color='primary.light'>
+    <Container size='xl' style={{ border: `1px solid` }}>
+      <Layout {...args}>
+        <Relative color='secondary.base' zIndex={1} height='200px'>
+          <Absolute height={100} width={200} color='notify' top='30px' right='-70px' />
+        </Relative>
+        <LayoutDemoBox color='primary.base' />
+      </Layout>
+    </Container>
+  </Flex>
+)
+
+export const Overlap = OverlapTemplate.bind({})
+Overlap.args = {
+  variation: '60-40',
+  gap: 'sm',
+  rowGap: 'sm',
 }

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import moize from 'moize'
 import PropTypes, { InferProps } from 'prop-types'
+import { zIndex } from 'styled-system'
+import styled from 'styled-components'
 
 import { Flex, Box } from '..'
 
@@ -139,6 +141,10 @@ const propTypes = {
   ]),
 }
 
+const ZIndexBox = styled(Box)`
+  ${zIndex}
+`
+
 const Layout: React.FC<InferProps<typeof propTypes>> = ({ children, gap, rowGap, variation }) => {
   const widths = memoGetChildrenWidths(variation, children.length)
   const { boxPaddingX, boxPaddingY, flexMarginX, flexMarginY } = memoGetGapValues(gap, rowGap)
@@ -149,9 +155,15 @@ const Layout: React.FC<InferProps<typeof propTypes>> = ({ children, gap, rowGap,
         children,
         (child, idx) =>
           child && (
-            <Box width={widths[idx]} px={boxPaddingX} py={boxPaddingY} data-testid={`box-${idx}`}>
+            <ZIndexBox
+              width={widths[idx]}
+              px={boxPaddingX}
+              py={boxPaddingY}
+              data-testid={`box-${idx}`}
+              zIndex={child.props.zIndex}
+            >
               {React.cloneElement(child)}
-            </Box>
+            </ZIndexBox>
           )
       )}
     </Flex>


### PR DESCRIPTION
This is useful if you need children to overlap.

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/3260642/160434590-3d194297-76f3-4fb1-bd1b-89905f2812e6.png">
