### PR TITLE
fix DS theme provider to account for existing provider

### DIFF
--- a/common/changes/pcln-design-system/fix-theme-wrapper_2022-03-29-19-50.json
+++ b/common/changes/pcln-design-system/fix-theme-wrapper_2022-03-29-19-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Updated theme wrapper to take existing into account when merging themes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/ThemeProvider/ThemeProvider.tsx
+++ b/packages/core/src/ThemeProvider/ThemeProvider.tsx
@@ -53,7 +53,7 @@ const propTypes = {
 
 const ThemeProvider: React.FC<InferProps<typeof propTypes>> = ({ theme, customBreakpoints, ...props }) => {
   // Once updated to React 16.8 this should be wrapped in React.useMemo()
-  const mergedTheme = createTheme(theme, customBreakpoints)
+  const mergedTheme = (existingTheme = {}) => createTheme(existingTheme, theme, customBreakpoints)
 
   return (
     <StyledThemeProvider theme={mergedTheme}>

--- a/packages/core/src/ThemeProvider/ThemeProvider.tsx
+++ b/packages/core/src/ThemeProvider/ThemeProvider.tsx
@@ -53,7 +53,7 @@ const propTypes = {
 
 const ThemeProvider: React.FC<InferProps<typeof propTypes>> = ({ theme, customBreakpoints, ...props }) => {
   // Once updated to React 16.8 this should be wrapped in React.useMemo()
-  const mergedTheme = (existingTheme = {}) => createTheme(existingTheme, theme, customBreakpoints)
+  const mergedTheme = (existingTheme) => createTheme(theme, customBreakpoints, existingTheme)
 
   return (
     <StyledThemeProvider theme={mergedTheme}>

--- a/packages/core/src/utils/createTheme.ts
+++ b/packages/core/src/utils/createTheme.ts
@@ -18,25 +18,25 @@ const addAliases = (arr) => {
 
 /**
  * Create the theme
- *
  * @param theme -             The theme to merge against the default
  * @param customBreakpoints - Custom breakpoints for the theme
+ * @param existingTheme -     Existing theme passed from a parent provider (Undefined if it's most outer provider)
  *
  * @returns The generated theme
  */
-const createTheme = (existingTheme, theme = {}, customBreakpoints = null) => {
-  const mergedTheme = deepmerge(defaultTheme, existingTheme)
-  const finalMergedTheme = deepmerge(mergedTheme, theme)
-
-  const mediaQueries = customBreakpoints ? createMediaQueries(customBreakpoints) : mergedTheme.mediaQueries
+const createTheme = (theme = {}, customBreakpoints = null, existingTheme = defaultTheme) => {
+  const finalMergedTheme = deepmerge(existingTheme, theme)
+  const mediaQueries = customBreakpoints
+    ? createMediaQueries(customBreakpoints)
+    : finalMergedTheme.mediaQueries
   return {
     ...finalMergedTheme,
-    contrastRatio: mergedTheme.contrastRatio || 2.6,
-    breakpoints: addAliases(customBreakpoints || mergedTheme.breakpoints),
+    contrastRatio: finalMergedTheme.contrastRatio || 2.6,
+    breakpoints: addAliases(customBreakpoints || finalMergedTheme.breakpoints),
     mediaQueries: addAliases(mediaQueries),
-    palette: createPalette(mergedTheme),
-    colorStyles: createColorStyles(mergedTheme),
-    textStyles: createTextStyles(mergedTheme),
+    palette: createPalette(finalMergedTheme),
+    colorStyles: createColorStyles(finalMergedTheme),
+    textStyles: createTextStyles(finalMergedTheme),
   }
 }
 

--- a/packages/core/src/utils/createTheme.ts
+++ b/packages/core/src/utils/createTheme.ts
@@ -24,12 +24,13 @@ const addAliases = (arr) => {
  *
  * @returns The generated theme
  */
-const createTheme = (theme = {}, customBreakpoints = null) => {
-  const mergedTheme = deepmerge(defaultTheme, theme)
+const createTheme = (existingTheme, theme = {}, customBreakpoints = null) => {
+  const mergedTheme = deepmerge(defaultTheme, existingTheme)
+  const finalMergedTheme = deepmerge(mergedTheme, theme)
 
   const mediaQueries = customBreakpoints ? createMediaQueries(customBreakpoints) : mergedTheme.mediaQueries
   return {
-    ...mergedTheme,
+    ...finalMergedTheme,
     contrastRatio: mergedTheme.contrastRatio || 2.6,
     breakpoints: addAliases(customBreakpoints || mergedTheme.breakpoints),
     mediaQueries: addAliases(mediaQueries),


### PR DESCRIPTION
Our current ThemeProvider does not take into account existing themes, so whenever an inner ThemeWrapper is invoked the existing styles created by the outer provider are ignored and the new theme is merged with the `defaultTheme` from DS.

Changing the signature of the theme prop from an object to a function allows us to retrieve the existing theme and merge it against the new theme. This follows the approach suggested by the Styled Components docs https://styled-components.com/docs/advanced#function-themes