### PR TITLE
Update form field to accept props

### DIFF
--- a/common/changes/pcln-design-system/update-form-field-to-accept-props_2022-04-01-22-35.json
+++ b/common/changes/pcln-design-system/update-form-field-to-accept-props_2022-04-01-22-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add common prop support to FormField",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/FormField/FormField.tsx
+++ b/packages/core/src/FormField/FormField.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { InferProps } from 'prop-types'
 
+import { Box } from '../Box'
 import { IconField } from '../IconField'
 
 const childrenPropType = (props, propName, componentName) => {
@@ -22,17 +23,17 @@ const propTypes = {
   children: childrenPropType,
 }
 
-const FormField: React.FC<InferProps<typeof propTypes>> = (props) => {
+const FormField: React.FC<InferProps<typeof propTypes>> = ({ children, ...props }) => {
   let iconBefore = false
 
-  const children = React.Children.toArray(props.children)
-  const [field] = children.filter((child) => child.type.isField)
-  const [label] = children.filter((child) => child.type.isLabel)
+  const childrenArray = React.Children.toArray(children)
+  const [field] = childrenArray.filter((child) => child.type.isField)
+  const [label] = childrenArray.filter((child) => child.type.isLabel)
   const valueNoLabel = !label && field && !!field.props.value
   const showLabel = ((label && !label.props.autoHide) || (field && !!field.props.value)) && !valueNoLabel
   const id = field && (field.props.id || field.props.name)
 
-  const styled = children.map((child, i, arr) => {
+  const styled = childrenArray.map((child, i, arr) => {
     if (child.type.isField && arr[i - 1] && arr[i - 1].type.isIcon) {
       iconBefore = true
     }
@@ -74,10 +75,10 @@ const FormField: React.FC<InferProps<typeof propTypes>> = (props) => {
     })
 
   return (
-    <div>
+    <Box {...props}>
       {styledLabel}
       <IconField>{styled}</IconField>
-    </div>
+    </Box>
   )
 }
 

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -82,7 +82,9 @@ exports[`FormField renders 1`] = `
   }
 }
 
-<div>
+<div
+  className=""
+>
   <label
     className="c0"
     color="text.light"
@@ -235,7 +237,9 @@ exports[`FormField renders with Icon 1`] = `
   }
 }
 
-<div>
+<div
+  className=""
+>
   <label
     className="c0"
     color="text.light"
@@ -409,7 +413,9 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   }
 }
 
-<div>
+<div
+  className=""
+>
   <label
     className="c0"
     color="text.light"
@@ -571,7 +577,9 @@ exports[`FormField renders with Select  1`] = `
   }
 }
 
-<div>
+<div
+  className=""
+>
   <label
     className="c0"
     color="text.light"
@@ -753,7 +761,9 @@ exports[`FormField renders with Select and Icon 1`] = `
   }
 }
 
-<div>
+<div
+  className=""
+>
   <label
     className="c0"
     color="text.light"


### PR DESCRIPTION
@pcln-brianna and I are trying to set the width prop on FormField but cannot, same goes for any other style overrule.

This will not have changes for people upgrading to the new version unless they were setting the props on FormField and expecting them to work but they weren't. 