### PR TITLE
fix missing semicolon on ArrowButton styling

### DIFF
--- a/common/changes/pcln-carousel/carousel-arrowButton-fix_2022-05-26-18-04.json
+++ b/common/changes/pcln-carousel/carousel-arrowButton-fix_2022-05-26-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "fix missing semicolon on ArrowButton styling causing z-index issues",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/ArrowButton/ArrowButton.styles.js
+++ b/packages/carousel/src/ArrowButton/ArrowButton.styles.js
@@ -20,7 +20,7 @@ const sidePositionStyles = (props) =>
     ${props.type == 'prev' ? 'left' : 'right'}: 0px;
     position: absolute;
     top: 50%;
-    margin-top: -30px
+    margin-top: -30px;
     z-index: 2;
     `
     : null


### PR DESCRIPTION
CSS error found in dev-tools: 
![image](https://user-images.githubusercontent.com/16519244/170543957-85610ba1-8ebf-4362-92eb-9bcea711849e.png)
