### PR TITLE
update popover to allow display styling and disabling onClick

### DIFF
--- a/common/changes/pcln-popover/feature-popover-styling_2022-06-02-18-56.json
+++ b/common/changes/pcln-popover/feature-popover-styling_2022-06-02-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "update popover to allow display styling and disabling onClick",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/Popover/Popover.js
+++ b/packages/popover/src/Popover/Popover.js
@@ -31,16 +31,22 @@ class Popover extends Component {
   }
 
   handleClose(evt) {
-    this.setState({ isPopoverOpen: false }, () => {
-      this.setFocusToRef(this.triggerRef)
-    })
+    if (this.props.toggleIsOpenOnClick) {
+      this.setState({ isPopoverOpen: false }, () => {
+        this.setFocusToRef(this.triggerRef)
+      })
+    }
+
     this.props.onClose && this.props.onClose(evt)
   }
 
   handleOpen(evt) {
-    this.setState({ isPopoverOpen: true }, () => {
-      this.setFocusToRef(this.contentRef)
-    })
+    if (this.props.toggleIsOpenOnClick) {
+      this.setState({ isPopoverOpen: true }, () => {
+        this.setFocusToRef(this.contentRef)
+      })
+    }
+
     this.props.onOpen && this.props.onOpen(evt)
   }
 
@@ -58,7 +64,7 @@ class Popover extends Component {
 
   render() {
     const { isPopoverOpen: isOpenState } = this.state
-    const { ariaLabel, children, isOpen: isOpenProp } = this.props
+    const { ariaLabel, children, isOpen: isOpenProp, display } = this.props
     const isPopoverOpen = isOpenState || isOpenProp
 
     return (
@@ -66,7 +72,7 @@ class Popover extends Component {
         <Reference>
           {({ ref }) => (
             // Need to be a native element, because of ref forwarding limitations with DS functional components
-            <InlineContainer ref={ref}>
+            <Container ref={ref} display={display}>
               {
                 // Clone element to pass down toggle event so it can be used directly from children as needed
                 React.cloneElement(children, {
@@ -75,7 +81,7 @@ class Popover extends Component {
                   ref: this.triggerRef,
                 })
               }
-            </InlineContainer>
+            </Container>
           )}
         </Reference>
         {isPopoverOpen && (
@@ -86,8 +92,8 @@ class Popover extends Component {
   }
 }
 
-const InlineContainer = styled.div`
-  display: inline-block;
+const Container = styled.div`
+  display: ${({ display }) => display};
 `
 
 Popover.propTypes = {
@@ -111,10 +117,14 @@ Popover.propTypes = {
   onClose: PropTypes.func,
   hideArrow: PropTypes.bool,
   hideOverlay: PropTypes.bool,
+  display: PropTypes.string,
+  toggleIsOpenOnClick: PropTypes.bool,
 }
 
 Popover.defaultProps = {
   ariaLabel: 'Click to open popover with more information',
+  toggleIsOpenOnClick: true,
+  display: 'inline-block',
 }
 
 export default Popover

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -57,6 +57,7 @@ exports[`Popover Trigger Element Renders trigger element and appends action prop
 >
   <div
     class="c1"
+    display="inline-block"
   >
     <button
       aria-label="Top Popover"
@@ -90,6 +91,7 @@ exports[`Popover Trigger Element renders with FocusLock 1`] = `
   >
     <div
       class="c1"
+      display="inline-block"
     >
       <button
         aria-label="Top Popover"


### PR DESCRIPTION
Adding additional functionality to `pcln-popover`:

- A `display` CSS override to help when the default `display: inline-block` causes styling issues in some contexts.
- A `toggleIsOpenOnClick` prop to disable the default onClick behavior in the case that Popover is triggered via hover events.