### PR TITLE
add onClick and onKeyDown handlers to Carousel children

### DIFF
--- a/common/changes/pcln-carousel/feature-add-events-carousel-slide_2022-06-03-20-40.json
+++ b/common/changes/pcln-carousel/feature-add-events-carousel-slide_2022-06-03-20-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "add onClick and onKeyDown handlers to Carousel children",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/common/changes/pcln-popover/feature-add-events-carousel-slide_2022-06-06-15-43.json
+++ b/common/changes/pcln-popover/feature-add-events-carousel-slide_2022-06-06-15-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "add prop to control event.stopPropagation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -48,6 +48,8 @@ export const Carousel = ({
   sideButtonMargin = '-30px',
   sidePositionArrowButton,
   stretchSlideHeight = true,
+  onSlideClick = () => {},
+  onSlideKeyDown = () => {},
 }) => {
   const [height, setHeight] = useState(0)
   const widths = layoutToFlexWidths(layout, children.length)
@@ -104,6 +106,12 @@ export const Carousel = ({
                   key={getSlideKey(item)}
                   style={widths[index] && { width: widths[index] }}
                   data-testid={`slide-${index}`}
+                  onClick={(e) => {
+                    onSlideClick(index, e)
+                  }}
+                  onKeyDown={(e) => {
+                    onSlideKeyDown(index, e)
+                  }}
                 >
                   <Box p={slideSpacing}>
                     {!layout && stretchSlideHeight ? (
@@ -193,4 +201,8 @@ Carousel.propTypes = {
   sidePositionArrowButton: PropTypes.element,
   /** Set height of slides based on tallest slide */
   stretchSlideHeight: PropTypes.bool,
+  /** Custom onClick event handler for each Slide child */
+  onSlideClick: PropTypes.func,
+  /** Custom onKeyDown event handler for each Slide child */
+  onSlideKeyDown: PropTypes.func,
 }

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -20,9 +20,17 @@ describe('Carousel', () => {
 
   it('should render a carousel', () => {
     const onSlideChange = jest.fn()
+    const onSlideClick = jest.fn()
+    const onSlideKeyDown = jest.fn()
 
     const { getByText, getByTestId, getByLabelText } = render(
-      <Carousel showDots arrowsPosition='side' onSlideChange={onSlideChange}>
+      <Carousel
+        showDots
+        arrowsPosition='side'
+        onSlideChange={onSlideChange}
+        onSlideClick={onSlideClick}
+        onSlideKeyDown={onSlideKeyDown}
+      >
         <Flex>Slide 1</Flex>
         <Flex>Slide 2</Flex>
         <Flex>Slide 3</Flex>
@@ -38,6 +46,10 @@ describe('Carousel', () => {
     expect(onSlideChange).toHaveBeenCalledWith(1)
     fireEvent.click(getByLabelText('previous'))
     expect(onSlideChange).toHaveBeenCalledWith(0)
+    fireEvent.click(getByText('Slide 1'))
+    expect(onSlideClick).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(getByText('Slide 1'), { key: 'Enter' })
+    expect(onSlideKeyDown).toHaveBeenCalledTimes(1)
   })
 
   it('should set slide widths if layout is set', () => {

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -50,6 +50,12 @@ export default {
     onSlideChange: {
       action: 'Current slide changed',
     },
+    onSlideClick: {
+      action: 'Current slide click',
+    },
+    onSlideKeyDown: {
+      action: 'Current slide key',
+    },
   },
 }
 

--- a/packages/popover/src/Popover/Popover.js
+++ b/packages/popover/src/Popover/Popover.js
@@ -22,7 +22,9 @@ class Popover extends Component {
 
   handleToggle(evt, isOpen) {
     evt.preventDefault()
-    evt.stopPropagation()
+    if (this.props.stopPropagation) {
+      evt.stopPropagation()
+    }
     if (isOpen) {
       this.handleClose(evt)
     } else {
@@ -119,12 +121,14 @@ Popover.propTypes = {
   hideOverlay: PropTypes.bool,
   display: PropTypes.string,
   toggleIsOpenOnClick: PropTypes.bool,
+  stopPropagation: PropTypes.bool,
 }
 
 Popover.defaultProps = {
   ariaLabel: 'Click to open popover with more information',
   toggleIsOpenOnClick: true,
   display: 'inline-block',
+  stopPropagation: true,
 }
 
 export default Popover


### PR DESCRIPTION
Add 2 event handler props for `Carousel`: `onSlideClick` and `onSlideKeyDown`. These are passed to the `Carousel` component and will be called for each carousel item.

Add a `stopPropagation` prop to `Popover` allowing an override when Popover causes issues with swallowing events that need to bubble up higher, like in a Carousel for example.