### PR TITLE
feat(indeterminate-checkbox): add support for indeterminate checkboxes

### DIFF
--- a/common/changes/pcln-design-system/feat-indeterminate-checkbox_2022-07-06-12-49.json
+++ b/common/changes/pcln-design-system/feat-indeterminate-checkbox_2022-07-06-12-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Added an indeterminate checkbox state",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Checkbox/Checkbox.spec.tsx
+++ b/packages/core/src/Checkbox/Checkbox.spec.tsx
@@ -13,8 +13,7 @@ describe('Checkbox', () => {
 
   test('renders checked when defaultChecked prop is passed as true', () => {
     const { getByRole } = render(<Checkbox id='check-box' defaultChecked onChange={onChange} />)
-    const checkbox = getByRole('checkbox')
-    // @ts-ignore
+    const checkbox = getByRole('checkbox') as HTMLInputElement
     expect(checkbox.checked).toBe(true)
   })
 
@@ -35,5 +34,35 @@ describe('Checkbox', () => {
     const checkbox = container.querySelector('[type=checkbox]')
     fireEvent.click(checkbox)
     expect(onChange).toHaveBeenCalled()
+  })
+
+  it('renders an indeterminate checkbox that can be clicked to set checked to true', () => {
+    const { getByRole } = render(<Checkbox id='check-box' indeterminate onChange={onChange} />)
+    const checkbox = getByRole('checkbox') as HTMLInputElement
+
+    expect(checkbox.checked).toBe(false)
+    expect(checkbox.indeterminate).toBe(true)
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+    expect(checkbox.indeterminate).toBe(false)
+  })
+  it('renders an indeterminate checkbox that can be clicked to set checked to false', () => {
+    const { getByRole } = render(<Checkbox id='check-box' indeterminate defaultChecked onChange={onChange} />)
+    const checkbox = getByRole('checkbox') as HTMLInputElement
+
+    expect(checkbox.checked).toBe(true)
+    expect(checkbox.indeterminate).toBe(true)
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(false)
+    expect(checkbox.indeterminate).toBe(false)
+  })
+  it('correctly passes in the ref so that the underlying input element can be modified by the parent component if needed', () => {
+    const ref = React.createRef()
+    const { getByRole } = render(
+      <Checkbox id='check-box' ref={ref} indeterminate defaultChecked onChange={onChange} />
+    )
+    const checkbox = getByRole('checkbox') as HTMLInputElement
+
+    expect(ref.current.id).toBe(checkbox.id)
   })
 })

--- a/packages/core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/core/src/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { action } from '@storybook/addon-actions'
 
@@ -37,59 +37,153 @@ function onSubmit(e) {
   return formAction(e)
 }
 
-export const CheckboxStates = () => (
-  <div>
-    <Wrapper>
-      <StyledLabel htmlFor='unchecked_box'>
-        <Checkbox id='unchecked_box' onChange={checkAction} />
-        Unchecked by default
-      </StyledLabel>
-    </Wrapper>
+const FilterExample: React.FC = () => {
+  const [filterState, setFilterState] = useState({
+    all: false,
+    indeterminate: false,
+    small: false,
+    medium: false,
+    large: false,
+  })
 
-    <Wrapper>
-      <StyledLabel htmlFor='checked_box'>
-        <Checkbox id='checked_box' defaultChecked onChange={checkAction} />
-        Checked by default
-      </StyledLabel>
-    </Wrapper>
+  const handleFilterSelection = (event: React.SyntheticEvent<HTMLInputElement>) => {
+    const target = event.target
+    if (target.id === 'all') {
+      if (filterState.all || filterState.indeterminate) {
+        setFilterState({
+          all: false,
+          indeterminate: false,
+          small: false,
+          medium: false,
+          large: false,
+        })
+      } else {
+        setFilterState({
+          all: true,
+          indeterminate: false,
+          small: true,
+          medium: true,
+          large: true,
+        })
+      }
+    } else {
+      const newFilterState = { ...filterState, [target.id]: !filterState[target.id] }
+      const indeterminate = !(
+        newFilterState.small === newFilterState.medium && newFilterState.small === newFilterState.large
+      )
+      const all = newFilterState.small && newFilterState.medium && newFilterState.large
+      setFilterState({
+        ...filterState,
+        [target.id]: !filterState[target.id],
+        indeterminate,
+        all,
+      })
+    }
+  }
+  return (
+    <>
+      <Wrapper>
+        <StyledLabel htmlFor='all'>
+          <Checkbox
+            id='all'
+            onChange={handleFilterSelection}
+            indeterminate={filterState.indeterminate}
+            checked={filterState.all}
+          />
+          Cars
+        </StyledLabel>
+        <Box ml={2}>
+          <StyledLabel htmlFor='small'>
+            <Checkbox id='small' onChange={handleFilterSelection} checked={filterState.small} />
+            Small
+          </StyledLabel>
+          <StyledLabel htmlFor='medium'>
+            <Checkbox id='medium' onChange={handleFilterSelection} checked={filterState.medium} />
+            Medium
+          </StyledLabel>
+          <StyledLabel htmlFor='large'>
+            <Checkbox id='large' onChange={handleFilterSelection} checked={filterState.large} />
+            Large
+          </StyledLabel>
+        </Box>
+      </Wrapper>
+    </>
+  )
+}
 
-    <Wrapper>
-      <StyledLabel htmlFor='disabled_box'>
-        <Checkbox id='disabled_box' disabled onChange={checkAction} />
-        <Text.span color='border.base'>Disabled</Text.span>
-      </StyledLabel>
-    </Wrapper>
+export const CheckboxStates = () => {
+  return (
+    <div>
+      <Wrapper>
+        <StyledLabel htmlFor='unchecked_box'>
+          <Checkbox id='unchecked_box' onChange={checkAction} />
+          Unchecked by default
+        </StyledLabel>
+      </Wrapper>
 
-    <Wrapper>
-      <StyledLabel htmlFor='disabled_checked_box'>
-        <Checkbox id='disabled_checked_box' disabled defaultChecked onChange={checkAction} />
-        <Text.span color='border.base'>Disabled &amp; Checked</Text.span>
-      </StyledLabel>
-    </Wrapper>
+      <Wrapper>
+        <StyledLabel htmlFor='checked_box'>
+          <Checkbox id='checked_box' defaultChecked onChange={checkAction} />
+          Checked by default
+        </StyledLabel>
+      </Wrapper>
 
-    <Wrapper title='In A Form'>
-      <form onSubmit={onSubmit}>
-        <fieldset style={{ display: 'inline-block', padding: '16px' }}>
-          <legend>Fancy Form</legend>
+      <Wrapper>
+        <StyledLabel htmlFor='disabled_box'>
+          <Checkbox id='disabled_box' disabled onChange={checkAction} />
+          <Text.span color='border.base'>Disabled</Text.span>
+        </StyledLabel>
+      </Wrapper>
 
-          <Wrapper>
-            <StyledLabel fontSize='14px' htmlFor='form_checkbox'>
-              <Checkbox id='form_checkbox' size={30} onChange={checkAction} />
-              &nbsp;In This Form
-            </StyledLabel>
-          </Wrapper>
+      <Wrapper>
+        <StyledLabel htmlFor='disabled_checked_box'>
+          <Checkbox id='disabled_checked_box' disabled defaultChecked onChange={checkAction} />
+          <Text.span color='border.base'>Disabled &amp; Checked</Text.span>
+        </StyledLabel>
+      </Wrapper>
 
-          <Button type='submit'>Submit Me</Button>
-          <br />
-          <br />
-          <Button variation='outline' color='border.base' type='reset'>
-            Reset Me
-          </Button>
-        </fieldset>
-      </form>
-    </Wrapper>
-  </div>
-)
+      <Wrapper>
+        <StyledLabel htmlFor='indeterminate_box'>
+          <Checkbox id='indeterminate_box' indeterminate onChange={checkAction} />
+          Initially indeterminate check box (clicking will checkmark it)
+        </StyledLabel>
+      </Wrapper>
+
+      <Wrapper>
+        <StyledLabel htmlFor='indeterminate_checked_box'>
+          <Checkbox id='indeterminate_checked_box' defaultChecked indeterminate onChange={checkAction} />
+          Initially indeterminate check box (clicking will uncheck it)
+        </StyledLabel>
+      </Wrapper>
+
+      <Wrapper title='Indeterminate Checkboxes'>
+        <FilterExample />
+      </Wrapper>
+
+      <Wrapper title='In A Form'>
+        <form onSubmit={onSubmit}>
+          <fieldset style={{ display: 'inline-block', padding: '16px' }}>
+            <legend>Fancy Form</legend>
+
+            <Wrapper>
+              <StyledLabel fontSize='14px' htmlFor='form_checkbox'>
+                <Checkbox id='form_checkbox' size={30} onChange={checkAction} />
+                &nbsp;In This Form
+              </StyledLabel>
+            </Wrapper>
+
+            <Button type='submit'>Submit Me</Button>
+            <br />
+            <br />
+            <Button variation='outline' color='border.base' type='reset'>
+              Reset Me
+            </Button>
+          </fieldset>
+        </form>
+      </Wrapper>
+    </div>
+  )
+}
 
 CheckboxStates.story = {
   name: 'Checkbox states',

--- a/packages/core/src/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/core/src/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -14,6 +14,10 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
   outline: none;
 }
 
+.c6 {
+  outline: none;
+}
+
 .c5 {
   outline: none;
 }
@@ -42,6 +46,27 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
 }
 
 .c1 svg[data-name='checked'] {
+  display: none;
+}
+
+.c1 svg[data-name='indeterminate'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='indeterminate'] {
+  display: inline-block;
+  color: #c0cad5;
+}
+
+.c1 > input:indeterminate:hover ~ svg[data-name='indeterminate'] {
+  color: #c0cad5;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='empty'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='checked'] {
   display: none;
 }
 
@@ -129,6 +154,23 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
       <svg
         aria-hidden="true"
         class="c3 c5"
+        data-name="indeterminate"
+        fill="currentcolor"
+        focusable="false"
+        height="24"
+        role="img"
+        tabindex="-1"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 5c-.6 0-1 .4-1 1v12c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V6c0-.6-.4-1-1-1H6zm0-2h12c1.7 0 3 1.3 3 3v12c0 1.7-1.3 3-3 3H6c-1.7 0-3-1.3-3-3V6c0-1.7 1.3-3 3-3zm1 8v2h10v-2H7z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="c3 c6"
         data-name="empty"
         fill="currentcolor"
         focusable="false"
@@ -162,6 +204,10 @@ exports[`Checkbox renders disabled with disabled prop 1`] = `
   outline: none;
 }
 
+.c6 {
+  outline: none;
+}
+
 .c5 {
   outline: none;
 }
@@ -190,6 +236,27 @@ exports[`Checkbox renders disabled with disabled prop 1`] = `
 }
 
 .c1 svg[data-name='checked'] {
+  display: none;
+}
+
+.c1 svg[data-name='indeterminate'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='indeterminate'] {
+  display: inline-block;
+  color: #c0cad5;
+}
+
+.c1 > input:indeterminate:hover ~ svg[data-name='indeterminate'] {
+  color: #c0cad5;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='empty'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='checked'] {
   display: none;
 }
 
@@ -276,6 +343,23 @@ exports[`Checkbox renders disabled with disabled prop 1`] = `
       <svg
         aria-hidden="true"
         class="c3 c5"
+        data-name="indeterminate"
+        fill="currentcolor"
+        focusable="false"
+        height="24"
+        role="img"
+        tabindex="-1"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 5c-.6 0-1 .4-1 1v12c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V6c0-.6-.4-1-1-1H6zm0-2h12c1.7 0 3 1.3 3 3v12c0 1.7-1.3 3-3 3H6c-1.7 0-3-1.3-3-3V6c0-1.7 1.3-3 3-3zm1 8v2h10v-2H7z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="c3 c6"
         data-name="empty"
         fill="currentcolor"
         focusable="false"
@@ -309,6 +393,10 @@ exports[`Checkbox renders without the theme passed specifically 1`] = `
   outline: none;
 }
 
+.c6 {
+  outline: none;
+}
+
 .c5 {
   outline: none;
 }
@@ -337,6 +425,27 @@ exports[`Checkbox renders without the theme passed specifically 1`] = `
 }
 
 .c1 svg[data-name='checked'] {
+  display: none;
+}
+
+.c1 svg[data-name='indeterminate'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='indeterminate'] {
+  display: inline-block;
+  color: #0068ef;
+}
+
+.c1 > input:indeterminate:hover ~ svg[data-name='indeterminate'] {
+  color: #049;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='empty'] {
+  display: none;
+}
+
+.c1 > input:indeterminate ~ svg[data-name='checked'] {
   display: none;
 }
 
@@ -421,6 +530,23 @@ exports[`Checkbox renders without the theme passed specifically 1`] = `
       <svg
         aria-hidden="true"
         class="c3 c5"
+        data-name="indeterminate"
+        fill="currentcolor"
+        focusable="false"
+        height="24"
+        role="img"
+        tabindex="-1"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 5c-.6 0-1 .4-1 1v12c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V6c0-.6-.4-1-1-1H6zm0-2h12c1.7 0 3 1.3 3 3v12c0 1.7-1.3 3-3 3H6c-1.7 0-3-1.3-3-3V6c0-1.7 1.3-3 3-3zm1 8v2h10v-2H7z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="c3 c6"
         data-name="empty"
         fill="currentcolor"
         focusable="false"


### PR DESCRIPTION
This adds support for the very legitimate indeterminate checkbox state.

`indeterminate` can only be set via javascript (you can't do something like `<input type='checkbox' indeterminate />`. It just won't work. 

Here is an example below (from the storybook story):
![indeterminateCheckboxes](https://user-images.githubusercontent.com/1385339/177403203-bdf3abb8-f940-4507-afe5-bee7a940367b.gif)

I made it so that it works by passing `indeterminate` as a prop, but it also has support for you to set `indeterminate` via the ref and the styling should apply correctly as well.

