### PR TITLE
Add font size and font weight to link

### DIFF
--- a/common/changes/pcln-design-system/add-fontSize-and-fontWeight-to-link_2022-07-26-22-27.json
+++ b/common/changes/pcln-design-system/add-fontSize-and-fontWeight-to-link_2022-07-26-22-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add fontSize and fontWeight props to Link component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/BlockLink/__snapshots__/BlockLink.spec.tsx.snap
+++ b/packages/core/src/BlockLink/__snapshots__/BlockLink.spec.tsx.snap
@@ -6,6 +6,8 @@ exports[`BlockLink renders 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0068ef;
+  font-size: 16px;
+  font-weight: normal;
   display: block;
   color: inherit;
   -webkit-text-decoration: none;
@@ -21,6 +23,8 @@ exports[`BlockLink renders 1`] = `
 <a
   className="c0"
   color="primary"
+  fontSize={2}
+  fontWeight="normal"
   rel={null}
   size="medium"
 >

--- a/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
+++ b/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
@@ -29,6 +29,8 @@ exports[`Breadcrumbs renders basic 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4f6f8f;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c2:hover {
@@ -42,6 +44,8 @@ exports[`Breadcrumbs renders basic 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #001023;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c4:hover {
@@ -59,6 +63,8 @@ exports[`Breadcrumbs renders basic 1`] = `
     <a
       className="c2"
       color="text.light"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com"
       rel={null}
       size="medium"
@@ -78,6 +84,8 @@ exports[`Breadcrumbs renders basic 1`] = `
     <a
       className="c2"
       color="text.light"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com/flights/"
       rel={null}
       size="medium"
@@ -97,6 +105,8 @@ exports[`Breadcrumbs renders basic 1`] = `
     <a
       className="c4"
       color="text.dark"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com/flights/"
       rel={null}
       size="medium"
@@ -168,6 +178,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4f6f8f;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c4:hover {
@@ -181,6 +193,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #001023;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c9:hover {
@@ -215,6 +229,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
     <a
       className="c4"
       color="text.light"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com"
       rel={null}
       size="medium"
@@ -251,6 +267,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
     <a
       className="c4"
       color="text.light"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com/flights/"
       rel={null}
       size="medium"
@@ -287,6 +305,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
     <a
       className="c9"
       color="text.dark"
+      fontSize={2}
+      fontWeight="normal"
       href="https://www.priceline.com/flights/"
       rel={null}
       size="medium"

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes, { InferProps } from 'prop-types'
 import styled, { css } from 'styled-components'
-import { width, space } from 'styled-system'
+import { fontSize, fontWeight, width, space } from 'styled-system'
 
 import { buttonStyles } from '../Button'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
@@ -34,6 +34,7 @@ const variations = {
 }
 
 const propTypes = {
+  ...fontSize.propTypes,
   color: deprecatedColorValue(),
   variation: PropTypes.oneOf(Object.keys(variations)),
 }
@@ -44,13 +45,15 @@ const Link: React.FC<InferProps<typeof propTypes>> = styled.a.attrs(({ target, .
   ...props,
 }))`
   ${applyVariations('Link', variations)}
-  ${width} ${space};
+  ${fontSize} ${fontWeight} ${width} ${space};
 `
 
 Link.displayName = 'Link'
 
 Link.defaultProps = {
   color: 'primary',
+  fontSize: 2,
+  fontWeight: 'normal',
   variation: 'link',
   size: 'medium',
 }

--- a/packages/core/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/core/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -7,6 +7,8 @@ exports[`Link should add rel="noopener" when target="_blank" 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0068ef;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c1:hover {
@@ -31,6 +33,8 @@ exports[`Link should add rel="noopener" when target="_blank" 1`] = `
     <a
       class="c1"
       color="primary"
+      font-size="2"
+      font-weight="normal"
       rel="noopener"
       target="_blank"
     >
@@ -47,6 +51,8 @@ exports[`Link should not add rel="noopener" when target is not "_blank" 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0068ef;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c1:hover {
@@ -71,6 +77,8 @@ exports[`Link should not add rel="noopener" when target is not "_blank" 1`] = `
     <a
       class="c1"
       color="primary"
+      font-size="2"
+      font-weight="normal"
     >
       Dummy
     </a>
@@ -85,6 +93,8 @@ exports[`Link should render correctly with no props without throwing 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0068ef;
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .c1:hover {
@@ -109,6 +119,8 @@ exports[`Link should render correctly with no props without throwing 1`] = `
     <a
       class="c1"
       color="primary"
+      font-size="2"
+      font-weight="normal"
     >
       Dummy
     </a>


### PR DESCRIPTION
This is required for some work I am doing on creating header links. I could use styled components, however this is likely something others want too and therefore makes sense to me for it to be a base feature.