### PR TITLE
Fix bug in 33-33-33 Carousel layout

### DIFF
--- a/common/changes/pcln-carousel/fix-carousel-button-position_2022-08-03-15-51.json
+++ b/common/changes/pcln-carousel/fix-carousel-button-position_2022-08-03-15-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Fix bug in 33-33-33 layout",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.stories.js
+++ b/packages/carousel/src/Carousel.stories.js
@@ -4,7 +4,7 @@ import { Flex, Card, Container, Image, Text, Box, BackgroundImage } from 'pcln-d
 import styled from 'styled-components'
 import { Carousel, ArrowButton } from '.'
 
-const SLIDE_COUNT = 10
+const SLIDE_COUNT = 6
 
 const ToutCard = styled(Card)`
   overflow: hidden;
@@ -60,8 +60,14 @@ export default {
 }
 
 function renderCards() {
-  return Array.from(Array(SLIDE_COUNT), (_, idx) => (
-    <ToutCard height={idx === 1 ? '300px' : '320px'} borderRadius={20} boxShadowSize='md' borderWidth={0}>
+  return Array.from(Array(SLIDE_COUNT)).map((_, idx) => (
+    <ToutCard
+      height={idx === 1 ? '300px' : '320px'}
+      borderRadius={20}
+      boxShadowSize='md'
+      borderWidth={0}
+      key={idx}
+    >
       <BackgroundImage height='190px' width='100%' image='https://cdn2.thecatapi.com/images/dnn.jpg' />
       <Flex color='background.lightest' p={[1, 1, 2, 2, 2, 3]}>
         <Box>
@@ -198,6 +204,16 @@ AlternateButtonColors.args = {
   showDots: false,
   showForwardBackBtns: true,
   sidePositionArrowButton: <ArrowButton {...buttonStyles} />,
+}
+
+export const CustomButtonPosition = BasicTemplate.bind({})
+CustomButtonPosition.args = {
+  visibleSlides: 3,
+  showDots: false,
+  showForwardBackBtns: true,
+  sideButtonMargin: '-50px',
+  slideSpacing: 3,
+  sidePositionArrowButton: <ArrowButton />,
 }
 
 const FixedVisibleSlidesTemplate = (args) => (

--- a/packages/carousel/src/layoutToFlexWidths.js
+++ b/packages/carousel/src/layoutToFlexWidths.js
@@ -3,7 +3,14 @@ export const layoutToFlexWidths = (layout, totalSlides) => {
     return []
   }
 
-  const layoutValues = layout?.split('-').map((i) => parseInt(i))
+  const layoutValues = layout?.split('-').map((i) => {
+    const value = parseInt(i)
+
+    // 33-33-33 is the only supported layout where values don't sum to 100. We need to
+    // account for this in order for slides not to be cut off.
+    return value === 33 ? value + 1 / 3 : value
+  })
+
   const numLayoutValues = layoutValues.length
 
   return layoutValues.reduce((acc, value) => {

--- a/packages/carousel/src/layoutToFlexWidths.spec.js
+++ b/packages/carousel/src/layoutToFlexWidths.spec.js
@@ -8,6 +8,6 @@ describe('layoutToFlexWidths', () => {
   it('should return array of percentages for layout based on totalSlides', () => {
     expect(layoutToFlexWidths('25-75', 10)).toEqual(['5%', '15%'])
     expect(layoutToFlexWidths('25-25-25-25', 20)).toEqual(['5%', '5%', '5%', '5%'])
-    expect(layoutToFlexWidths('33-33-33', 10)).toEqual(['9.9%', '9.9%', '9.9%'])
+    expect(layoutToFlexWidths('33-33-33', 10)).toEqual(['10%', '10%', '10%'])
   })
 })


### PR DESCRIPTION
This PR fixes a bug in the width calculation for `Carousel`'s 33-33-33 layout that caused some slides to appear cut off after clicking the `next` button.