### PR TITLE
Make height of each Carousel slide 100%

### DIFF
--- a/common/changes/pcln-carousel/fix-carousel-slide-height_2022-08-03-18-54.json
+++ b/common/changes/pcln-carousel/fix-carousel-slide-height_2022-08-03-18-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Make height of each Carousel slide 100%",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.js
+++ b/packages/carousel/src/Carousel.js
@@ -118,7 +118,7 @@ export const Carousel = ({
                     onSlideKeyDown(index, e)
                   }}
                 >
-                  <Box p={slideSpacing}>
+                  <Box p={slideSpacing} height='100%'>
                     {!layout && stretchSlideHeight ? (
                       <StretchSlide
                         slideSpacing={slideSpacing}


### PR DESCRIPTION
This fixes a bug where `Carousel` slides whose contents of have dynamic heights don't fill the whole vertical space available, which can result in slides having different heights.