### PR TITLE
Remove node 16.x from CI check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,18 +10,16 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # needed by chromatic for git history
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14.x
 
       - name: PNPM cache via actions/cache@v2
         id: pnpm-cache
@@ -39,7 +37,6 @@ jobs:
         run: node common/scripts/install-run-rush.js build
 
       - name: Build Storybook
-        if: ${{ matrix.node-version == '14.x' }}
         working-directory: ./
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -52,7 +49,6 @@ jobs:
         run: node common/scripts/install-run-rush.js lint
 
       - name: Generate and upload coverage report
-        if: ${{ matrix.node-version == '14.x' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |


### PR DESCRIPTION
As discussed on Friday, we should just remove node 16 from CI checks for now