### PR TITLE
Create Menu link-dropdown storybook example

### DIFF
--- a/packages/menu/src/Menu/Menu.stories.js
+++ b/packages/menu/src/Menu/Menu.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Box, ButtonChip, Flex, Text } from 'pcln-design-system'
+import { Box, ButtonChip, Divider, Flex, Link, Text } from 'pcln-design-system'
 
 import Menu from './Menu'
 import MenuItem from '../MenuItem'
@@ -152,6 +152,21 @@ export const ChipAsPopoverButton = () => {
           </MenuItem>
         )
       })}
+    </Menu>
+  )
+}
+
+export const LinkDropdown = () => {
+  return (
+    <Menu idx='link-dropdown' buttonText='Support' width='300px'>
+      <Text p={3}>Unselectable title text</Text>
+      <Divider mt={0} mb={2} />
+      <Link href='https://www.priceline.com/faq' target='_blank' px={3} py={2}>
+        FAQ
+      </Link>
+      <Link href='https://www.priceline.com/contact' target='_blank' px={3} py={2}>
+        Contact
+      </Link>
     </Menu>
   )
 }


### PR DESCRIPTION
Bri wanted to use the Menu component to create a header link dropdown, we played around with a few ideas and this is one example of how you might do that.

Video demonstrates using "tab" and arrow keys

https://user-images.githubusercontent.com/62619213/182922592-cee6bf32-9ba1-4556-a98d-89f747f89f08.mov

