### PR TITLE
Fix popover scroll jumps

### DIFF
--- a/common/changes/pcln-popover/fix-popover-scroll-jumps_2022-08-08-20-28.json
+++ b/common/changes/pcln-popover/fix-popover-scroll-jumps_2022-08-08-20-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Fix Popover jumping",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -96,7 +96,7 @@ function PopoverContent({
   }
 
   const content = trapFocus ? (
-    <FocusLock>
+    <FocusLock focusOptions={{ preventScroll: true }}>
       {renderContent({
         handleClose: onCloseRequest,
       })}


### PR DESCRIPTION
People have reported an issue where opening the popover below the fold will bounce back up to the top of the screen. Adding `preventScroll` to the `FocusLock` resolves this issue.