### PR TITLE
Fix moize perf issue determining default profile name

### DIFF
--- a/common/changes/pcln-carousel/bug-moize-profile-name_2022-08-10-19-58.json
+++ b/common/changes/pcln-carousel/bug-moize-profile-name_2022-08-10-19-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Fix moize perf issue determining default profile name",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/common/changes/pcln-design-system/bug-moize-profile-name_2022-08-10-19-58.json
+++ b/common/changes/pcln-design-system/bug-moize-profile-name_2022-08-10-19-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix moize perf issue determining default profile name",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -185,7 +185,7 @@ importers:
       jest: ^26.6.3
       jest-standard-reporter: ^2.0.0
       jest-styled-components: ^6.3.4
-      moize: ^6.1.0
+      moize: ^6.1.1
       npm-run-all: ^4.1.5
       pcln-design-system: workspace:*
       pcln-icons: workspace:*
@@ -9212,7 +9212,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12273,18 +12273,6 @@ packages:
         optional: true
     dev: false
 
-  /follow-redirects/1.15.1_debug@4.3.4:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4_supports-color@6.1.0
-    dev: false
-
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
@@ -13349,7 +13337,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1_debug@4.3.4
+      follow-redirects: 1.15.1
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -18038,6 +18026,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise.allsettled/1.0.5:
     resolution: {integrity: sha512-tVDqeZPoBC0SlzJHzWGZ2NKAguVq2oiYj7gbggbiTvH2itHohijTp7njOUA0aQ/nl+0lr/r6egmhoYu63UZ/pQ==}

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -44,7 +44,7 @@
     "@types/styled-system": "^4.2.2",
     "prop-types": "^15.8.1",
     "pure-react-carousel": "^1.27.8",
-    "moize": "^6.1.0",
+    "moize": "^6.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/carousel/src/helpers.js
+++ b/packages/carousel/src/helpers.js
@@ -9,7 +9,7 @@ import {
   MEDIA_QUERY_MATCH,
 } from './constants'
 
-const getSlideKey = moize(uuidv4)
+const getSlideKey = moize(uuidv4, { profileName: 'getSlideKey' })
 
 const getVisibleSlidesArray = (visibleSlides) =>
   Array.isArray(visibleSlides) ? visibleSlides : [XS_VISIBLE_SLIDES, SM_VISIBLE_SLIDES, visibleSlides]

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -70,7 +70,7 @@ const getChildrenWidths = (variation: string, numChildren: number) => {
   }
 }
 
-const memoGetChildrenWidths = moize(getChildrenWidths)
+const memoGetChildrenWidths = moize(getChildrenWidths, { profileName: 'getChildrenWidths' })
 
 // Map named sizes to responsive size values from theme
 const gapValues = {
@@ -114,7 +114,7 @@ const getGapValues = (gapProp, rowGapProp) => {
   return { boxPaddingX, boxPaddingY, flexMarginX, flexMarginY }
 }
 
-const memoGetGapValues = moize(getGapValues)
+const memoGetGapValues = moize(getGapValues, { profileName: 'getGapValues' })
 
 const ALLOWED_LAYOUT_VALUES = ['50-50', '33-33-33', '33-66', '66-33', '25-25-25-25', '60-40', '40-60', '100']
 const ALLOWED_GAP_VALUES = ['sm', 'md', 'lg', 'xl']


### PR DESCRIPTION
If the `moize` [profileName](https://github.com/planttheidea/moize#profilename) option is not set, it will create a stack trace and retrieve a default from there.  This has performance implications.  If a profileName is passed as an option, it is used instead.

Contrary to the docs, the profileName option is used regardless of whether stats are collected.

For ref:  https://github.com/planttheidea/moize/blob/master/src/stats.ts#L95