### PR TITLE
fix(PKG-16093): fix carousel dots overflow

### DIFF
--- a/common/changes/pcln-carousel/fix-PKG-16093-carousel-dots-overflow_2022-08-26-17-43.json
+++ b/common/changes/pcln-carousel/fix-PKG-16093-carousel-dots-overflow_2022-08-26-17-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "fix carousel dot overflow",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Dots/Dots.styles.js
+++ b/packages/carousel/src/Dots/Dots.styles.js
@@ -13,6 +13,9 @@ const StyledDotGroup = styled(DotGroup)`
     border-style: solid;
     border-color: ${(props) => getPaletteColor('border.tint')(props)};
     background: ${(props) => getPaletteColor('border.tint')(props)};
+    margin: 0px;
+    border: 0px;
+    padding: 0px;
   }
   &>button: hover {
     border-color: ${(props) => getPaletteColor('background.lightest')(props)};


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description/Summary of changes

Fix Carousel dot overflow issue. Now the buttons will autosize to fit the group max-width.

### Screenshots


