### PR TITLE
Adding a new size for the buttons 'xl' or 'extraLarge'

### DIFF
--- a/common/changes/pcln-design-system/xlButtons_2022-09-15-18-37.json
+++ b/common/changes/pcln-design-system/xlButtons_2022-09-15-18-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Added an extra large button with a height of 56px",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Button/Button.stories.args.ts
+++ b/packages/core/src/Button/Button.stories.args.ts
@@ -1,7 +1,7 @@
 import { colors, shadows } from '../storybook/args'
 import { borderRadiusButtonValues } from './Button'
 export const variations = ['fill', 'link', 'outline', 'plain', 'subtle', 'lightFill', 'white']
-export const sizes = ['small', 'medium', 'large']
+export const sizes = ['small', 'medium', 'large', 'extraLarge']
 
 export const argTypes = {
   variation: {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -14,7 +14,7 @@ import {
   boxShadowSizeValues,
 } from '../utils'
 
-export const borderRadiusButtonValues = ['none', 'sm', 'md', 'lg']
+export const borderRadiusButtonValues = ['none', 'sm', 'md', 'lg', 'xl']
 const isValidBorderRadius = (size) => size && borderRadiusButtonValues.includes(size)
 
 const sizes = {
@@ -41,6 +41,14 @@ const sizes = {
       )};
     font-size: ${themeGet('fontSizes.2')}px;
     padding: 12px 22px;
+  `,
+  extraLarge: css`
+    border-radius: ${(props) =>
+      themeGet(`borderRadii.${isValidBorderRadius(props.borderRadius) ? props.borderRadius : 'action-xl'}`)(
+        props
+      )};
+    font-size: ${themeGet('fontSizes.2')}px;
+    padding: 16px 22px;
   `,
 }
 
@@ -165,7 +173,7 @@ export const buttonStyles = css`
 `
 
 const propTypes = {
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'extraLarge']),
   ...width.propTypes,
   ...space.propTypes,
   fullWidth: deprecatedPropType('width'),


### PR DESCRIPTION
Next-Landing has recently adapted to having inputs of height 56px, which is larger than any of the variants that we have here. After talking with @wesleymartin85, he thought that adding a xL button would be a good way to get onboarded into the design-system but also benefit my team! 

Screen shots: 
<img width="1619" alt="Screen Shot 2022-09-15 at 3 07 39 PM" src="https://user-images.githubusercontent.com/25209141/190488692-3269628c-f9e2-480b-88a4-a7b1619abdc5.png">
