### PR TITLE
bug(RC-21569): removes left from PopoverGuide

### DIFF
--- a/common/changes/pcln-popover/feature-RC-21569-popover-left_2022-10-05-14-53.json
+++ b/common/changes/pcln-popover/feature-RC-21569-popover-left_2022-10-05-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "removes left style from PopoverGuide",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -137,25 +137,19 @@ exports[`Popover UI Positioning Bottom 1`] = `
   padding: 8px;
   width: 400px;
   border-radius: 6px;
-  z-index: 102;
+  box-sizing: border-box;
   max-width: 400px;
   width: 100%;
-  box-sizing: border-box;
+  z-index: 102;
 }
 
 .c2 {
+  box-sizing: border-box;
   box-shadow: 0 0 0 1px #c0cad5,0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08),0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
-  box-sizing: border-box;
-  outline: 0;
   max-width: 100%;
+  outline: 0;
   border-radius: 6px;
-}
-
-@media (max-width:640px) {
-  .c0 {
-    left: 0 !important;
-  }
 }
 
 <div
@@ -257,25 +251,19 @@ exports[`Popover UI Positioning Bottom End 1`] = `
   padding: 8px;
   width: 400px;
   border-radius: 6px;
-  z-index: 102;
+  box-sizing: border-box;
   max-width: 400px;
   width: 100%;
-  box-sizing: border-box;
+  z-index: 102;
 }
 
 .c2 {
+  box-sizing: border-box;
   box-shadow: 0 0 0 1px #c0cad5,0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08),0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
-  box-sizing: border-box;
-  outline: 0;
   max-width: 100%;
+  outline: 0;
   border-radius: 6px;
-}
-
-@media (max-width:640px) {
-  .c0 {
-    left: 0 !important;
-  }
 }
 
 <div
@@ -377,25 +365,19 @@ exports[`Popover UI Positioning Bottom Start 1`] = `
   padding: 8px;
   width: 400px;
   border-radius: 6px;
-  z-index: 102;
+  box-sizing: border-box;
   max-width: 400px;
   width: 100%;
-  box-sizing: border-box;
+  z-index: 102;
 }
 
 .c2 {
+  box-sizing: border-box;
   box-shadow: 0 0 0 1px #c0cad5,0 0 4px 0 rgba(0,0,0,0.08),0 8px 8px 0 rgba(0,0,0,0.08),0 16px 16px 0 rgba(0,0,0,0.08);
   font-size: 12px;
-  box-sizing: border-box;
-  outline: 0;
   max-width: 100%;
+  outline: 0;
   border-radius: 6px;
-}
-
-@media (max-width:640px) {
-  .c0 {
-    left: 0 !important;
-  }
 }
 
 <div

--- a/packages/popover/src/PopoverContent/PopoverContent.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.js
@@ -18,22 +18,18 @@ import Overlay from '../Overlay'
 const ESCAPE_KEY = 27
 
 const PopoverGuide = styled(Box)`
-  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)};
+  box-sizing: border-box;
   max-width: ${({ width }) => (typeof width === 'number' ? `${width}px` : width)};
   width: 100%;
-  box-sizing: border-box;
-
-  @media (max-width: 640px) {
-    left: 0 !important;
-  }
+  z-index: ${({ zIndex }) => (zIndex < 0 ? 1 : zIndex)};
 `
 const ContentContainer = styled.section.attrs(borderRadiusAttrs)`
+  box-sizing: border-box;
   box-shadow: 0 0 0 1px ${(props) => getPaletteColor(props.borderColor, 'base')(props)},
     0 0 4px 0 rgba(0, 0, 0, 0.08), 0 8px 8px 0 rgba(0, 0, 0, 0.08), 0 16px 16px 0 rgba(0, 0, 0, 0.08);
   font-size: ${themeGet('fontSizes.0')}px;
-  box-sizing: border-box;
-  outline: 0;
   max-width: 100%;
+  outline: 0;
   ${borderRadius};
 `
 


### PR DESCRIPTION
Removes "left" position from PopoverGuide

BUG (Sort By Menu does not render under button chip due to left position being set to 0!important)
<img width="873" alt="Screen Shot 2022-10-05 at 12 09 38 AM" src="https://user-images.githubusercontent.com/15201013/194092219-c7cc93fd-e4b4-4f88-a71a-299667a39b31.png">

When 0!important is removed... it renders as expected!
<img width="860" alt="Screen Shot 2022-10-05 at 12 04 11 AM" src="https://user-images.githubusercontent.com/15201013/194092355-f7d1a9a5-ff3a-4e3d-af2c-f9cc2f0dfe86.png">

