### PR TITLE
Update GHA workflows to run on Node 16

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16, 18]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0 # needed by chromatic for git history
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -39,7 +39,7 @@ jobs:
         run: node common/scripts/install-run-rush.js build
 
       - name: Build Storybook
-        if: ${{ matrix.node-version == '14.x' }}
+        if: ${{ matrix.node-version == '16' }}
         working-directory: ./
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
         run: node common/scripts/install-run-rush.js lint
 
       - name: Generate and upload coverage report
-        if: ${{ matrix.node-version == '14.x' }}
+        if: ${{ matrix.node-version == '16' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |

--- a/.github/workflows/npm-publish-beta.yaml
+++ b/.github/workflows/npm-publish-beta.yaml
@@ -25,6 +25,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: PNPM cache via actions/cache@v2
         id: pnpm-cache
         uses: actions/cache@v2

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -24,6 +24,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: PNPM cache via actions/cache@v2
         id: pnpm-cache
         uses: actions/cache@v2

--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
 
       - name: PNPM cache via actions/cache@v2
         id: pnpm-cache


### PR DESCRIPTION
Upgrading our workflows to run on Node 16 since 14 is deprecated.