### PR TITLE
Update link and textColorOn disabled states

### DIFF
--- a/common/changes/pcln-design-system/PPN-59016-update-link-and-textColorOn_2022-11-07-23-48.json
+++ b/common/changes/pcln-design-system/PPN-59016-update-link-and-textColorOn_2022-11-07-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add disabled state to Link and add overrides to getTextColorOn",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "debug": "heft --debug test --clean",
     "start": "heft start",
     "storybook": "heft start --storybook",
+    "test": "heft test",
     "test:snapshots": "heft test --update-snapshots",
     "test:watch": "heft test --watch"
   },

--- a/packages/core/src/Divider/Divider.spec.tsx
+++ b/packages/core/src/Divider/Divider.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { render, screen } from '../__test__/testing-library'
 import { Divider, theme } from '..'
 
 describe('Divider', () => {
@@ -23,5 +24,12 @@ describe('Divider', () => {
     const json = rendererCreateWithTheme(<Divider borderColor='blue' />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('border-color', theme.colors.blue)
+  })
+
+  test('override default margin left and right', () => {
+    render(<Divider mx={2} data-testid='divider' />)
+
+    expect(screen.getByTestId('divider')).toHaveStyleRule('margin-left', theme.space[2])
+    expect(screen.getByTestId('divider')).toHaveStyleRule('margin-right', theme.space[2])
   })
 })

--- a/packages/core/src/Link/Link.spec.tsx
+++ b/packages/core/src/Link/Link.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '../__test__/testing-library'
+import { fireEvent, render, screen } from '../__test__/testing-library'
 
 import { Link } from '..'
 
@@ -13,24 +13,62 @@ describe('Link', () => {
   })
 
   it('should add rel="noopener" when target="_blank"', () => {
-    const { asFragment, getByText } = render(<Link target='_blank'>Dummy</Link>)
+    const { asFragment } = render(<Link target='_blank'>Dummy</Link>)
 
     expect(asFragment()).toMatchSnapshot()
 
-    const link = getByText('Dummy')
+    const link = screen.getByText('Dummy')
 
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener')
   })
 
   it('should not add rel="noopener" when target is not "_blank"', () => {
-    const { asFragment, getByText } = render(<Link>Dummy</Link>)
+    const { asFragment } = render(<Link>Dummy</Link>)
 
     expect(asFragment()).toMatchSnapshot()
 
-    const link = getByText('Dummy')
+    const link = screen.getByText('Dummy')
 
     expect(link).not.toHaveAttribute('target', '_blank')
     expect(link).not.toHaveAttribute('rel', 'noopener')
+  })
+
+  it('should be clickable when not disabled', () => {
+    const mockOnClick = jest.fn()
+    render(
+      <Link href='href' onClick={mockOnClick}>
+        Enabled
+      </Link>
+    )
+
+    const link = screen.getByText('Enabled')
+    expect(link).toHaveAttribute('href')
+    expect(link).toHaveStyleRule('color', '#0068ef')
+    expect(link).toHaveStyleRule('cursor', 'pointer')
+    expect(link).toHaveStyleRule('text-decoration', 'underline', { modifier: ':hover' })
+
+    expect(mockOnClick).toHaveBeenCalledTimes(0)
+    fireEvent.click(link)
+    expect(mockOnClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not be clickable when disabled', () => {
+    const mockOnClick = jest.fn()
+    render(
+      <Link disabled href='href' onClick={mockOnClick}>
+        Disabled
+      </Link>
+    )
+
+    const link = screen.getByText('Disabled')
+    expect(link).not.toHaveAttribute('href')
+    expect(link).toHaveStyleRule('color', '#4f6f8f')
+    expect(link).toHaveStyleRule('cursor', 'default')
+    expect(link).toHaveStyleRule('text-decoration', 'none', { modifier: ':hover' })
+
+    expect(mockOnClick).toHaveBeenCalledTimes(0)
+    fireEvent.click(link)
+    expect(mockOnClick).toHaveBeenCalledTimes(0)
   })
 })

--- a/packages/core/src/Link/Link.stories.args.ts
+++ b/packages/core/src/Link/Link.stories.args.ts
@@ -22,11 +22,11 @@ export const argTypes = {
   size: {
     name: 'size',
     options: ['small', 'medium', 'large'],
-    control: 'select',
+    control: 'radio',
   },
   target: {
     name: 'target',
     options: ['_blank', '_self'],
-    control: 'select',
+    control: 'radio',
   },
 }

--- a/packages/core/src/Link/Link.stories.args.ts
+++ b/packages/core/src/Link/Link.stories.args.ts
@@ -1,0 +1,32 @@
+import { action } from '@storybook/addon-actions'
+import { colors } from '../__test__/mocks/colors'
+
+export const defaultArgs = {
+  children: 'Hello There',
+  color: 'primary',
+  disabled: false,
+  href: 'https://www.priceline.com/',
+  size: 'medium',
+  target: '_blank',
+  variation: 'link',
+  onClick: action('Clicked Link'),
+}
+
+export const argTypes = {
+  color: {
+    name: 'color',
+    options: Object.keys(colors),
+    mapping: colors,
+    control: 'select',
+  },
+  size: {
+    name: 'size',
+    options: ['small', 'medium', 'large'],
+    control: 'select',
+  },
+  target: {
+    name: 'target',
+    options: ['_blank', '_self'],
+    control: 'select',
+  },
+}

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -1,60 +1,19 @@
 import React from 'react'
-
 import { Button, Link, Text } from '..'
+import { ILinkProps } from './Link'
+import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
-
-// for Args
-// const variations = { link: 'link', fill: 'fill', outline: 'outline' }
-// const colors = {
-//   primary: 'primary',
-//   secondary: 'secondary',
-//   text: 'text',
-//   success: 'success',
-//   error: 'error',
-//   warning: 'warning',
-//   alert: 'alert',
-//   caution: 'caution',
-//   notify: 'notify',
-//   pricePrimary: 'pricePrimary',
-//   priceSecondary: 'priceSecondary',
-//   promoPrimary: 'promoPrimary',
-//   promoSecondary: 'promoSecondary',
-//   border: 'border',
-//   background: 'background',
-// }
 
 export default {
   title: 'Link',
   component: Link,
+  args: defaultArgs,
+  argTypes,
 }
 
-export const LinkComponent = () => (
-  <Link href='https://www.priceline.com/home/' target='_blank'>
-    Priceline Home
-  </Link>
-)
+const Template = (args: ILinkProps) => <Link {...args} />
 
-LinkComponent.story = {
-  name: 'Link component',
-}
-
-export const AsSmallFilledButton = () => (
-  <>
-    <Link variation='fill' size='small' href='https://www.priceline.com/home/' target='_blank'>
-      Priceline Home
-    </Link>
-  </>
-)
-
-export const LinkOpenSelf = () => (
-  <Link href='https://www.priceline.com/home/' target='_self'>
-    Open the Priceline Home in the same window
-  </Link>
-)
-
-LinkOpenSelf.story = {
-  name: 'Link open self',
-}
+export const _Link = Template.bind({})
 
 export function ForwardRefs() {
   function refChild(dsRef) {
@@ -79,16 +38,6 @@ export function ForwardRefs() {
 ForwardRefs.story = {
   name: 'Forward refs',
 }
-
-export const Color = () => (
-  <div>
-    <Link color='text.dark'>I am a different color!</Link>
-    <br />
-    <Link color='secondary'>I am a different color!</Link>
-    <br />
-    <Link color='error'>I am a different color!</Link>
-  </div>
-)
 
 export const LargeText = () => (
   <Link color='text.light'>

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -35,6 +35,7 @@ const variations = {
 
 const propTypes = {
   color: deprecatedColorValue(),
+  disabled: PropTypes.bool,
   variation: PropTypes.oneOf(Object.keys(variations)),
 }
 
@@ -43,21 +44,28 @@ export interface ILinkProps
     SpaceProps,
     React.HTMLAttributes<HTMLAnchorElement>,
     React.RefAttributes<unknown> {
-  color?: string
-  href?: string
-  variation?: 'fill' | 'link' | 'outline'
   children?: React.ReactNode | string
-  onFocus?: (unknown) => unknown
-  onClick?: (unknown) => unknown
-  target?: string
+  color?: string
+  disabled?: boolean
+  href?: string
   size?: 'small' | 'medium' | 'large'
+  target?: string
+  variation?: 'fill' | 'link' | 'outline'
+  onClick?: (unknown) => unknown
+  onFocus?: (unknown) => unknown
 }
 
-const Link: React.FC<ILinkProps> = styled.a.attrs(({ target, ...props }) => ({
-  rel: target === '_blank' ? 'noopener' : null,
-  target,
-  ...props,
-}))`
+const Link: React.FC<ILinkProps> = styled.a.attrs(
+  ({ color, disabled, href, target, onClick, ...props }) => ({
+    color: disabled ? 'text.light' : color,
+    disabled,
+    href: !disabled && href,
+    rel: target === '_blank' ? 'noopener' : null,
+    target,
+    onClick: !disabled && onClick,
+    ...props,
+  })
+)`
   ${applyVariations('Link', variations)}
   ${width} ${space};
 `

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -55,19 +55,27 @@ export interface ILinkProps
   onFocus?: (unknown) => unknown
 }
 
-const Link: React.FC<ILinkProps> = styled.a.attrs(
-  ({ color, disabled, href, target, onClick, ...props }) => ({
-    color: disabled ? 'text.light' : color,
-    disabled,
-    href: !disabled && href,
-    rel: target === '_blank' ? 'noopener' : null,
-    target,
-    onClick: !disabled && onClick,
-    ...props,
-  })
-)`
+const Link: React.FC<ILinkProps> = styled.a.attrs(({ color, disabled, href, target, onClick, ...props }) => ({
+  color: disabled ? 'text.light' : color,
+  disabled,
+  href: !disabled ? href : undefined,
+  rel: target === '_blank' ? 'noopener' : null,
+  target,
+  onClick: !disabled ? onClick : () => {},
+  ...props,
+}))`
   ${applyVariations('Link', variations)}
   ${width} ${space};
+
+  ${(props) =>
+    props.disabled &&
+    `
+    cursor: default;
+
+    &:hover {
+      text-decoration: none;
+    }
+  `}
 `
 
 Link.displayName = 'Link'

--- a/packages/core/src/__test__/mocks/colors.ts
+++ b/packages/core/src/__test__/mocks/colors.ts
@@ -1,0 +1,17 @@
+export const colors = {
+  primary: 'primary',
+  secondary: 'secondary',
+  text: 'text',
+  success: 'success',
+  error: 'error',
+  warning: 'warning',
+  alert: 'alert',
+  caution: 'caution',
+  notify: 'notify',
+  pricePrimary: 'pricePrimary',
+  priceSecondary: 'priceSecondary',
+  promoPrimary: 'promoPrimary',
+  promoSecondary: 'promoSecondary',
+  border: 'border',
+  background: 'background',
+}

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -13,7 +13,9 @@ import {
   getLuminance,
   getPaletteColor,
   getTextColorOn,
+  getValidPaletteColor,
   hasPaletteColor,
+  hasPaletteColorShade,
   hexToRgb,
 } from '.'
 
@@ -197,6 +199,34 @@ describe('utils', () => {
     })
   })
 
+  describe('getValidPaletteColor', () => {
+    const props = {
+      theme: createTheme(),
+    }
+
+    test('returns value for valid color without shade', () => {
+      const result = getValidPaletteColor('primary')(props)
+      expect(result).toBe('#0068ef')
+    })
+
+    test('returns value for valid color shade', () => {
+      const result = getValidPaletteColor('primary.dark')(props)
+      expect(result).toBe('#049')
+    })
+
+    test('returns null for invalid colorShade', () => {
+      const result = getValidPaletteColor('#0068ef')(props)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for invalid type', () => {
+      const result = getValidPaletteColor(0)(props)
+      expect(result).toBeNull()
+    })
+
+    test('returns null for null color', () => {})
+  })
+
   describe('hasPaletteColor', () => {
     test('returns true if palette color', () => {
       expect(hasPaletteColor({ theme: createTheme(), color: 'primary' })).toBeTruthy()
@@ -205,6 +235,21 @@ describe('utils', () => {
 
     test('returns false if not a palette color', () => {
       expect(hasPaletteColor({ theme: createTheme(), color: 'orange' })).toBeFalsy()
+    })
+  })
+
+  describe('hasPaletteColorShade', () => {
+    test('returns true if palette color and shade', () => {
+      expect(hasPaletteColorShade({ theme: createTheme(), color: 'primary' })).toBeFalsy()
+      expect(hasPaletteColorShade({ theme: createTheme(), color: 'primary.dark' })).toBeTruthy()
+    })
+
+    test('returns false if not a palette color', () => {
+      expect(hasPaletteColorShade({ theme: createTheme(), color: 'orange' })).toBeFalsy()
+    })
+
+    test('returns false if not a palette color shade', () => {
+      expect(hasPaletteColorShade({ theme: createTheme(), color: 'primary.sparkly' })).toBeFalsy()
     })
   })
 
@@ -230,6 +275,21 @@ describe('utils', () => {
       expect(getTextColorOn('light')({ ...props, color: 'primary' })).toEqual(props.theme.palette.text.base)
       expect(getTextColorOn('dark')({ ...props, color: 'primary' })).toEqual(
         props.theme.palette.text.lightest
+      )
+    })
+
+    test('can override the text color defaults', () => {
+      expect(getTextColorOn('background.lightest', 'text.lightest', 'primary')(props)).toEqual(
+        props.theme.palette.primary.base
+      )
+      expect(getTextColorOn('primary.base', 'text.lightest', 'primary')(props)).toEqual(
+        props.theme.palette.text.lightest
+      )
+    })
+
+    test('can override the text color defaults with a dark colour', () => {
+      expect(getTextColorOn('background.lightest', 'text.lightest', 'primary.dark')(props)).toEqual(
+        props.theme.palette.primary.dark
       )
     })
   })

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -252,18 +252,21 @@ export const getPaletteColor =
  * @param name - The name of the background color
  *
  */
-export const getTextColorOn = (name) => (props) => {
+export const getTextColorOn = (name, lightColor = null, darkColor = null) => (props) => {
   const { theme } = props
 
   if (theme.palette) {
     const color = getPaletteColor(name)(props)
     const text = theme.palette.text
 
+    lightColor = lightColor || text.lightest
+    darkColor = darkColor || text.base
+
     if (color) {
-      return getContrastRatio(text.lightest, color) >= theme.contrastRatio ? text.lightest : text.base
+      return getContrastRatio(lightColor, color) >= theme.contrastRatio ? lightColor : darkColor
     }
 
-    return text.base
+    return darkColor
   }
 
   return ''

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -23,6 +23,18 @@ export const hasPaletteColor = (props) => {
   )
 }
 
+export const hasPaletteColorShade = (props, color = undefined) => {
+  const validColor = (typeof color === 'string' && color) || (typeof props.color === 'string' && props.color)
+  const [col, shade] = validColor.split('.')
+
+  return (
+    props.theme &&
+    props.theme.palette &&
+    Object.keys(props.theme.palette).includes(col) &&
+    Object.keys(props.theme.palette[col]).includes(shade)
+  )
+}
+
 export const deprecatedColorValue = () => (props, propName, componentName) => {
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -137,16 +149,16 @@ export const getBreakpointSize = (array, length) => {
  *
  */
 
-export const applySizes =
-  (sizes = null, defaultSize = 'medium', mediaQueriesOptions = mediaQueries) =>
-  ({ size }) => {
-    if (sizes && typeof size === 'string') {
-      // prettier-ignore
-      return css`${sizes[size] || sizes[defaultSize] || ''}`
-    }
-    if (sizes && Array.isArray(size)) {
-      // prettier-ignore
-      return css`${sizes[getBreakpointSize(size, 1)]};
+export const applySizes = (sizes = null, defaultSize = 'medium', mediaQueriesOptions = mediaQueries) => ({
+  size,
+}) => {
+  if (sizes && typeof size === 'string') {
+    // prettier-ignore
+    return css`${sizes[size] || sizes[defaultSize] || ''}`
+  }
+  if (sizes && Array.isArray(size)) {
+    // prettier-ignore
+    return css`${sizes[getBreakpointSize(size, 1)]};
         ${mediaQueriesOptions.sm} {
           ${sizes[getBreakpointSize(size, 2)]};
         }
@@ -162,8 +174,8 @@ export const applySizes =
         ${mediaQueriesOptions.xxl} {
           ${sizes[getBreakpointSize(size, 6)]};
         }`
-    }
   }
+}
 
 const colorShadeRegex = /^([a-z]+)\.([a-z]+)$/i
 
@@ -178,43 +190,41 @@ const colorShadeRegex = /^([a-z]+)\.([a-z]+)$/i
  * @param componentName - The name of the component
  * @param variations - An object of variation styles
  */
-export const applyVariations =
-  (componentName, variations = null) =>
-  (props) => {
-    let { color } = props
-    const { variation } = props
+export const applyVariations = (componentName, variations = null) => (props) => {
+  let { color } = props
+  const { variation } = props
 
-    const colorShade = !!color && typeof color === 'string' && color.match(colorShadeRegex)
+  const colorShade = !!color && typeof color === 'string' && color.match(colorShadeRegex)
 
-    let shade
-    if (colorShade) {
-      color = colorShade[1]
-      shade = colorShade[2]
-    }
+  let shade
+  if (colorShade) {
+    color = colorShade[1]
+    shade = colorShade[2]
+  }
 
-    const isValidShade = shade && typeof shade === 'string'
+  const isValidShade = shade && typeof shade === 'string'
 
-    if (variations && typeof variation === 'string') {
-      if (isValidShade) {
-        // prettier-ignore
-        return css`${variations[variation] || ''}
-          ${typeof color === 'string' &&
-          themeGet(`componentStyles.${componentName}.${variation}.${color}.${shade}`, '')}`
-      }
-
-      // prettier-ignore
-      return css`${variations[variation] || ''}
-        ${typeof color === 'string' && themeGet(`componentStyles.${componentName}.${variation}.${color}`, '')}`
-    }
-
+  if (variations && typeof variation === 'string') {
     if (isValidShade) {
       // prettier-ignore
-      return css`${themeGet(`componentStyles.${componentName}.${color}.${shade}`, '')}`
+      return css`${variations[variation] || ''}
+          ${typeof color === 'string' &&
+          themeGet(`componentStyles.${componentName}.${variation}.${color}.${shade}`, '')}`
     }
 
     // prettier-ignore
-    return css`${themeGet(`componentStyles.${componentName}.${color}`, '')}`
+    return css`${variations[variation] || ''}
+        ${typeof color === 'string' && themeGet(`componentStyles.${componentName}.${variation}.${color}`, '')}`
   }
+
+  if (isValidShade) {
+    // prettier-ignore
+    return css`${themeGet(`componentStyles.${componentName}.${color}.${shade}`, '')}`
+  }
+
+  // prettier-ignore
+  return css`${themeGet(`componentStyles.${componentName}.${color}`, '')}`
+}
 
 /**
  * Gets the color of a palette shade, using props.color as
@@ -226,25 +236,38 @@ export const applyVariations =
  * @example getPaletteColor('primary.base')(props) =\> theme.palette.primary.base
  * @example getPaletteColor('primary', 'base')(props) =\> theme.palette.primary.base
  */
-export const getPaletteColor =
-  (...args) =>
-  (props) => {
-    let color = args.length === 2 ? args[0] : props.color
-    let shade = args.length === 2 ? args[1] : args[0]
+export const getPaletteColor = (...args) => (props) => {
+  let color = args.length === 2 ? args[0] : props.color
+  let shade = args.length === 2 ? args[1] : args[0]
 
-    const colorShade = shade.match(colorShadeRegex)
+  const colorShade = shade.match(colorShadeRegex)
 
-    if (colorShade) {
-      color = colorShade[0]
-      shade = colorShade[1]
-    }
-
-    return (
-      themeGet(`palette.${color}.${shade}`)(props) ||
-      themeGet(`palette.${color}`)(props) ||
-      themeGet(`colors.${color}`)(props)
-    )
+  if (colorShade) {
+    color = colorShade[0]
+    shade = colorShade[1]
   }
+
+  return (
+    themeGet(`palette.${color}.${shade}`)(props) ||
+    themeGet(`palette.${color}`)(props) ||
+    themeGet(`colors.${color}`)(props)
+  )
+}
+
+export const getValidPaletteColor = (color) => (props) => {
+  if (!color || typeof color !== 'string') {
+    return null
+  }
+
+  const [col, shade] = color.split('.')
+  const newColor = `${col}.${shade || 'base'}`
+
+  if (hasPaletteColorShade(props, newColor)) {
+    return getPaletteColor(newColor)(props)
+  }
+
+  return null
+}
 
 /**
  * Gets the text color that belongs on a given background color
@@ -259,8 +282,8 @@ export const getTextColorOn = (name, lightColor = null, darkColor = null) => (pr
     const color = getPaletteColor(name)(props)
     const text = theme.palette.text
 
-    lightColor = lightColor || text.lightest
-    darkColor = darkColor || text.base
+    lightColor = getValidPaletteColor(lightColor)(props) || text.lightest
+    darkColor = getValidPaletteColor(darkColor)(props) || text.base
 
     if (color) {
       return getContrastRatio(lightColor, color) >= theme.contrastRatio ? lightColor : darkColor


### PR DESCRIPTION
* `textColorOn` updated to include overrides for the light and dark colors, falling back to `text.lightest` and `text.base` as it was before. This allows us to set the fallback dark color to `primary` for example.
  * Created `getValidPaletteColor` and `hasPaletteColorShade` as support functions
* `Link` disabled state added to support cards that can be disabled.