### PR TITLE
fix ChipContentWrapper TS complaint

### DIFF
--- a/common/changes/pcln-design-system/resolve-typescript-complaint-ChipContentWrapper_2022-11-07-19-02.json
+++ b/common/changes/pcln-design-system/resolve-typescript-complaint-ChipContentWrapper_2022-11-07-19-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Improve TS interface for ChipContentWrapper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -21,8 +21,8 @@ export default {
 
 const Template = (args) => <Badge {...args}>badge</Badge>
 
-export const Default = Template.bind({})
-Default.args = {
+export const _Badge = Template.bind({})
+_Badge.args = {
   bg: 'lightGray',
 }
 

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -31,7 +31,13 @@ const getBorderColor = (props) =>
 const getBackgroundColor = (props) =>
   props.disabled ? 'background.light' : props.selected ? 'light' : 'background.lightest'
 
-const ChipContentWrapper: React.FC<IBoxProps> = styled(Box)`
+interface IChipContentWrapper extends IBoxProps {
+  disabled: boolean
+  hasChildren: boolean
+  selected: boolean
+}
+
+const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
   ${(props) => `
     cursor: ${getCursor(props)};
     color: ${getPaletteColor(getColor(props))(props)};


### PR DESCRIPTION
* Changed the default story for Badge from `Default` to `_Badge` to match storybook pattern
* Created `IChipContentWrapper` interface