### PR TITLE
Clickable labels and storybook improvements

### DIFF
--- a/common/changes/pcln-design-system/clickable-labels-and-storybook-improvements_2022-11-16-19-38.json
+++ b/common/changes/pcln-design-system/clickable-labels-and-storybook-improvements_2022-11-16-19-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Visually clickable labels and improve label storybooks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Label/Label.spec.tsx
+++ b/packages/core/src/Label/Label.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-
+import { fireEvent, render, screen } from '../__test__/testing-library'
 import { Label } from '..'
 
 describe('Label', () => {
@@ -21,5 +21,17 @@ describe('Label', () => {
   test('Label width renders', () => {
     const json = rendererCreateWithTheme(<Label width={1 / 2} nowrap />).toJSON()
     expect(json).toMatchSnapshot()
+  })
+
+  test('Label clickable renders with cursor pointer', () => {
+    const mockOnClick = jest.fn()
+    render(<Label onClick={mockOnClick}>Clickable Label</Label>)
+
+    const label = screen.getByText('Clickable Label')
+    expect(label).toHaveStyleRule('cursor', 'pointer')
+
+    expect(mockOnClick).toHaveBeenCalledTimes(0)
+    fireEvent.click(label)
+    expect(mockOnClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/Label/Label.stories.args.ts
+++ b/packages/core/src/Label/Label.stories.args.ts
@@ -1,0 +1,37 @@
+import { action } from '@storybook/addon-actions'
+import { colors } from '../__test__/mocks/colors'
+
+const actions = {
+  noAction: null,
+  basicAction: action('Label Clicked'),
+}
+
+export const defaultArgs = {
+  children: 'Label Children',
+  width: 'auto',
+}
+
+export const argTypes = {
+  color: {
+    name: 'color',
+    options: Object.keys(colors),
+    mapping: colors,
+    control: 'select',
+  },
+  fontSize: {
+    name: 'fontSize',
+    options: [0, 1, 2, 3, 4, 5, 6],
+    control: 'select',
+  },
+  width: {
+    name: 'width',
+    options: [0.5, '20px', 'auto'],
+    control: 'radio',
+  },
+  onClick: {
+    name: 'onClick',
+    options: Object.keys(actions),
+    mapping: actions,
+    control: 'radio',
+  },
+}

--- a/packages/core/src/Label/Label.stories.tsx
+++ b/packages/core/src/Label/Label.stories.tsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { Label, Input, Radio, Flex } from '..'
+import { ILabelProps } from './Label'
+import { argTypes, defaultArgs } from './Label.stories.args'
 
 export default {
   title: 'Label',
   component: Label,
+  args: defaultArgs,
+  argTypes,
   parameters: {
     docs: {
       description: {
@@ -13,23 +17,9 @@ export default {
   },
 }
 
-export const LabelComponent = () => <Label m={3}>Label Component</Label>
+const Template = (args: ILabelProps) => <Label {...args} />
 
-export const UsingFontSize = () => (
-  <div>
-    <Label fontSize={6}>Label with fontSize 6</Label>
-    <Label fontSize={5}>Label with fontSize 5</Label>
-    <Label fontSize={4}>Label with fontSize 4</Label>
-    <Label fontSize={3}>Label with fontSize 3</Label>
-    <Label fontSize={2}>Label with fontSize 2</Label>
-    <Label fontSize={1}>Label with fontSize 1</Label>
-    <Label fontSize={0}>Label with fontSize 0</Label>
-  </div>
-)
-
-UsingFontSize.story = {
-  name: 'Using fontSize',
-}
+export const _Label = Template.bind({})
 
 export const Spacing = () => (
   <div>
@@ -39,17 +29,6 @@ export const Spacing = () => (
     <Label pl={3}>A dash of padding</Label>
   </div>
 )
-
-export const Color = () => (
-  <div>
-    <Label color='blue'>A blue label</Label>
-    <Label color='green'>a green label</Label>
-  </div>
-)
-
-Color.story = {
-  name: 'color',
-}
 
 export const HtmlFor = () => (
   <div>
@@ -86,20 +65,4 @@ export const Nowrap = () => (
 
 Nowrap.story = {
   name: 'nowrap',
-}
-
-export const Width = () => (
-  <div>
-    <Label width={1 / 2} color='blue'>
-      label with 50% width
-    </Label>
-    <Label width='20px' color='green'>
-      label with 20px width
-    </Label>
-    <Label color='orange'>default label width</Label>
-  </div>
-)
-
-Width.story = {
-  name: 'width',
 }

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -49,6 +49,7 @@ export interface ILabelProps
   autoHide?: boolean
   nowrap?: boolean
   for?: string
+  onClick?: (evt: unknown) => void
 }
 
 const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label`
@@ -59,6 +60,7 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label`
   margin: 0;
   color: ${getPaletteColor('base')};
   ${(props) => (props.bg ? `background-color: ${getPaletteColor(props.bg, 'base')(props)};` : '')}
+  ${(props) => (props.onClick ? 'cursor: pointer;' : '')}
 
   ${applyVariations('Label')}
   ${space} ${fontSize} ${fontWeight} ${width};


### PR DESCRIPTION
We use labels as clickable elements in a few place, I've seen people using custom styling so why not update it at the root.

I wonder if a `for` prop is passed in that the label should be `cursor: pointer` too 🤔 

While I was in the code, I updated some of the Label stories that made sense into the template format with controls.