### PR TITLE
Button input variation

### DIFF
--- a/common/changes/pcln-design-system/button-input-variation_2022-11-21-22-46.json
+++ b/common/changes/pcln-design-system/button-input-variation_2022-11-21-22-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add Button variation (input)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Button/Button.spec.tsx
+++ b/packages/core/src/Button/Button.spec.tsx
@@ -190,6 +190,20 @@ describe('Button', () => {
     })
   })
 
+  it('should render correctly for extraLarge size', () => {
+    const { getByText } = render(
+      <Button borderRadius='xl' size='extraLarge'>
+        BUTTON
+      </Button>
+    )
+
+    const button = getByText('BUTTON')
+
+    expect(button).toHaveStyleRule('border-radius', '16px')
+    expect(button).toHaveStyleRule('font-size', '16px')
+    expect(button).toHaveStyleRule('padding', '16px 22px')
+  })
+
   describe('variations', () => {
     describe('fill variation', () => {
       it('should render correctly', () => {
@@ -446,6 +460,24 @@ describe('Button', () => {
         })
         expect(button).toHaveStyleRule('background-color', theme.palette.background.base, {
           modifier: ':disabled',
+        })
+      })
+    })
+
+    describe('input variation', () => {
+      it('should render correctly', () => {
+        const { getByText } = render(<Button variation='input'>BUTTON</Button>)
+
+        const button = getByText('BUTTON')
+
+        expect(button).toHaveStyleRule('color', theme.palette.text.base)
+        expect(button).toHaveStyleRule('background-color', 'transparent')
+        expect(button).toHaveStyleRule('border-color', theme.palette.border.base)
+        expect(button).toHaveStyleRule('border-color', theme.palette.primary.base, {
+          modifier: ':focus',
+        })
+        expect(button).toHaveStyleRule('box-shadow', `0 0 0 2px ${theme.palette.primary.base}`, {
+          modifier: ':focus',
         })
       })
     })

--- a/packages/core/src/Button/Button.stories.args.ts
+++ b/packages/core/src/Button/Button.stories.args.ts
@@ -1,6 +1,6 @@
 import { colors, shadows } from '../storybook/args'
 import { borderRadiusButtonValues } from './Button'
-export const variations = ['fill', 'link', 'outline', 'plain', 'subtle', 'lightFill', 'white']
+export const variations = ['fill', 'link', 'outline', 'plain', 'subtle', 'lightFill', 'white', 'input']
 export const sizes = ['small', 'medium', 'large', 'extraLarge']
 
 export const argTypes = {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -1,12 +1,22 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
-import { width, space, boxShadow, WidthProps, SpaceProps, BoxShadowProps } from 'styled-system'
+import {
+  borderRadius,
+  fontSize,
+  width,
+  space,
+  boxShadow,
+  WidthProps,
+  SpaceProps,
+  BoxShadowProps,
+} from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import { themeGet } from '@styled-system/theme-get'
 import {
   applySizes,
   applyVariations,
+  borders,
   getPaletteColor,
   getTextColorOn,
   deprecatedColorValue,
@@ -142,6 +152,24 @@ const variations = {
       outline: ${(props) => `0px solid ${getPaletteColor(props.disabled ? '' : 'dark')(props)}`};
       box-shadow: ${(props) => ` 0 0 0 2px  ${getPaletteColor(props.disabled ? '' : 'dark')(props)}`};
     }
+  `,
+  input: css`
+    appearance: none;
+    background-color: transparent;
+    border-style: solid;
+    border-width: 1px;
+    color: inherit;
+    display: block;
+    font-family: inherit;
+    font-weight: normal;
+    line-height: normal;
+    margin: 0;
+    padding: 14px 12px;
+    text-align: left;
+    width: 100%;
+
+    ${(props) => borders({ ...props, color: undefined })}
+    ${space} ${fontSize} ${borderRadius};
   `,
 }
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -158,7 +158,7 @@ const variations = {
     background-color: transparent;
     border-style: solid;
     border-width: 1px;
-    color: inherit;
+    color: ${getPaletteColor('text.base')};
     display: block;
     font-family: inherit;
     font-weight: normal;
@@ -223,7 +223,7 @@ export interface IButtonProps
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     React.RefAttributes<unknown> {
   color?: string
-  variation?: 'fill' | 'link' | 'outline' | 'plain' | 'subtle' | 'white' | 'lightFill'
+  variation?: 'fill' | 'link' | 'outline' | 'plain' | 'subtle' | 'white' | 'lightFill' | 'input'
   size?: Sizes | Sizes[]
   borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | ''
   boxShadowSize?: '' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'overlay-lg' | 'overlay-xl'


### PR DESCRIPTION
Created a new variation for the `Button` component called `input` which makes the Button render in a similar fashion to an input. This is useful for situation like my screenshot when we want a dropdown, the clickable element to open the dropdown is a Button but it looks like an input.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/62619213/203365095-e8e12dd2-b3ef-43f0-8161-4efe36f76ef0.png">
