### PR TITLE
Input text color should always be text.base

### DIFF
--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`FormField renders 1`] = `
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;
@@ -195,7 +195,7 @@ exports[`FormField renders with Icon 1`] = `
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;
@@ -376,7 +376,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;

--- a/packages/core/src/Input/Input.stories.tsx
+++ b/packages/core/src/Input/Input.stories.tsx
@@ -44,7 +44,7 @@ export const WithExternalLabel = () => (
 export const WithHelperText = () => (
   <Box width={400}>
     <Box>
-      <Label fontSize={4} htmlFor='sample-input'>
+      <Label fontSize={4} htmlFor='sample-input-2'>
         Same color as Input
       </Label>
       <Input
@@ -56,7 +56,7 @@ export const WithHelperText = () => (
     </Box>
     <Divider />
     <Box>
-      <Label fontSize={4} htmlFor='sample-input'>
+      <Label fontSize={4} htmlFor='sample-input-3'>
         Override color for helper text
       </Label>
       <Input
@@ -66,6 +66,15 @@ export const WithHelperText = () => (
         helperText={<Input.HelperText color='secondary.base'>No soup for you!</Input.HelperText>}
       />
     </Box>
+  </Box>
+)
+
+export const WithLabel = () => (
+  <Box width={400}>
+    <Label>
+      Label Text
+      <Input id='input-with-label' placeholder='Click the label' mt={1} />
+    </Label>
   </Box>
 )
 

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -33,7 +33,7 @@ const StyledInput = styled.input.attrs(borderRadiusAttrs)`
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: ${getPaletteColor('text.base')};
   background-color: transparent;
   border-width: 1px;
   border-style: solid;

--- a/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Input it renders 1`] = `
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;
@@ -77,7 +77,7 @@ exports[`Input it renders an input element with a really large padding and margi
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;
@@ -148,7 +148,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;
@@ -218,7 +218,7 @@ exports[`Input it renders an input element with large text 1`] = `
   display: block;
   width: 100%;
   font-family: inherit;
-  color: inherit;
+  color: #001833;
   background-color: transparent;
   border-width: 1px;
   border-style: solid;


### PR DESCRIPTION
Wrapping an Input component in a Label component would cause the Input text be the `text.light` color, matching the label and the placeholder text. I spoke to Wes and he said that this was not intended, so I have set the text color of an Input to always be `text.base`, @wesleymartin85 could you confirm this is the desired behaviour.