### PR TITLE
feat: Add border for Swatch component

### DIFF
--- a/common/changes/pcln-design-system/feat-add-border-for-swatch-component_2022-11-25-20-26.json
+++ b/common/changes/pcln-design-system/feat-add-border-for-swatch-component_2022-11-25-20-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add border for Swatch component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Swatch/Swatch.spec.tsx
+++ b/packages/core/src/Swatch/Swatch.spec.tsx
@@ -10,6 +10,7 @@ describe('Swatch', () => {
 
     mockColors.map((color, idx) => {
       expect(getByTestId(`${idx}-${color}`)).toHaveStyle(`background-color: ${color}`)
+      expect(getByTestId(`${idx}-${color}`)).toHaveStyle(`border: 1px solid #c0cad5}`)
     })
   })
 

--- a/packages/core/src/Swatch/Swatch.stories.tsx
+++ b/packages/core/src/Swatch/Swatch.stories.tsx
@@ -33,7 +33,7 @@ export const SelectColor = () => {
   const [color, setColor] = useState('#D50032')
   return (
     <>
-      <Swatch colors={['#D50032', '#1B7742', '#0033A0']} onClick={(color) => setColor(color)} />
+      <Swatch colors={['#FFFFFF', '#D50032', '#1B7742', '#0033A0']} onClick={(color) => setColor(color)} />
       <Flex mt='3' flexDirection='row' alignItems='center'>
         <Text mr={2}>Color:</Text>
         <Text>{color}</Text>

--- a/packages/core/src/Swatch/Swatch.tsx
+++ b/packages/core/src/Swatch/Swatch.tsx
@@ -2,12 +2,14 @@ import PropTypes, { InferProps } from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { Flex } from '../Flex'
+import { getPaletteColor } from '../utils'
 
 const SwatchColor = styled.div`
   height: 24px;
   width: 24px;
   background-color: ${(props) => props.color};
   border-radius: 50%;
+  border: 1px solid ${getPaletteColor('border.base')};
   display: flex;
   margin: 4px;
   cursor: ${(props) => (props.onClick ? 'pointer' : 'default')};


### PR DESCRIPTION
Added border (`border.base`). the Swatch color is `#FFFFFF` it is very difficult to see in light background.

<img width="149" alt="Screen Shot 2022-11-25 at 2 42 52 PM" src="https://user-images.githubusercontent.com/90356592/204053950-285f84df-06ae-423f-9200-28f20e601f8c.png">


