### PR TITLE
Remove broken badge in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,5 @@
 # Priceline Design System
 
-![Node.js CI](https://github.com/priceline/design-system/workflows/Node.js%20CI/badge.svg)
 [![Coverage][coverage-badge]][coverage]
 [![npm version][npm version]][npm version]
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/priceline/design-system.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/priceline/design-system/alerts/)


### PR DESCRIPTION
This is a micro-cleanup of the README, mainly used to trigger a publish for the Design-System core package