### PR TITLE
Enable TurboSnap for Chromatic

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -11,9 +11,9 @@
     "start": "start-storybook --quiet -p 8000",
     "storybook": "run-s storybook:build chromatic",
     "storybook:baseline": "run-s storybook:build storybook:baseline:chromatic",
-    "storybook:build": "build-storybook --quiet -o ../docs/out/storybook",
+    "storybook:build": "build-storybook --webpack-stats-json --quiet -o ../docs/out/storybook",
     "storybook:baseline:chromatic": "chromatic --storybook-build-dir=../docs/out/storybook --auto-accept-changes --exit-once-uploaded",
-    "chromatic": "chromatic --storybook-build-dir=../docs/out/storybook --exit-once-uploaded"
+    "chromatic": "chromatic --storybook-build-dir=../docs/out/storybook --exit-once-uploaded --only-changed --untraced=**/package.json"
   },
   "author": "Priceline Design System Working Group",
   "license": "MIT",


### PR DESCRIPTION
This PR enables Chromatic's [TurboSnap](https://www.chromatic.com/docs/turbosnap) feature to speed up Chromatic tests and reduce our monthly snapshot usage.

Example Storybook build step after changing `Button.tsx`: https://github.com/priceline/design-system/actions/runs/3875543293/jobs/6608225403#step:7:131