### PR TITLE
feat(v5): Add util for getting link styles on color

### DIFF
--- a/apps/docs/pages/utilities/getLinkStylesOn.md
+++ b/apps/docs/pages/utilities/getLinkStylesOn.md
@@ -1,0 +1,52 @@
+# getLinkStylesOn
+
+A utility function to get the link styles that belong on a background color.
+
+## Syntax
+
+```js
+getLinkStylesOn(colorShade)(props)
+```
+
+## Usage
+
+```jsx
+import { Link, getLinkStylesOn } from 'pcln-design-system'
+
+const Component = styled(Link)`
+  ${props => getLinkStylesOn('primary.base')(props)};
+`
+```
+
+## Arguments
+
+| Argument     | Type   | Description                                                                         |
+| ------------ | ------ | ----------------------------------------------------------------------------------- |
+| `colorShade` | String | The full palette color and shade expressed in dot notation, example `primary.base`. |
+| `props`      | Object | The props passed to the component, must contain a `theme` prop.                     |
+
+## Example
+
+```jsx
+const StyledLink = styled(Link)`
+  ${props => getLinkStylesOn(props.backgroundColor)(props)}
+`
+
+const LinkDemo = ({ backgroundColor, children, ...props }) => (
+  <Box color={backgroundColor}>
+    <StyledLink backgroundColor={backgroundColor} {...props}>
+      {children}
+    </StyledLink>
+  </Box>
+)
+```
+
+```.jsx
+<LinkDemo backgroundColor='primary.base'>light link styling</LinkDemo>
+
+<LinkDemo backgroundColor='background.base'>default link styling</LinkDemo>
+
+<LinkDemo backgroundColor='highlight.tone'>dark link styling</LinkDemo>
+```
+
+Pass a full palette color and shade to return the link styles that belong on that color. The above examples demonstrate the styles that are returned in order to make the link accessible on colors that do not meet the theme's contrast ratio (color, on-hover color, bold font weight, and text decoration underline).

--- a/apps/docs/pages/utilities/getLinkStylesOn.md
+++ b/apps/docs/pages/utilities/getLinkStylesOn.md
@@ -49,4 +49,4 @@ const LinkDemo = ({ backgroundColor, children, ...props }) => (
 <LinkDemo backgroundColor='highlight.tone'>dark link styling</LinkDemo>
 ```
 
-Pass a full palette color and shade to return the link styles that belong on that color. The above examples demonstrate the styles that are returned in order to make the link accessible on colors that do not meet the theme's contrast ratio (color, on-hover color, bold font weight, and text decoration underline).
+Pass a full palette color and shade to return the link styles that belong on that color. The above examples demonstrate the styles that are returned in order to make the link accessible on colors that do not meet the theme's contrast ratio (color, on-hover color, text decoration underline, and optional bold font weight).

--- a/apps/docs/src/components.js
+++ b/apps/docs/src/components.js
@@ -8,11 +8,13 @@ import { space, fontSize, color } from 'styled-system'
 import { components as mdxDocsComponents } from 'mdx-docs'
 
 import {
+  Box,
   Button,
   GenericBanner,
   Heading,
   Link,
   Text,
+  getLinkStylesOn,
   getPaletteColor,
   getTextColorOn,
   createTheme,
@@ -125,6 +127,19 @@ export const ButtonLink = ({ children, ...props }) => (
   </Button>
 )
 
+const StyledLink = styled(Link)`
+  ${(props) => getLinkStylesOn(props.backgroundColor)(props)}
+`
+
+export const LinkDemo = ({ backgroundColor, children, ...props }) => (
+  <Box color={backgroundColor} p={2} my={1}>
+    {'Example text and '}
+    <StyledLink backgroundColor={backgroundColor} {...props}>
+      {children}
+    </StyledLink>
+  </Box>
+)
+
 const StaticDemo = styled.div`
   color: ${getPaletteColor('primary.base')};
 `
@@ -159,6 +174,7 @@ const components = {
   GenericBanner,
   RangeSlider,
   Slider,
+  LinkDemo,
   Modal,
   ModalDemo,
   Popover,

--- a/apps/docs/src/navigation.js
+++ b/apps/docs/src/navigation.js
@@ -81,6 +81,7 @@ export default [
       { name: 'color', path: '/utilities/color' },
       { name: 'getPaletteColor', path: '/utilities/getPaletteColor' },
       { name: 'getTextColorOn', path: '/utilities/getTextColorOn' },
+      { name: 'getLinkStylesOn', path: '/utilities/getLinkStylesOn' },
     ],
   },
   {

--- a/common/changes/pcln-design-system/feat-add-link-contrast-styling-helper_2023-01-11-22-53.json
+++ b/common/changes/pcln-design-system/feat-add-link-contrast-styling-helper_2023-01-11-22-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add util for getting link styles on a color",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -46,18 +46,33 @@ export const LargeText = () => (
   </Link>
 )
 
-const ResponsiveLink = styled(Link)`
+const ReactiveLink = styled(Link)`
   ${(props) => getLinkStylesOn(props.backgroundColor, props.linkLightColor, props.linkDarkColor)(props)};
 `
 
-const ResponsiveLinkTemplate = (args) => (
-  <Box color={args.backgroundColor} p={2} width={300}>
-    <ResponsiveLink {...args}>Hello there.</ResponsiveLink>
-  </Box>
+const ReactiveLinkTemplate = (args) => (
+  <>
+    <Text mb={2}>
+      Uses the <code>getLinkStylesOn</code> utility
+    </Text>
+    <Box color={args.backgroundColor} p={2} width={300}>
+      <ReactiveLink {...args}>{args.children}</ReactiveLink>
+    </Box>
+    <Box color='background.lightest' p={2} width={300}>
+      <ReactiveLink {...args} backgroundColor='background.lightest'>
+        {args.children}
+      </ReactiveLink>
+    </Box>
+    <Box color='highlight.tone' p={2} width={300}>
+      <ReactiveLink {...args} backgroundColor='highlight.tone'>
+        {args.children}
+      </ReactiveLink>
+    </Box>
+  </>
 )
 
-export const ResponsiveStyling = ResponsiveLinkTemplate.bind({})
-ResponsiveStyling.args = {
+export const ReactiveStyling = ReactiveLinkTemplate.bind({})
+ReactiveStyling.args = {
   backgroundColor: 'primary.base',
   linkLightColor: 'text.lightest',
   linkDarkColor: 'text.base',

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Button, Link, Text } from '..'
+import styled from 'styled-components'
+import { Box, Button, Link, Text, getLinkStylesOn } from '..'
 import { ILinkProps } from './Link'
 import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
@@ -44,3 +45,20 @@ export const LargeText = () => (
     <Text textStyle='heading2'>I am a link with text styles</Text>
   </Link>
 )
+
+const ResponsiveLink = styled(Link)`
+  ${(props) => getLinkStylesOn(props.backgroundColor, props.linkLightColor, props.linkDarkColor)(props)};
+`
+
+const ResponsiveLinkTemplate = (args) => (
+  <Box color={args.backgroundColor} p={2} width={300}>
+    <ResponsiveLink {...args}>Hello there.</ResponsiveLink>
+  </Box>
+)
+
+export const ResponsiveStyling = ResponsiveLinkTemplate.bind({})
+ResponsiveStyling.args = {
+  backgroundColor: 'primary.base',
+  linkLightColor: 'text.lightest',
+  linkDarkColor: 'text.base',
+}

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -47,7 +47,13 @@ export const LargeText = () => (
 )
 
 const ReactiveLink = styled(Link)`
-  ${(props) => getLinkStylesOn(props.backgroundColor, props.linkLightColor, props.linkDarkColor)(props)};
+  ${(props) =>
+    getLinkStylesOn(
+      props.backgroundColor,
+      props.linkLightColor,
+      props.linkDarkColor,
+      props.isLinkBold
+    )(props)};
 `
 
 const ReactiveLinkTemplate = (args) => (
@@ -76,4 +82,5 @@ ReactiveStyling.args = {
   backgroundColor: 'primary.base',
   linkLightColor: 'text.lightest',
   linkDarkColor: 'text.base',
+  isLinkBold: false,
 }

--- a/packages/core/src/Text/Text.stories.tsx
+++ b/packages/core/src/Text/Text.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Box, Text, Divider } from '..'
+import styled from 'styled-components'
+import { Box, Divider, Text } from '..'
 import { defaultArgs, argTypes } from './Text.stories.args'
-import { textStylesValues } from '../utils'
+import { getTextColorOn, textStylesValues } from '../utils'
 
 export default {
   title: 'Typography / Text',
@@ -108,6 +109,23 @@ export const Color = () => (
     <Text color='green'>Hello Green</Text>
   </div>
 )
+
+const ResponsiveText = styled(Text)`
+  color: ${(props) => getTextColorOn(props.backgroundColor, props.lightColor, props.darkColor)(props)};
+`
+
+const ResponsiveColorTemplate = (args) => (
+  <Box color={args.backgroundColor} p={2} width={300}>
+    <ResponsiveText {...args}>Hello there.</ResponsiveText>
+  </Box>
+)
+
+export const ResponsiveColor = ResponsiveColorTemplate.bind({})
+ResponsiveColor.args = {
+  backgroundColor: 'primary.base',
+  lightColor: 'text.lightest',
+  darkColor: 'text.base',
+}
 
 export const MinMaxHeight = () => (
   <div>

--- a/packages/core/src/Text/Text.stories.tsx
+++ b/packages/core/src/Text/Text.stories.tsx
@@ -110,18 +110,29 @@ export const Color = () => (
   </div>
 )
 
-const ResponsiveText = styled(Text)`
+const ReactiveText = styled(Text)`
   color: ${(props) => getTextColorOn(props.backgroundColor, props.lightColor, props.darkColor)(props)};
 `
 
-const ResponsiveColorTemplate = (args) => (
-  <Box color={args.backgroundColor} p={2} width={300}>
-    <ResponsiveText {...args}>Hello there.</ResponsiveText>
-  </Box>
+const ReactiveColorTemplate = (args) => (
+  <>
+    <Text mb={2}>
+      Uses the <code>getTextColorOn</code> utility
+    </Text>
+    <Box color={args.backgroundColor} p={2} width={300}>
+      <ReactiveText {...args}>{args.children}</ReactiveText>
+    </Box>
+    <Box color='primary.light' p={2} width={300}>
+      <ReactiveText {...args} backgroundColor='background.lightest'>
+        {args.children}
+      </ReactiveText>
+    </Box>
+  </>
 )
 
-export const ResponsiveColor = ResponsiveColorTemplate.bind({})
-ResponsiveColor.args = {
+export const ReactiveColor = ReactiveColorTemplate.bind({})
+ReactiveColor.args = {
+  children: 'Hello There',
   backgroundColor: 'primary.base',
   lightColor: 'text.lightest',
   darkColor: 'text.base',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
   deprecatedPropType,
   deprecatedColorValue,
   getContrastRatio,
+  getLinkStylesOn,
   getPaletteColor,
   getTextColorOn,
   hasPaletteColor,

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getContrastRatio,
   getLuminance,
   getPaletteColor,
+  getLinkStylesOn,
   getTextColorOn,
   getValidPaletteColor,
   hasPaletteColor,
@@ -253,6 +254,76 @@ describe('utils', () => {
     })
   })
 
+  describe('getLinkStylesOn', () => {
+    const props = { theme: createTheme() }
+    const textLightest = props.theme.palette.text.lightest
+    const textBase = props.theme.palette.text.base
+
+    test('returns correct text color', () => {
+      expect(getLinkStylesOn('test')({ theme: {} })).toEqual('')
+      expect(getLinkStylesOn('abcde')(props)).toEqual('')
+
+      expect(getLinkStylesOn('primary.base')(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textLightest,
+          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          textLightest,
+          '; }',
+        ])
+      )
+      expect(getLinkStylesOn('highlight.tone')(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textBase,
+          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          textBase,
+          '; }',
+        ])
+      )
+    })
+
+    test('returns correct text color with custom contrast ratio', () => {
+      expect(
+        getLinkStylesOn('primary.dark')({
+          theme: { ...props.theme, contrastRatio: 9.2 },
+        })
+      ).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textBase,
+          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          textBase,
+          '; }',
+        ])
+      )
+    })
+
+    test('can override the link light and dark color defaults', () => {
+      const borderLight = props.theme.palette.border.light
+      const primaryShade = props.theme.palette.primary.shade
+
+      expect(getLinkStylesOn('primary.base', 'border.light', 'primary.shade')(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          borderLight,
+          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          borderLight,
+          '; }',
+        ])
+      )
+      expect(getLinkStylesOn('highlight.tone', 'border.light', 'primary.shade')(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          primaryShade,
+          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          primaryShade,
+          '; }',
+        ])
+      )
+    })
+  })
+
   describe('getTextColorOn', () => {
     const props = { theme: createTheme() }
 
@@ -354,6 +425,15 @@ describe('utils', () => {
       expect(color({ ...props, color: 'text' })).toEqual(
         expect.arrayContaining(['color: ', props.theme.colors.text, ';'])
       )
+      expect(color({ ...props, color: 'text', bg: 'blue' })).toEqual(
+        expect.arrayContaining([
+          'background-color: ',
+          props.theme.colors.blue,
+          ';color: ',
+          props.theme.colors.text,
+          ';',
+        ])
+      )
       expect(color({ ...props, color: 'blue' })).toEqual(
         expect.arrayContaining(['color: ', props.theme.colors.blue, ';'])
       )
@@ -409,6 +489,16 @@ describe('utils', () => {
       medium: 'medium css',
     }
 
+    test('expected result when passed size is not a valid index and no default', () => {
+      const result = applySizes({})({ size: 'notreal' })
+      expect(result).toEqual([])
+    })
+
+    test('expected result when passed size is not a valid index and has default', () => {
+      const result = applySizes(sizesCss)({ size: 'notreal' })
+      expect(result).toEqual(['medium css'])
+    })
+
     test('returns the expected result when size is an array', () => {
       const sizeArray1 = ['small', 'medium', null, null, null, null]
       const sizeArray2 = ['medium', null, null, null, 'small', null]
@@ -418,6 +508,7 @@ describe('utils', () => {
       const result2 = applySizes(sizesCss)({ size: sizeArray2 })
       expect(result2[0]).toBe('medium css')
     })
+
     test('expected result when size is a string', () => {
       const result1 = applySizes(sizesCss)({ size: 'medium' })
       const result2 = applySizes(sizesCss)({ size: 'small' })

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -267,7 +267,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textLightest,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textLightest,
           '; }',
         ])
@@ -276,7 +278,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textBase,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textBase,
           '; }',
         ])
@@ -292,8 +296,24 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textBase,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textBase,
+          '; }',
+        ])
+      )
+    })
+
+    test('returns correct font weight when isBold is true', () => {
+      expect(getLinkStylesOn('primary.base', 'text.lightest', 'text.base', true)(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textLightest,
+          '; font-weight: ',
+          'bold',
+          '; text-decoration: underline; :hover { color: ',
+          textLightest,
           '; }',
         ])
       )
@@ -307,7 +327,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           borderLight,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           borderLight,
           '; }',
         ])
@@ -316,7 +338,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           primaryShade,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           primaryShade,
           '; }',
         ])

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -491,12 +491,12 @@ describe('utils', () => {
 
     test('expected result when passed size is not a valid index and no default', () => {
       const result = applySizes({})({ size: 'notreal' })
-      expect(result).toEqual([])
+      expect(JSON.stringify(result)).toEqual(JSON.stringify([]))
     })
 
     test('expected result when passed size is not a valid index and has default', () => {
       const result = applySizes(sizesCss)({ size: 'notreal' })
-      expect(result).toEqual(['medium css'])
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(['medium css']))
     })
 
     test('returns the expected result when size is an array', () => {

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -274,26 +274,32 @@ export const getValidPaletteColor = (color) => (props) => {
  * @param name       - The name of the background color
  * @param lightColor - Optional light color to use if it meets the contrast ratio, default is text.lightest
  * @param darkColor  - Optional dark color to use if it meets the contrast ratio, default is text.base
+ * @param isBold     - Determines the font weight if an alternative color for the link is picked
  */
-export const getLinkStylesOn = (name, lightColor = null, darkColor = null) => (props) => {
+export const getLinkStylesOn = (
+  name,
+  lightColor = 'text.lightest',
+  darkColor = 'text.base',
+  isBold = false
+) => (props) => {
   const { theme } = props
 
   if (theme.palette) {
     const backgroundColor = getPaletteColor(name)(props)
-    const text = theme.palette.text
     const linkColor = theme.palette.primary.base
 
-    lightColor = getValidPaletteColor(lightColor)(props) || text.lightest
-    darkColor = getValidPaletteColor(darkColor)(props) || text.base
+    lightColor = getValidPaletteColor(lightColor)(props)
+    darkColor = getValidPaletteColor(darkColor)(props)
 
     if (backgroundColor) {
       const hasDefaultContrast = getContrastRatio(backgroundColor, linkColor) >= theme.contrastRatio
       const hasLightContrast = getContrastRatio(backgroundColor, lightColor) >= theme.contrastRatio
 
       if (!hasDefaultContrast) {
+        const fontWeight = isBold ? 'bold' : 'inherit'
         const contrastLinkColor = hasLightContrast ? lightColor : darkColor
         // prettier-ignore
-        return css`color: ${contrastLinkColor}; font-weight: bold; text-decoration: underline; :hover { color: ${contrastLinkColor}; }`
+        return css`color: ${contrastLinkColor}; font-weight: ${fontWeight}; text-decoration: underline; :hover { color: ${contrastLinkColor}; }`
       }
     }
   }

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -148,7 +148,6 @@ export const getBreakpointSize = (array, length) => {
  * @param sizes - An object of size styles
  *
  */
-
 export const applySizes = (sizes = null, defaultSize = 'medium', mediaQueriesOptions = mediaQueries) => ({
   size,
 }) => {
@@ -267,6 +266,39 @@ export const getValidPaletteColor = (color) => (props) => {
   }
 
   return null
+}
+
+/**
+ * Gets css styles that make links more accessible depending on a given background color
+ *
+ * @param name       - The name of the background color
+ * @param lightColor - Optional light color to use if it meets the contrast ratio, default is text.lightest
+ * @param darkColor  - Optional dark color to use if it meets the contrast ratio, default is text.base
+ */
+export const getLinkStylesOn = (name, lightColor = null, darkColor = null) => (props) => {
+  const { theme } = props
+
+  if (theme.palette) {
+    const backgroundColor = getPaletteColor(name)(props)
+    const text = theme.palette.text
+    const linkColor = theme.palette.primary.base
+
+    lightColor = getValidPaletteColor(lightColor)(props) || text.lightest
+    darkColor = getValidPaletteColor(darkColor)(props) || text.base
+
+    if (backgroundColor) {
+      const hasDefaultContrast = getContrastRatio(backgroundColor, linkColor) >= theme.contrastRatio
+      const hasLightContrast = getContrastRatio(backgroundColor, lightColor) >= theme.contrastRatio
+
+      if (!hasDefaultContrast) {
+        const contrastLinkColor = hasLightContrast ? lightColor : darkColor
+        // prettier-ignore
+        return css`color: ${contrastLinkColor}; font-weight: bold; text-decoration: underline; :hover { color: ${contrastLinkColor}; }`
+      }
+    }
+  }
+
+  return ''
 }
 
 /**


### PR DESCRIPTION
v4 PR: https://github.com/priceline/design-system/pull/1241

- Similar to the `getTextColorOn` util but for links so that their default and on-hover state is accessible on different theme palette colors
  - If not the default link color, add color, font weight, and underline styles
- Add new page to docs to demonstrate the three possible outcomes (light link, default link, and dark link styling)
- Add test suite for new util, also add some more coverage on other lines
- Add test command to core `package.json`

#### Before using `getLinkStylesOn`
![Screen Shot 2023-01-11 at 4 15 42 PM](https://user-images.githubusercontent.com/62613356/211931629-7c8c6ac1-c7da-4e69-ad0b-9d882de17e34.png)

#### After using `getLinkStylesOn`
![Screen Shot 2023-01-11 at 4 27 12 PM](https://user-images.githubusercontent.com/62613356/211931657-8fc98c4e-6a68-451f-80ad-ac901c7396dd.png)

### New Stories
![Screen Shot 2023-01-12 at 11 15 45 AM](https://user-images.githubusercontent.com/62613356/212158266-6f3f6749-dc25-470b-859b-673d9371b01c.png)

![Screen Shot 2023-01-12 at 12 05 09 PM](https://user-images.githubusercontent.com/62613356/212158157-d35b7523-3c9c-4c04-ae3d-38ba1709a372.png)