### PR TITLE
fix(v4): Update Link and Text colour stories based on feedback

### DIFF
--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -45,18 +45,33 @@ export const LargeText = () => (
   </Link>
 )
 
-const ResponsiveLink = styled(Link)`
+const ReactiveLink = styled(Link)`
   ${(props) => getLinkStylesOn(props.backgroundColor, props.linkLightColor, props.linkDarkColor)(props)};
 `
 
-const ResponsiveLinkTemplate = (args) => (
-  <Box color={args.backgroundColor} p={2} width={300}>
-    <ResponsiveLink {...args}>Hello there.</ResponsiveLink>
-  </Box>
+const ReactiveLinkTemplate = (args) => (
+  <>
+    <Text mb={2}>
+      Uses the <code>getLinkStylesOn</code> utility
+    </Text>
+    <Box color={args.backgroundColor} p={2} width={300}>
+      <ReactiveLink {...args}>{args.children}</ReactiveLink>
+    </Box>
+    <Box color='background.lightest' p={2} width={300}>
+      <ReactiveLink {...args} backgroundColor='background.lightest'>
+        {args.children}
+      </ReactiveLink>
+    </Box>
+    <Box color='highlight.tone' p={2} width={300}>
+      <ReactiveLink {...args} backgroundColor='highlight.tone'>
+        {args.children}
+      </ReactiveLink>
+    </Box>
+  </>
 )
 
-export const ResponsiveStyling = ResponsiveLinkTemplate.bind({})
-ResponsiveStyling.args = {
+export const ReactiveStyling = ReactiveLinkTemplate.bind({})
+ReactiveStyling.args = {
   backgroundColor: 'primary.base',
   linkLightColor: 'text.lightest',
   linkDarkColor: 'text.base',

--- a/packages/core/src/Text/Text.stories.tsx
+++ b/packages/core/src/Text/Text.stories.tsx
@@ -110,18 +110,29 @@ export const Color = () => (
   </div>
 )
 
-const ResponsiveText = styled(Text)`
+const ReactiveText = styled(Text)`
   color: ${(props) => getTextColorOn(props.backgroundColor, props.lightColor, props.darkColor)(props)};
 `
 
-const ResponsiveColorTemplate = (args) => (
-  <Box color={args.backgroundColor} p={2} width={300}>
-    <ResponsiveText {...args}>Hello there.</ResponsiveText>
-  </Box>
+const ReactiveColorTemplate = (args) => (
+  <>
+    <Text mb={2}>
+      Uses the <code>getTextColorOn</code> utility
+    </Text>
+    <Box color={args.backgroundColor} p={2} width={300}>
+      <ReactiveText {...args}>{args.children}</ReactiveText>
+    </Box>
+    <Box color='primary.light' p={2} width={300}>
+      <ReactiveText {...args} backgroundColor='background.lightest'>
+        {args.children}
+      </ReactiveText>
+    </Box>
+  </>
 )
 
-export const ResponsiveColor = ResponsiveColorTemplate.bind({})
-ResponsiveColor.args = {
+export const ReactiveColor = ReactiveColorTemplate.bind({})
+ReactiveColor.args = {
+  children: 'Hello There',
   backgroundColor: 'primary.base',
   lightColor: 'text.lightest',
   darkColor: 'text.base',


### PR DESCRIPTION
- Change "responsive" story naming for colour examples in Link and Text to "reactive"
- Add multiple components to demo different colour interactions on one story (first one stays configurable)
- Make text interactive in Text colour story

![Screen Shot 2023-01-13 at 11 45 46 AM](https://user-images.githubusercontent.com/62613356/212393887-faa14602-7c80-41fe-bfb7-0cb088b5ed1d.png)
![Screen Shot 2023-01-13 at 11 47 28 AM](https://user-images.githubusercontent.com/62613356/212393891-12bea77b-e1b8-4678-8e43-125f51a4912b.png)
