### PR TITLE
fix(v4): Make bold optional in getLinkStylesOn

### DIFF
--- a/apps/docs/pages/utilities/getLinkStylesOn.md
+++ b/apps/docs/pages/utilities/getLinkStylesOn.md
@@ -49,4 +49,4 @@ const LinkDemo = ({ backgroundColor, children, ...props }) => (
 <LinkDemo backgroundColor='highlight.tone'>dark link styling</LinkDemo>
 ```
 
-Pass a full palette color and shade to return the link styles that belong on that color. The above examples demonstrate the styles that are returned in order to make the link accessible on colors that do not meet the theme's contrast ratio (color, on-hover color, bold font weight, and text decoration underline).
+Pass a full palette color and shade to return the link styles that belong on that color. The above examples demonstrate the styles that are returned in order to make the link accessible on colors that do not meet the theme's contrast ratio (color, on-hover color, text decoration underline, and optional bold font weight).

--- a/common/changes/pcln-design-system/feat-getlinkstyleson-bold-optional_2023-01-16-15-51.json
+++ b/common/changes/pcln-design-system/feat-getlinkstyleson-bold-optional_2023-01-16-15-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update getLinkStylesOn to make font weight bold optional",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -46,7 +46,13 @@ export const LargeText = () => (
 )
 
 const ReactiveLink = styled(Link)`
-  ${(props) => getLinkStylesOn(props.backgroundColor, props.linkLightColor, props.linkDarkColor)(props)};
+  ${(props) =>
+    getLinkStylesOn(
+      props.backgroundColor,
+      props.linkLightColor,
+      props.linkDarkColor,
+      props.isLinkBold
+    )(props)};
 `
 
 const ReactiveLinkTemplate = (args) => (
@@ -75,4 +81,5 @@ ReactiveStyling.args = {
   backgroundColor: 'primary.base',
   linkLightColor: 'text.lightest',
   linkDarkColor: 'text.base',
+  isLinkBold: false,
 }

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -267,7 +267,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textLightest,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textLightest,
           '; }',
         ])
@@ -276,7 +278,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textBase,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textBase,
           '; }',
         ])
@@ -292,8 +296,24 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           textBase,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           textBase,
+          '; }',
+        ])
+      )
+    })
+
+    test('returns correct font weight when isBold is true', () => {
+      expect(getLinkStylesOn('primary.base', 'text.lightest', 'text.base', true)(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textLightest,
+          '; font-weight: ',
+          'bold',
+          '; text-decoration: underline; :hover { color: ',
+          textLightest,
           '; }',
         ])
       )
@@ -307,7 +327,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           borderLight,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           borderLight,
           '; }',
         ])
@@ -316,7 +338,9 @@ describe('utils', () => {
         expect.arrayContaining([
           'color: ',
           primaryShade,
-          '; font-weight: bold; text-decoration: underline; :hover { color: ',
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
           primaryShade,
           '; }',
         ])

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -275,26 +275,32 @@ export const getValidPaletteColor = (color) => (props) => {
  * @param name       - The name of the background color
  * @param lightColor - Optional light color to use if it meets the contrast ratio, default is text.lightest
  * @param darkColor  - Optional dark color to use if it meets the contrast ratio, default is text.base
+ * @param isBold     - Determines the font weight if an alternative color for the link is picked
  */
-export const getLinkStylesOn = (name, lightColor = null, darkColor = null) => (props) => {
+export const getLinkStylesOn = (
+  name,
+  lightColor = 'text.lightest',
+  darkColor = 'text.base',
+  isBold = false
+) => (props) => {
   const { theme } = props
 
   if (theme.palette) {
     const backgroundColor = getPaletteColor(name)(props)
-    const text = theme.palette.text
     const linkColor = theme.palette.primary.base
 
-    lightColor = getValidPaletteColor(lightColor)(props) || text.lightest
-    darkColor = getValidPaletteColor(darkColor)(props) || text.base
+    lightColor = getValidPaletteColor(lightColor)(props)
+    darkColor = getValidPaletteColor(darkColor)(props)
 
     if (backgroundColor) {
       const hasDefaultContrast = getContrastRatio(backgroundColor, linkColor) >= theme.contrastRatio
       const hasLightContrast = getContrastRatio(backgroundColor, lightColor) >= theme.contrastRatio
 
       if (!hasDefaultContrast) {
+        const fontWeight = isBold ? 'bold' : 'inherit'
         const contrastLinkColor = hasLightContrast ? lightColor : darkColor
         // prettier-ignore
-        return css`color: ${contrastLinkColor}; font-weight: bold; text-decoration: underline; :hover { color: ${contrastLinkColor}; }`
+        return css`color: ${contrastLinkColor}; font-weight: ${fontWeight}; text-decoration: underline; :hover { color: ${contrastLinkColor}; }`
       }
     }
   }


### PR DESCRIPTION
- Add fourth param to allow for making bold optional if a different colour than the default is chosen for the link styles
- Update docs page and add toggle on the Link storybook
- Util is not yet in use so patching this in
- Add new test and update existing

#### Screenshots
![Screen Shot 2023-01-16 at 9 55 08 AM](https://user-images.githubusercontent.com/62613356/212719704-f4a7d3ba-712c-4081-80a4-82b155e0d962.png)
![Screen Shot 2023-01-16 at 9 55 13 AM](https://user-images.githubusercontent.com/62613356/212719710-f7b91d3d-0a21-47dc-9fc2-13cfae7d674b.png)
