### PR TITLE
Fix sustainability svg change for v4

### DIFF
--- a/common/changes/pcln-icons/feat-HTL-86887-v4-sustainable-svg_2023-01-13-20-43.json
+++ b/common/changes/pcln-icons/feat-HTL-86887-v4-sustainable-svg_2023-01-13-20-43.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "pcln-icons",
-      "comment": "",
-      "type": "none"
+      "comment": "add sustainable icon v4",
+      "type": "minor"
     }
   ],
   "packageName": "pcln-icons"


### PR DESCRIPTION
Ron's PR adding the Sustainability svg did not include a type change for the icons package: https://github.com/priceline/design-system/pull/1245/files#diff-ce82642d1194ef693b17c7c387e4fd3efcb3f8d18ecb5e68ad962a3e7a0123baR5