### PR TITLE
fix(main): Check onhover color in getLinkStylesOn

### DIFF
--- a/common/changes/pcln-design-system/fix-getlinkstyleson-check-hover-color-contrast_2023-01-24-20-58.json
+++ b/common/changes/pcln-design-system/fix-getlinkstyleson-check-hover-color-contrast_2023-01-24-20-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add fix for onhover color check to getLinkStylesOn",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -74,6 +74,11 @@ const ReactiveLinkTemplate = (args) => (
         {args.children}
       </ReactiveLink>
     </Box>
+    <Box color='background.darkest' p={2} width={300}>
+      <ReactiveLink {...args} backgroundColor='background.darkest'>
+        {args.children}
+      </ReactiveLink>
+    </Box>
   </>
 )
 

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -259,7 +259,7 @@ describe('utils', () => {
     const textLightest = props.theme.palette.text.lightest
     const textBase = props.theme.palette.text.base
 
-    test('returns correct text color', () => {
+    test('returns correct link styles', () => {
       expect(getLinkStylesOn('test')({ theme: {} })).toEqual('')
       expect(getLinkStylesOn('abcde')(props)).toEqual('')
 
@@ -287,7 +287,21 @@ describe('utils', () => {
       )
     })
 
-    test('returns correct text color with custom contrast ratio', () => {
+    test('returns correct link styles when only link hover does not meet contrast', () => {
+      expect(getLinkStylesOn('background.darkest')(props)).toEqual(
+        expect.arrayContaining([
+          'color: ',
+          textLightest,
+          '; font-weight: ',
+          'inherit',
+          '; text-decoration: underline; :hover { color: ',
+          textLightest,
+          '; }',
+        ])
+      )
+    })
+
+    test('returns correct link styles with custom contrast ratio', () => {
       expect(
         getLinkStylesOn('primary.dark')({
           theme: { ...props.theme, contrastRatio: 9.2 },

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -286,13 +286,16 @@ export const getLinkStylesOn = (
 
   if (theme.palette) {
     const backgroundColor = getPaletteColor(name)(props)
-    const linkColor = theme.palette.primary.base
+    const linkBaseColor = theme.palette.primary.base
+    const linkHoverColor = theme.palette.primary.dark
 
     lightColor = getValidPaletteColor(lightColor)(props)
     darkColor = getValidPaletteColor(darkColor)(props)
 
     if (backgroundColor) {
-      const hasDefaultContrast = getContrastRatio(backgroundColor, linkColor) >= theme.contrastRatio
+      const hasDefaultContrast =
+        getContrastRatio(backgroundColor, linkBaseColor) >= theme.contrastRatio &&
+        getContrastRatio(backgroundColor, linkHoverColor) >= theme.contrastRatio
       const hasLightContrast = getContrastRatio(backgroundColor, lightColor) >= theme.contrastRatio
 
       if (!hasDefaultContrast) {


### PR DESCRIPTION
- In order to ensure contrast is maintained, we should also check the onhover color before we allow the default link styles to still apply
- Add condition for default contrast check and test for this case
- Update storybook with example as well

#### Before
<img width="117" alt="Screen Shot 2023-01-24 at 2 37 40 PM" src="https://user-images.githubusercontent.com/62613356/214411763-1d56947e-28b6-4c5b-99b0-0b92dfced0d1.png"> <img width="109" alt="Screen Shot 2023-01-24 at 2 37 48 PM" src="https://user-images.githubusercontent.com/62613356/214411326-da8ba03d-4325-4c9a-81e7-83683ba544dc.png">

#### After
<img width="580" alt="Screen Shot 2023-01-24 at 2 44 06 PM" src="https://user-images.githubusercontent.com/62613356/214411484-a6c05ac2-e672-4c61-8250-1c7677236dfc.png">
