### PR TITLE
ChoiceChip text should not wrap

### DIFF
--- a/common/changes/pcln-design-system/fix-chip-filter-text-wrap_2023-02-16-15-44.json
+++ b/common/changes/pcln-design-system/fix-chip-filter-text-wrap_2023-02-16-15-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "ChoiceChip text should not wrap",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -71,6 +71,7 @@ const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
   align-items: center;
   position: relative;
   border-radius: 2px;
+  white-space: nowrap;
   ${({ theme, hasChildren }) => applySizes(getSizes({ hasChildren }), undefined, theme.mediaQueries)};
   ${space};
   ${fontSize};

--- a/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
+++ b/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
@@ -53,6 +53,13 @@ const labelOnly = [
 ]
 export const LabelOnly = () => getExamples(labelOnly, [small, medium, responsive])
 
+const noTextWrap = [
+  { label: 'Lots of Words that Do Not Wrap' },
+  { label: 'Long Words and Things!', selected: true },
+  { label: 'This Is A Test', selected: true, disabled: true },
+]
+export const NoTextWrap = () => getExamples(noTextWrap, [small, medium, responsive])
+
 //With Icon
 const withIcon = [
   { label: 'Enabled', Icon: Departure },


### PR DESCRIPTION
This change will prevent text inside `ChoiceChip` from wrapping. 

**Before:**
<img width="768" alt="CleanShot 2023-02-16 at 10 44 49@2x" src="https://user-images.githubusercontent.com/3260642/219415940-3a65aa00-17ee-4eba-837a-a3dd15a8741c.png">

**After:**
<img width="813" alt="CleanShot 2023-02-16 at 10 45 20@2x" src="https://user-images.githubusercontent.com/3260642/219416064-2e02a3a6-3582-4140-ad91-7c0a20539556.png">
