### PR TITLE
feat(UXPT-3871): Add variation prop to badge to support semantic colors

### DIFF
--- a/common/changes/pcln-design-system/feat-UPXT-3871--add-variation-prop-to-badge-to-support-semantic-colors_2023-02-23-19-16.json
+++ b/common/changes/pcln-design-system/feat-UPXT-3871--add-variation-prop-to-badge-to-support-semantic-colors_2023-02-23-19-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add prop badgeStyle to Badge which apply semantic styling",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Badge/Badge.spec.tsx
+++ b/packages/core/src/Badge/Badge.spec.tsx
@@ -81,4 +81,68 @@ describe('Badge', () => {
     expect(json).toHaveStyleRule('background-color', theme.colors.lightBlue)
     expect(json).toHaveStyleRule('color', theme.colors.text)
   })
+
+  test.each([
+    { badgeStyle: 'primary', backgroundColor: theme.colors.blue, color: theme.colors.lightestText },
+    { badgeStyle: 'primaryLight', backgroundColor: theme.colors.lightBlue, color: theme.colors.blue },
+    { badgeStyle: 'primaryDark', backgroundColor: theme.colors.darkBlue, color: theme.colors.lightestText },
+    { badgeStyle: 'primaryDarkLight', backgroundColor: theme.colors.lightBlue, color: theme.colors.darkBlue },
+    { badgeStyle: 'secondary', backgroundColor: theme.colors.green, color: theme.colors.lightestText },
+    { badgeStyle: 'secondaryLight', backgroundColor: theme.colors.lightGreen, color: theme.colors.green },
+    {
+      badgeStyle: 'backgroundDarkest',
+      backgroundColor: theme.colors.darkestBackground,
+      color: theme.colors.lightestText,
+    },
+    {
+      badgeStyle: 'backgroundLightest',
+      backgroundColor: theme.colors.lightestBackground,
+      color: theme.colors.text,
+    },
+    { badgeStyle: 'neutral', backgroundColor: theme.colors.darkBackground, color: theme.colors.lightestText },
+    {
+      badgeStyle: 'neutralLight',
+      backgroundColor: theme.colors.background,
+      color: theme.colors.lightText,
+    },
+    {
+      badgeStyle: 'warning',
+      backgroundColor: theme.colors.red,
+      color: theme.colors.lightestText,
+    },
+    {
+      badgeStyle: 'warningLight',
+      backgroundColor: theme.colors.lightRed,
+      color: theme.colors.red,
+    },
+    {
+      badgeStyle: 'highlight',
+      backgroundColor: theme.colors.lightHighlight,
+      color: theme.colors.shadeHighlight,
+    },
+    {
+      badgeStyle: 'notify',
+      backgroundColor: theme.colors.lightYellow,
+      color: theme.colors.text,
+    },
+    {
+      badgeStyle: 'success',
+      backgroundColor: theme.colors.green,
+      color: theme.colors.lightestText,
+    },
+    {
+      badgeStyle: 'successLight',
+      backgroundColor: theme.colors.lightGreen,
+      color: theme.colors.green,
+    },
+  ])(
+    'badgeStyle $badgeStyle sets background-color to $backgroundColor and color to $color',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ({ badgeStyle, backgroundColor, color }: { badgeStyle: any; backgroundColor: string; color: string }) => {
+      const json = rendererCreateWithTheme(<Badge badgeStyle={badgeStyle} />).toJSON()
+      expect(json).toMatchSnapshot()
+      expect(json).toHaveStyleRule('background-color', backgroundColor)
+      expect(json).toHaveStyleRule('color', color)
+    }
+  )
 })

--- a/packages/core/src/Badge/Badge.stories.args.ts
+++ b/packages/core/src/Badge/Badge.stories.args.ts
@@ -1,4 +1,4 @@
-import { borderRadii, colors } from '../storybook/args'
+import { borderRadii, colors, badgeStyles } from '../storybook/args'
 
 export const argTypes = {
   borderRadius: {
@@ -24,6 +24,15 @@ export const argTypes = {
     type: { name: 'string' },
     options: colors,
     description: 'Color of badge',
+    control: {
+      type: 'select',
+    },
+  },
+  badgeStyle: {
+    name: 'badgeStyle',
+    type: { name: 'string' },
+    options: badgeStyles,
+    description: 'Semantic badge styles',
     control: {
       type: 'select',
     },

--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -22,9 +22,6 @@ export default {
 const Template = (args) => <Badge {...args}>badge</Badge>
 
 export const _Badge = Template.bind({})
-_Badge.args = {
-  bg: 'lightGray',
-}
 
 export const TextCustom = Template.bind({})
 TextCustom.storyName = 'text (custom)'
@@ -39,3 +36,71 @@ LightBlueAndTextCustom.args = {
   bg: 'primary.light',
   color: 'text',
 }
+
+export const BadgeStyle = () => (
+  <>
+    <Badge m={1} badgeStyle='primary'>
+      primary
+    </Badge>
+
+    <Badge m={1} badgeStyle='primaryLight'>
+      primaryLight
+    </Badge>
+
+    <Badge m={1} badgeStyle='primaryDark'>
+      primaryDark
+    </Badge>
+
+    <Badge m={1} badgeStyle='primaryDarkLight'>
+      primaryDarkLight
+    </Badge>
+
+    <Badge m={1} badgeStyle='secondary'>
+      secondary
+    </Badge>
+
+    <Badge m={1} badgeStyle='secondaryLight'>
+      secondaryLight
+    </Badge>
+
+    <Badge m={1} badgeStyle='backgroundDarkest'>
+      backgroundDarkest
+    </Badge>
+
+    <Badge m={1} badgeStyle='backgroundLightest'>
+      backgroundLightest
+    </Badge>
+
+    <Badge m={1} badgeStyle='neutral'>
+      neutral
+    </Badge>
+
+    <Badge m={1} badgeStyle='neutralLight'>
+      neutralLight
+    </Badge>
+
+    <Badge m={1} badgeStyle='warning'>
+      warning
+    </Badge>
+
+    <Badge m={1} badgeStyle='warningLight'>
+      warningLight
+    </Badge>
+
+    <Badge m={1} badgeStyle='highlight'>
+      hightlight
+    </Badge>
+
+    <Badge m={1} badgeStyle='notify'>
+      notify
+    </Badge>
+
+    <Badge m={1} badgeStyle='success'>
+      success
+    </Badge>
+
+    <Badge m={1} badgeStyle='successLight'>
+      successLight
+    </Badge>
+  </>
+)

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -57,11 +57,106 @@ const sizes = {
   `,
 }
 
+const badgeStyles = {
+  primary: {
+    backgroundColor: themeGet('palette.primary.base'),
+    color: themeGet('palette.text.lightest'),
+  },
+  primaryLight: {
+    backgroundColor: themeGet('palette.primary.light'),
+    color: themeGet('palette.primary.base'),
+  },
+  primaryDark: {
+    backgroundColor: themeGet('palette.primary.dark'),
+    color: themeGet('palette.text.lightest'),
+  },
+  primaryDarkLight: {
+    backgroundColor: themeGet('palette.primary.light'),
+    color: themeGet('palette.primary.dark'),
+  },
+  secondary: {
+    backgroundColor: themeGet('palette.secondary.base'),
+    color: themeGet('palette.text.lightest'),
+  },
+  secondaryLight: {
+    backgroundColor: themeGet('palette.secondary.light'),
+    color: themeGet('palette.secondary.base'),
+  },
+  backgroundDarkest: {
+    backgroundColor: themeGet('palette.background.darkest'),
+    color: themeGet('palette.text.lightest'),
+  },
+  backgroundLightest: {
+    backgroundColor: themeGet('palette.background.lightest'),
+    color: themeGet('palette.text.base'),
+  },
+  neutral: {
+    backgroundColor: themeGet('palette.background.dark'),
+    color: themeGet('palette.text.lightest'),
+  },
+  neutralLight: {
+    backgroundColor: themeGet('palette.background.base'),
+    color: themeGet('palette.text.light'),
+  },
+  warning: {
+    backgroundColor: themeGet('palette.warning.base'),
+    color: themeGet('palette.text.lightest'),
+  },
+  warningLight: {
+    backgroundColor: themeGet('palette.warning.light'),
+    color: themeGet('palette.warning.base'),
+  },
+  highlight: {
+    backgroundColor: themeGet('palette.highlight.light'),
+    color: themeGet('palette.highlight.shade'),
+  },
+  notify: {
+    backgroundColor: themeGet('palette.notify.light'),
+    color: themeGet('palette.text.base'),
+  },
+  success: {
+    backgroundColor: themeGet('palette.success.base'),
+    color: themeGet('palette.text.lightest'),
+  },
+  successLight: {
+    backgroundColor: themeGet('palette.success.light'),
+    color: themeGet('palette.success.base'),
+  },
+}
+
+export const badgeStyleValues = Object.keys(badgeStyles)
+
+const badgeStyle = (props) => {
+  return (
+    !props.bg &&
+    !props.color &&
+    css`
+      ${badgeStyles[props.badgeStyle] || {}}
+    `
+  )
+}
 export interface IBadgeProps extends SpaceProps, React.HtmlHTMLAttributes<HTMLElement> {
   size?: 'small' | 'medium'
   color?: string
   bg?: string
   borderRadius?: string
+  badgeStyle?:
+    | 'primary'
+    | 'primaryLight'
+    | 'primaryDark'
+    | 'primaryDarkLight'
+    | 'secondary'
+    | 'secondaryLight'
+    | 'backgroundDarkest'
+    | 'backgroundLightest'
+    | 'neutral'
+    | 'neutralLight'
+    | 'warning'
+    | 'warningLight'
+    | 'highlight'
+    | 'notify'
+    | 'success'
+    | 'successLight'
 }
 
 const Badge: React.FC<IBadgeProps> = styled.div.attrs(borderRadiusAttrs)`
@@ -70,9 +165,12 @@ const Badge: React.FC<IBadgeProps> = styled.div.attrs(borderRadiusAttrs)`
   letter-spacing: ${themeGet('letterSpacings.caps')};
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Badge')};
-  ${space} ${type} ${color};
-
+  ${space}
+  ${type} 
+  ${color}
+  
   ${borderRadius}
+  ${badgeStyle}
 `
 
 Badge.displayName = 'Badge'
@@ -83,6 +181,7 @@ Badge.propTypes = {
   color: deprecatedColorValue(),
   bg: deprecatedColorValue(),
   borderRadius: PropTypes.string,
+  badgeStyle: PropTypes.oneOf(badgeStyleValues),
 }
 
 Badge.defaultProps = {

--- a/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -1,5 +1,1305 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Badge badgeStyle backgroundDarkest sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #001833;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle backgroundDarkest sets background-color to #001833 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #001833;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle backgroundLighest sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle backgroundLighest sets background-color to #fff and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff;
+  color: #001833;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle backgroundLightest sets background-color to #fff and color to #001833 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff;
+  color: #001833;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle backgroundLightest sets background-color to #fff and color to undefined 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff;
+  color: #001833;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle highlight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #d0f1ac;
+  color: #017000;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle highlight sets background-color to #d0f1ac and color to #017000 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #d0f1ac;
+  color: #017000;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle neutral sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #4f6f8f;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle neutral sets background-color to #4f6f8f and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #4f6f8f;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle neutralLight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #4f6f8f;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle neutralLight sets background-color to #4f6f8f and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #edf0f3;
+  color: #4f6f8f;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle neutralLight sets background-color to #edf0f3 and color to #4f6f8f 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #edf0f3;
+  color: #4f6f8f;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle notify sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff3c0;
+  color: #001833;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle notify sets background-color to #fff3c0 and color to #001833 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fff3c0;
+  color: #001833;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primary sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0068ef;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primary sets background-color sets #0068ef and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0068ef;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primary sets background-color to #0068ef and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0068ef;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryDark sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #049;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryDark sets background-color sets #049 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #049;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryDark sets background-color to #049 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #049;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryDarkLight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #e8f2ff;
+  color: #049;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryDarkLight sets background-color to #e8f2ff and color to #049 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #e8f2ff;
+  color: #049;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryLight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #e8f2ff;
+  color: #0068ef;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryLight sets background-color sets #e8f2ff and color to #0068ef 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #e8f2ff;
+  color: #0068ef;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle primaryLight sets background-color to #e8f2ff and color to #0068ef 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #e8f2ff;
+  color: #0068ef;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle secondary sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0a0;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle secondary sets background-color to #0a0 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0a0;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle secondaryLight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #ecf7ec;
+  color: #0a0;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle secondaryLight sets background-color to #ecf7ec and color to #0a0 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #ecf7ec;
+  color: #0a0;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  color: #fff;
+}
+
+.c0 backgroundColor {
+  light: #e8f2ff;
+  tint: #99c3f9;
+  base: #0068ef;
+  tone: #0055c4;
+  dark: #049;
+  shade: #002f6d;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle success sets background-color to #0a0 and color to #001833 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0a0;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle success sets background-color to #0a0 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #0a0;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle successLight sets background-color to #ecf7ec and color to #0a0 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #ecf7ec;
+  color: #0a0;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle warning sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #c00;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle warning sets background-color to #c00 and color to #fff 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #c00;
+  color: #fff;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle warningLight sets background-color and color 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fbebeb;
+  color: #c00;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
+exports[`Badge badgeStyle warningLight sets background-color to #fbebeb and color to #c00 1`] = `
+.c0 {
+  display: inline-block;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #f4f6f8;
+  color: #001833;
+  border-radius: 9999px;
+  background-color: #fbebeb;
+  color: #c00;
+}
+
+<div
+  className="c0"
+  size="medium"
+/>
+`;
+
 exports[`Badge bg blue sets background-color and color 1`] = `
 .c0 {
   display: inline-block;

--- a/packages/core/src/storybook/args/index.ts
+++ b/packages/core/src/storybook/args/index.ts
@@ -6,6 +6,8 @@ import {
   textStylesValues,
 } from '../../utils'
 
+import { badgeStyleValues } from '../../Badge/Badge'
+
 export const colors = ['', ...paletteFamilies, 'NOTVALID']
 
 export const borderRadii = ['', ...borderRadiusValues, 'NOTVALID']
@@ -15,6 +17,8 @@ export const rounded = ['', ...roundedValues, 'NOTVALID']
 export const shadows = ['', ...boxShadowSizeValues, 'NOTVALID']
 
 export const textStyles = ['', ...textStylesValues, 'NOTVALID']
+
+export const badgeStyles = ['', ...badgeStyleValues, 'NOTVALID']
 
 export const inputArgs = ['sm', 'md', 'lg', 'xl']
 


### PR DESCRIPTION
This change introduces a new prop `BadgeStyle` to the core `<Badge/>` component.   Consumers can now provide a semantic value to the `BadgeStyle` prop to style the `<Badge/>`. 