### PR TITLE
Fix two prop type warnings

### DIFF
--- a/common/changes/pcln-design-system/fix-two-prop-type-warnings_2023-02-28-19-18.json
+++ b/common/changes/pcln-design-system/fix-two-prop-type-warnings_2023-02-28-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update FormField to use an interface instead of prop types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-menu/fix-two-prop-type-warnings_2023-02-28-19-18.json
+++ b/common/changes/pcln-menu/fix-two-prop-type-warnings_2023-02-28-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Pass id prop to Popover idx prop to fix prop type warning",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/packages/core/src/FormField/FormField.spec.tsx
+++ b/packages/core/src/FormField/FormField.spec.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
-
 import { FormField, Input, Label, Select } from '..'
 import { Email as EmailIcon } from 'pcln-icons'
 
@@ -84,48 +82,5 @@ describe('FormField', () => {
     ).toJSON()
     const [label] = json.children
     expect(label.props.htmlFor).toBe('hello')
-  })
-
-  describe('propTypes', () => {
-    let consoleError
-    beforeEach(() => {
-      consoleError = console.error
-      console.error = jest.fn()
-    })
-    afterEach(() => (console.error = consoleError))
-
-    test('warns when field is missing', () => {
-      PropTypes.checkPropTypes(
-        FormField.propTypes,
-        {
-          // eslint-disable-next-line react/jsx-key
-          children: [<Label />],
-        },
-        'children',
-        'FormField'
-      )
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Warning: Failed children type: No form field found for FormField. Please include an Input, Select, or other form field as a child.'
-        )
-      )
-    })
-
-    test('warns when Label is missing', () => {
-      PropTypes.checkPropTypes(
-        FormField.propTypes,
-        {
-          // eslint-disable-next-line react/jsx-key
-          children: [<Input id='test' name='test' />],
-        },
-        'children',
-        'FormField'
-      )
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'Warning: Failed children type: No label found for FormField. Please include a Label as a child.'
-        )
-      )
-    })
   })
 })

--- a/packages/core/src/FormField/FormField.tsx
+++ b/packages/core/src/FormField/FormField.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Box, IBoxProps } from '../Box'
 import { IconField } from '../IconField'
 
-interface IFormFieldProps extends IBoxProps {}
+export interface IFormFieldProps extends IBoxProps {}
 
 const paddingTopWithLabel = {
   sm: '14px',

--- a/packages/core/src/FormField/FormField.tsx
+++ b/packages/core/src/FormField/FormField.tsx
@@ -1,10 +1,10 @@
 // @ts-nocheck
 
 import React from 'react'
-import { InferProps } from 'prop-types'
-
-import { Box } from '../Box'
+import { Box, IBoxProps } from '../Box'
 import { IconField } from '../IconField'
+
+interface IFormFieldProps extends IBoxProps {}
 
 const paddingTopWithLabel = {
   sm: '14px',
@@ -25,25 +25,6 @@ const paddingTopForLabel = {
   xl: '10px',
 }
 
-const childrenPropType = (props, propName, componentName) => {
-  const children = React.Children.toArray(props.children)
-  const [label] = children.filter((child) => child.type.isLabel)
-  const [field] = children.filter((child) => child.type.isField)
-
-  if (!field) {
-    return new Error(
-      `No form field found for ${componentName}. Please include an Input, Select, or other form field as a child.`
-    )
-  }
-  if (!label) {
-    return new Error(`No label found for ${componentName}. Please include a Label as a child.`)
-  }
-}
-
-const propTypes = {
-  children: childrenPropType,
-}
-
 const inputPaddingTop = (size) => {
   return paddingTopWithLabel?.[size] ? paddingTopWithLabel[size] : '20px'
 }
@@ -54,7 +35,7 @@ const labelPaddingTop = (size) => {
   return paddingTopForLabel?.[size] ? paddingTopForLabel[size] : '6px'
 }
 
-const FormField: React.FC<InferProps<typeof propTypes>> = ({ children, ...props }) => {
+const FormField = ({ children, ...props }: IFormFieldProps) => {
   let iconBefore = false
 
   const childrenArray = React.Children.toArray(children)
@@ -113,8 +94,6 @@ const FormField: React.FC<InferProps<typeof propTypes>> = ({ children, ...props 
     </Box>
   )
 }
-
-FormField.propTypes = propTypes
 
 FormField.displayName = 'FormField'
 

--- a/packages/core/src/FormField/index.ts
+++ b/packages/core/src/FormField/index.ts
@@ -1,3 +1,3 @@
-import FormField from './FormField'
+import FormField, { IFormFieldProps } from './FormField'
 
-export { FormField, FormField as InputField }
+export { FormField, FormField as InputField, IFormFieldProps }

--- a/packages/core/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Tooltip, InputField, Box, Flex } from '..'
+import { Box, Flex, FormField, Label, Input, Tooltip } from '..'
+import { Check } from 'pcln-icons'
 import { argTypes } from './Tooltip.stories.args'
 import styled from 'styled-components'
 
@@ -20,13 +21,13 @@ TooltipComponent.args = { color: 'primary' }
 
 export const WithoutAnchors = () => (
   <Box mt={5} width={500}>
-    <Tooltip bg='blue' color='white' top left>
+    <Tooltip color='primary' top left>
       left tooltip
     </Tooltip>
-    <Tooltip bg='black' color='white' top center>
+    <Tooltip color='primary' top center>
       centered tooltip
     </Tooltip>
-    <Tooltip bg='red' color='white' top right>
+    <Tooltip color='error' top right>
       right tooltip
     </Tooltip>
     <br />
@@ -45,94 +46,100 @@ export const WithoutAnchors = () => (
 export const WithAnchors = () => (
   <FlexColumn justifyContent='space-between' wrap='wrap'>
     <Box width={300} p={2} my={2}>
-      <Tooltip top left bg='blue' color='white'>
+      <Tooltip top left color='primary'>
         top left tooltip
       </Tooltip>
       <div>some text</div>
     </Box>
     <Box width={'300px'} p={2} mb={5}>
       <div>some text</div>
-      <Tooltip bottom left bg='red' color='white'>
+      <Tooltip bottom left color='error'>
         bottom left tooltip
       </Tooltip>
     </Box>
     <Box width={'300px'} p={2} mb={55}>
-      <InputField
-        icon='circleInfo'
-        color='blue'
-        label='Email Address'
-        defaultValue='albus.dumbledore@priceline.com'
-        id='form-field-3'
-        placeholder='example@test.com'
-      />
-      <Tooltip bottom left bg='blue' color='white'>
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-3'
+          placeholder='example@test.com'
+        />
+        <Check color='primary' />
+      </FormField>
+      <Tooltip bottom left color='primary'>
         bottom left tooltip
       </Tooltip>
     </Box>
     <Box width={'300px'} p={2} mb={5}>
-      <InputField
-        icon='circleInfo'
-        color='blue'
-        label='Email Address'
-        defaultValue='albus.dumbledore@priceline.com'
-        id='form-field-4'
-        placeholder='example@test.com'
-      />
-      <Tooltip bottom center bg='blue' color='white'>
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-4'
+          placeholder='example@test.com'
+        />
+        <Check color='primary' />
+      </FormField>
+      <Tooltip bottom center color='primary'>
         bottom center tooltip
       </Tooltip>
     </Box>
     <Box width={'300px'} p={2} mb={'80px'}>
-      <InputField
-        icon='circleInfo'
-        color='red'
-        label='Email Address'
-        defaultValue='albus.dumbledore@pr'
-        id='form-field-5'
-        placeholder='example@test.com'
-      />
-      <Tooltip bottom right bg='red' color='white'>
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-5'
+          placeholder='example@test.com'
+        />
+        <Check color='error' />
+      </FormField>
+      <Tooltip bottom right color='error'>
         Email Address Invalid
       </Tooltip>
     </Box>
     <Box width={'300px'} p={2} mb={5}>
-      <Tooltip top left bg='blue' color='white'>
+      <Tooltip top left color='primary'>
         top left tooltip
       </Tooltip>
-      <InputField
-        icon='circleInfo'
-        color='blue'
-        label='Email Address'
-        defaultValue='albus.dumbledore@priceline.com'
-        id='form-field-6'
-        placeholder='example@test.com'
-      />
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-6'
+          placeholder='example@test.com'
+        />
+        <Check color='primary' />
+      </FormField>
     </Box>
     <Box width={'300px'} p={2} mb={5}>
-      <Tooltip top center bg='blue' color='white'>
+      <Tooltip top center color='primary'>
         top center tooltip
       </Tooltip>
-      <InputField
-        icon='circleInfo'
-        color='blue'
-        label='Email Address'
-        defaultValue='albus.dumbledore@priceline.com'
-        id='form-field-7'
-        placeholder='example@test.com'
-      />
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-7'
+          placeholder='example@test.com'
+        />
+        <Check color='primary' />
+      </FormField>
     </Box>
     <Box width={'300px'} p={2}>
-      <Tooltip top right bg='blue' color='white'>
+      <Tooltip top right color='primary'>
         top right tooltip
       </Tooltip>
-      <InputField
-        icon='circleInfo'
-        color='blue'
-        label='Email Address'
-        defaultValue='albus.dumbledore@priceline.com'
-        id='form-field-8'
-        placeholder='example@test.com'
-      />
+      <FormField>
+        <Label>Email Address</Label>
+        <Input
+          defaultValue='albus.dumbledore@priceline.com'
+          id='form-field-8'
+          placeholder='example@test.com'
+        />
+        <Check color='primary' />
+      </FormField>
     </Box>
   </FlexColumn>
 )

--- a/packages/menu/src/Menu/Menu.js
+++ b/packages/menu/src/Menu/Menu.js
@@ -57,13 +57,14 @@ function Menu({
 
   return (
     <Popover
+      aria-controls={id}
       hideArrow
+      idx={id}
+      placement={placement ?? 'bottom-start'}
+      renderContent={MenuContent}
       trapFocus={trapFocus}
       width={width}
       zIndex={1600}
-      placement={placement ?? 'bottom-start'}
-      aria-controls={id}
-      renderContent={MenuContent}
       {...props}
     >
       <ClickableNode />


### PR DESCRIPTION
* Update FormField to use an interface instead of prop types
* Pass id prop to Popover idx prop to fix prop type warning

We have a situation where the label for our FormField needs to be outside of the FormField but then a prop warning gets thrown. a11y is satisfied but we still get the warning. I'm removing the prop check as there are edge cases that make this check incorrect.

Here is the component in question:

https://user-images.githubusercontent.com/62619213/221957723-ebc5990d-8347-4376-8aaa-d88c39509ef8.mov


