### PR TITLE
Add the textStyle prop to the Label component

### DIFF
--- a/common/changes/pcln-design-system/add-textStyles-to-label_2023-03-02-23-45.json
+++ b/common/changes/pcln-design-system/add-textStyles-to-label_2023-03-02-23-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add the textStyle prop to the Label component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -89,7 +89,7 @@ exports[`FormField renders 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize="10px"
+    fontSize={10}
     fontWeight={700}
     htmlFor="email"
     letterSpacing="0.2px"
@@ -250,7 +250,7 @@ exports[`FormField renders with Icon 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize="10px"
+    fontSize={10}
     fontWeight={700}
     htmlFor="email"
     letterSpacing="0.2px"
@@ -432,7 +432,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize="10px"
+    fontSize={10}
     fontWeight={700}
     htmlFor="email"
     letterSpacing="0.2px"
@@ -595,7 +595,7 @@ exports[`FormField renders with Select  1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize="10px"
+    fontSize={10}
     fontWeight={700}
     letterSpacing="0.2px"
     style={
@@ -782,7 +782,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize="10px"
+    fontSize={10}
     fontWeight={700}
     letterSpacing="0.2px"
     style={

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`FormField renders 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -179,7 +179,7 @@ exports[`FormField renders with Icon 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -361,7 +361,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -536,7 +536,7 @@ exports[`FormField renders with Select  1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -722,7 +722,7 @@ exports[`FormField renders with Select and Icon 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -13,20 +13,20 @@ exports[`FormField renders 1`] = `
 }
 
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   margin-left: 12px;
   padding-top: 6px;
   margin-bottom: -20px;
-  font-size: 10px;
-  font-weight: 700;
 }
 
 .c2 {
@@ -89,9 +89,10 @@ exports[`FormField renders 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize={10}
-    fontWeight="bold"
+    fontSize="10px"
+    fontWeight={700}
     htmlFor="email"
+    letterSpacing="0.2px"
     style={
       Object {
         "height": 20,
@@ -172,20 +173,20 @@ exports[`FormField renders with Icon 1`] = `
 }
 
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   margin-left: 40px;
   padding-top: 6px;
   margin-bottom: -20px;
-  font-size: 10px;
-  font-weight: 700;
 }
 
 .c6 {
@@ -249,9 +250,10 @@ exports[`FormField renders with Icon 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize={10}
-    fontWeight="bold"
+    fontSize="10px"
+    fontWeight={700}
     htmlFor="email"
+    letterSpacing="0.2px"
     style={
       Object {
         "height": 20,
@@ -353,20 +355,20 @@ exports[`FormField renders with Label autoHide prop 1`] = `
 }
 
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   margin-left: 40px;
   padding-top: 6px;
   margin-bottom: -20px;
-  font-size: 10px;
-  font-weight: 700;
 }
 
 .c6 {
@@ -430,9 +432,10 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize={10}
-    fontWeight="bold"
+    fontSize="10px"
+    fontWeight={700}
     htmlFor="email"
+    letterSpacing="0.2px"
     style={
       Object {
         "height": 20,
@@ -527,20 +530,20 @@ exports[`FormField renders with Select  1`] = `
 }
 
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   margin-left: 12px;
   padding-top: 6px;
   margin-bottom: -20px;
-  font-size: 10px;
-  font-weight: 700;
 }
 
 .c6 {
@@ -592,8 +595,9 @@ exports[`FormField renders with Select  1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize={10}
-    fontWeight="bold"
+    fontSize="10px"
+    fontWeight={700}
+    letterSpacing="0.2px"
     style={
       Object {
         "height": 20,
@@ -712,20 +716,20 @@ exports[`FormField renders with Select and Icon 1`] = `
 }
 
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   margin-left: 40px;
   padding-top: 6px;
   margin-bottom: -20px;
-  font-size: 10px;
-  font-weight: 700;
 }
 
 .c10 {
@@ -778,8 +782,9 @@ exports[`FormField renders with Select and Icon 1`] = `
   <label
     className="c0"
     color="text.light"
-    fontSize={10}
-    fontWeight="bold"
+    fontSize="10px"
+    fontWeight={700}
+    letterSpacing="0.2px"
     style={
       Object {
         "height": 20,

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -1,17 +1,29 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {
   space,
   fontSize,
   fontWeight,
+  letterSpacing,
+  lineHeight,
+  textStyle,
   width,
   SpaceProps,
   FontSizeProps,
   FontWeightProps,
+  LineHeightProps,
+  TextStyleProps,
   WidthProps,
 } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
+import {
+  applyVariations,
+  getPaletteColor,
+  deprecatedColorValue,
+  textStylesValues,
+  typographyAttrs,
+} from '../utils'
 
 const nowrap = (props) =>
   props.nowrap
@@ -34,14 +46,19 @@ const labelPropTypes = {
   ...propTypes.space,
   ...propTypes.fontSize,
   ...propTypes.fontWeight,
+  ...propTypes.lineHeight,
+  ...propTypes.textStyle,
   ...propTypes.width,
   color: deprecatedColorValue(),
+  textStyle: PropTypes.oneOf(textStylesValues),
 }
 
 export interface ILabelProps
   extends SpaceProps,
     FontSizeProps,
     FontWeightProps,
+    LineHeightProps,
+    TextStyleProps,
     WidthProps,
     Partial<Omit<HTMLLabelElement, 'children'>> {
   children?: React.ReactNode | string
@@ -52,9 +69,7 @@ export interface ILabelProps
   onClick?: (evt: unknown) => void
 }
 
-const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label`
-  font-size: 10px;
-  letter-spacing: 0.2px;
+const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(typographyAttrs)`
   display: block;
   width: 100%;
   margin: 0;
@@ -63,7 +78,15 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label`
   ${(props) => (props.onClick ? 'cursor: pointer;' : '')}
 
   ${applyVariations('Label')}
-  ${space} ${fontSize} ${fontWeight} ${width};
+
+  ${fontSize}
+  ${fontWeight}
+  ${lineHeight}
+  ${letterSpacing}
+  ${space}
+  ${textStyle}
+  ${width}
+
   ${nowrap}
   ${accessiblyHide}
 `
@@ -71,8 +94,7 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label`
 Label.propTypes = labelPropTypes
 
 Label.defaultProps = {
-  fontSize: '10px',
-  fontWeight: 'bold',
+  textStyle: 'label',
   color: 'text.light',
 }
 

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -78,13 +78,13 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(
   ${(props) => (props.onClick ? 'cursor: pointer;' : '')}
 
   ${applyVariations('Label')}
-
+  
+  ${textStyle}
   ${fontSize}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
   ${space}
-  ${textStyle}
   ${width}
 
   ${nowrap}

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -69,7 +69,10 @@ export interface ILabelProps
   onClick?: (evt: unknown) => void
 }
 
-const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(typographyAttrs)`
+const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs((props) => ({
+  ...typographyAttrs(props),
+  ...props,
+}))`
   display: block;
   width: 100%;
   margin: 0;
@@ -79,12 +82,12 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(
 
   ${applyVariations('Label')}
   
-  ${textStyle}
   ${fontSize}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
   ${space}
+  ${textStyle}
   ${width}
 
   ${nowrap}
@@ -94,8 +97,8 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(
 Label.propTypes = labelPropTypes
 
 Label.defaultProps = {
-  textStyle: 'label',
   color: 'text.light',
+  textStyle: 'label',
 }
 
 Label.displayName = 'Label'

--- a/packages/core/src/Label/__snapshots__/Label.spec.tsx.snap
+++ b/packages/core/src/Label/__snapshots__/Label.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Label Label hidden renders 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -38,7 +38,7 @@ exports[`Label Label nowrap renders 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -63,7 +63,7 @@ exports[`Label Label width renders 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;
@@ -90,7 +90,7 @@ exports[`Label it renders 1`] = `
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
-  line-height: 14px;
+  line-height: 1.4;
   -webkit-letter-spacing: 0.2px;
   -moz-letter-spacing: 0.2px;
   -ms-letter-spacing: 0.2px;

--- a/packages/core/src/Label/__snapshots__/Label.spec.tsx.snap
+++ b/packages/core/src/Label/__snapshots__/Label.spec.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`Label Label hidden renders 1`] = `
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   position: absolute;
   width: 1px;
   height: 1px;
@@ -24,24 +24,25 @@ exports[`Label Label hidden renders 1`] = `
   className="c0"
   color="text.light"
   fontSize="10px"
-  fontWeight="bold"
+  fontWeight={700}
   hidden={true}
+  letterSpacing="0.2px"
 />
 `;
 
 exports[`Label Label nowrap renders 1`] = `
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   white-space: nowrap;
 }
 
@@ -49,23 +50,24 @@ exports[`Label Label nowrap renders 1`] = `
   className="c0"
   color="text.light"
   fontSize="10px"
-  fontWeight="bold"
+  fontWeight={700}
+  letterSpacing="0.2px"
 />
 `;
 
 exports[`Label Label width renders 1`] = `
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
   width: 50%;
   white-space: nowrap;
 }
@@ -74,30 +76,32 @@ exports[`Label Label width renders 1`] = `
   className="c0"
   color="text.light"
   fontSize="10px"
-  fontWeight="bold"
+  fontWeight={700}
+  letterSpacing="0.2px"
   width={0.5}
 />
 `;
 
 exports[`Label it renders 1`] = `
 .c0 {
-  font-size: 10px;
-  -webkit-letter-spacing: 0.2px;
-  -moz-letter-spacing: 0.2px;
-  -ms-letter-spacing: 0.2px;
-  letter-spacing: 0.2px;
   display: block;
   width: 100%;
   margin: 0;
   color: #4f6f8f;
   font-size: 10px;
   font-weight: 700;
+  line-height: 14px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
 }
 
 <label
   className="c0"
   color="text.light"
   fontSize="10px"
-  fontWeight="bold"
+  fontWeight={700}
+  letterSpacing="0.2px"
 />
 `;

--- a/packages/core/src/theme/__snapshots__/theme.spec.ts.snap
+++ b/packages/core/src/theme/__snapshots__/theme.spec.ts.snap
@@ -472,7 +472,7 @@ Object {
       "fontSize": "10px",
       "fontWeight": 700,
       "letterSpacing": "0.2px",
-      "lineHeight": "14px",
+      "lineHeight": 1.4,
     },
     "overline": Object {
       "fontSize": "12px",

--- a/packages/core/src/theme/__snapshots__/theme.spec.ts.snap
+++ b/packages/core/src/theme/__snapshots__/theme.spec.ts.snap
@@ -468,6 +468,12 @@ Object {
       "lineHeight": "12px",
       "textTransform": "uppercase",
     },
+    "label": Object {
+      "fontSize": "10px",
+      "fontWeight": 700,
+      "letterSpacing": "0.2px",
+      "lineHeight": "14px",
+    },
     "overline": Object {
       "fontSize": "12px",
       "fontWeight": 700,

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -226,7 +226,7 @@ export const typography = {
   label: {
     fontWeight: 700,
     fontSize: '10px',
-    lineHeight: '14px',
+    lineHeight: 1.4,
     letterSpacing: '0.2px',
   },
 }

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -223,6 +223,12 @@ export const typography = {
     lineHeight: '16px',
     letterSpacing: '0.013rem',
   },
+  label: {
+    fontWeight: 700,
+    fontSize: '10px',
+    lineHeight: '14px',
+    letterSpacing: '0.2px',
+  },
 }
 
 // styled-system's `borderRadius` function can hook into the `radii` object/array
@@ -256,10 +262,14 @@ export const borderRadii = {
 export const maxContainerWidth = '1280px'
 
 export const shadows = {
-  sm: '0 -1px 0 0 rgba(0,0,0,0.03),0 0 1px 0 rgba(0,0,0,0.24),0 2px 1px -1px rgba(0,0,0,0.16),0 2px 4px 0 rgba(0,0,0,0.12)',
-  md: '0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16)',
-  lg: '0 -1px 0 0 rgba(0,0,0,0.03),0 1px 4px 0 rgba(0,0,0,0.2),0 6px 4px -4px rgba(0,0,0,0.12),0 8px 16px -1px rgba(0,0,0,0.16)',
-  xl: '0 -1px 0 0 rgba(0,0,0,0.03),0 2px 8px 0 rgba(0,0,0,0.16),0 10px 8px -5px rgba(0,0,0,0.16),0 12px 32px -2px rgba(0,0,0,0.16)',
+  sm:
+    '0 -1px 0 0 rgba(0,0,0,0.03),0 0 1px 0 rgba(0,0,0,0.24),0 2px 1px -1px rgba(0,0,0,0.16),0 2px 4px 0 rgba(0,0,0,0.12)',
+  md:
+    '0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16)',
+  lg:
+    '0 -1px 0 0 rgba(0,0,0,0.03),0 1px 4px 0 rgba(0,0,0,0.2),0 6px 4px -4px rgba(0,0,0,0.12),0 8px 16px -1px rgba(0,0,0,0.16)',
+  xl:
+    '0 -1px 0 0 rgba(0,0,0,0.03),0 2px 8px 0 rgba(0,0,0,0.16),0 10px 8px -5px rgba(0,0,0,0.16),0 12px 32px -2px rgba(0,0,0,0.16)',
   '2xl':
     '0 -1px 0 0 rgba(0,0,0,0.03),0 4px 12px 0 rgba(0,0,0,0.16),0 12px 12px -4px rgba(0,0,0,0.16),0 24px 64px -2px rgba(0,0,0,0.16)',
   'overlay-md':

--- a/packages/core/src/utils/attrs/__snapshots__/typographyAttrs.spec.ts.snap
+++ b/packages/core/src/utils/attrs/__snapshots__/typographyAttrs.spec.ts.snap
@@ -164,7 +164,7 @@ Object {
   "fontSize": "10px",
   "fontWeight": 700,
   "letterSpacing": "0.2px",
-  "lineHeight": "14px",
+  "lineHeight": 1.4,
 }
 `;
 

--- a/packages/core/src/utils/attrs/__snapshots__/typographyAttrs.spec.ts.snap
+++ b/packages/core/src/utils/attrs/__snapshots__/typographyAttrs.spec.ts.snap
@@ -159,6 +159,15 @@ Object {
 }
 `;
 
+exports[`typographyAttrs works with and textStyle=label 1`] = `
+Object {
+  "fontSize": "10px",
+  "fontWeight": 700,
+  "letterSpacing": "0.2px",
+  "lineHeight": "14px",
+}
+`;
+
 exports[`typographyAttrs works with and textStyle=overline 1`] = `
 Object {
   "fontSize": "12px",

--- a/packages/core/src/utils/attrs/typographyAttrs.ts
+++ b/packages/core/src/utils/attrs/typographyAttrs.ts
@@ -29,6 +29,7 @@ export const textStylesValues = [
   'subheading4',
   'subheading5',
   'subheading6',
+  'label',
 ]
 
 export function typographyAttrs(props) {


### PR DESCRIPTION
Wes explained to me that we need different label text styles for different situations. For example, a form checkbox vs filter checkboxes, they both use labels but they need to be styled differently. This is a perfect use case for textStyles, I just needed to add support for them to the Label component.