### PR TITLE
Fix bug in change analyzer when comparing against main

### DIFF
--- a/tools/project-change-analyzer/src/getChangedProjects/getChangedProjects.ts
+++ b/tools/project-change-analyzer/src/getChangedProjects/getChangedProjects.ts
@@ -32,11 +32,11 @@ function getPackagesWithDirectChanges(targetBranchName): string[] {
     rushConfiguration.tryGetProjectForPath(join(rushConfiguration.rushJsonFolder, name as string))
   )
 
-  return Array.from(projects.map((project) => project.packageName))
+  return Array.from(projects.map((project) => project?.packageName)).filter(Boolean)
 }
 
 /** @public */
-export async function runAsync(targetBranchName = 'refs/remotes/origin/main'): Promise<void> {
+export async function runAsync(targetBranchName = 'refs/remotes/origin/v4'): Promise<void> {
   const terminal: Terminal = new Terminal(new ConsoleTerminalProvider())
 
   const changedProjects = getPackagesWithDirectChanges(targetBranchName)


### PR DESCRIPTION
I think the issue is that we were comparing against the wrong branch when detecting changes. I also added a filter just to be safe.