### PR TITLE
Fix responsive styles when using custom breakpoints

### DIFF
--- a/apps/docs/src/NavLink.js
+++ b/apps/docs/src/NavLink.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import NextLink from 'next/link'
-import { space, color } from 'styled-system'
+import { space, color, compose } from 'styled-system'
 import { createTheme } from 'pcln-design-system'
 import { withDocs } from 'mdx-docs'
 import isAbsoluteURL from 'is-absolute-url'
@@ -12,7 +12,7 @@ const Base = styled.a`
   display: block;
   text-decoration: none;
   font-size: ${theme.fontSizes['2']}px;
-  ${space} ${color} &:hover {
+  &:hover {
     color: ${theme.colors.text};
   }
   &.active {
@@ -22,6 +22,8 @@ const Base = styled.a`
     margin-left: -16px;
     padding-left: 28px;
   }
+
+  ${(props) => compose(space, color)(props)}
 `
 Base.defaultProps = {
   pl: 3,

--- a/common/changes/pcln-design-system/fix-responsive-styles_2023-03-21-16-22.json
+++ b/common/changes/pcln-design-system/fix-responsive-styles_2023-03-21-16-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix bug when using customBreakpoints with responsive style props",
+      "type": "patch",
+      "packageName": "pcln-design-system"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-icons/fix-responsive-styles_2023-03-21-16-22.json
+++ b/common/changes/pcln-icons/fix-responsive-styles_2023-03-21-16-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix bug when using customBreakpoints with responsive style props",
+      "type": "patch",
+      "packageName": "pcln-icons"
+    }
+  ],
+  "packageName": "pcln-icons",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-modal/fix-responsive-styles_2023-03-21-16-22.json
+++ b/common/changes/pcln-modal/fix-responsive-styles_2023-03-21-16-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix bug when using customBreakpoints with responsive style props",
+      "type": "patch",
+      "packageName": "pcln-modal"
+    }
+  ],
+  "packageName": "pcln-modal",
+  "email": "craig.palermo@priceline.com"
+}

--- a/common/changes/pcln-popover/fix-responsive-styles_2023-03-21-16-22.json
+++ b/common/changes/pcln-popover/fix-responsive-styles_2023-03-21-16-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix bug when using customBreakpoints with responsive style props",
+      "type": "patch",
+      "packageName": "pcln-popover"
+    }
+  ],
+  "packageName": "pcln-popover",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/core/src/Absolute/Absolute.tsx
+++ b/packages/core/src/Absolute/Absolute.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
-import { top, right, bottom, left, zIndex } from 'styled-system'
+import { top, right, bottom, left, zIndex, compose } from 'styled-system'
 
 import { Box } from '../Box'
 
 const Absolute = styled(Box)`
   position: absolute;
-  ${top} ${bottom} ${left} ${right}
-  ${zIndex}
+
+  ${(props) => compose(top, bottom, left, right, zIndex)(props)}
 `
 
 Absolute.propTypes = {

--- a/packages/core/src/Avatar/__snapshots__/Avatar.spec.tsx.snap
+++ b/packages/core/src/Avatar/__snapshots__/Avatar.spec.tsx.snap
@@ -14,12 +14,12 @@ exports[`Avatar renders default 1`] = `
 }
 
 .c1 {
-  min-width: 40px;
-  width: 40px;
-  height: 40px;
-  padding: 8px;
   background-color: #0068ef;
   color: #fff;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  padding: 8px;
 }
 
 .c0 {
@@ -79,12 +79,12 @@ exports[`Avatar renders default 1`] = `
 
 exports[`Avatar renders initials 1`] = `
 .c1 {
-  min-width: 40px;
-  width: 40px;
-  height: 40px;
-  padding: 8px;
   background-color: #0068ef;
   color: #fff;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  padding: 8px;
 }
 
 .c0 {
@@ -139,12 +139,12 @@ exports[`Avatar renders initials 1`] = `
 exports[`Avatar renders mr elon 1`] = `
 <DocumentFragment>
   .c2 {
-  min-width: 40px;
-  width: 40px;
-  height: 40px;
-  padding: 8px;
   background-color: #0068ef;
   color: #fff;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  padding: 8px;
 }
 
 .c4 {
@@ -163,13 +163,13 @@ exports[`Avatar renders mr elon 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c6 {

--- a/packages/core/src/BackgroundImage/BackgroundImage.tsx
+++ b/packages/core/src/BackgroundImage/BackgroundImage.tsx
@@ -1,7 +1,15 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
-import { width, height, borderRadius, WidthProps, HeightProps, BorderRadiusProps } from 'styled-system'
+import {
+  width,
+  height,
+  borderRadius,
+  WidthProps,
+  HeightProps,
+  BorderRadiusProps,
+  compose,
+} from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import {
   getPaletteColor,
@@ -50,7 +58,9 @@ const BackgroundImage: React.FC<IBackgroundImageProps> = styled.div.attrs(border
   background-repeat: no-repeat;
   background-color: ${getPaletteColor('border.light')};
   ${applyVariations('BackgroundImage', variations)}
-  ${image} ${height} ${width} ${borderRadius};
+  ${image} 
+
+  ${(props) => compose(height, width, borderRadius)(props)}
 `
 
 BackgroundImage.propTypes = backgroundImagePropTypes

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import themeGet from '@styled-system/theme-get'
 import { applySizes, applyVariations, color, deprecatedColorValue, borderRadiusAttrs } from '../utils'
-import { space, borderRadius, SpaceProps } from 'styled-system'
+import { space, borderRadius, SpaceProps, compose } from 'styled-system'
 
 const type = (props) => {
   const badgeColors = {
@@ -70,9 +70,9 @@ const Badge: React.FC<IBadgeProps> = styled.div.attrs(borderRadiusAttrs)`
   letter-spacing: ${themeGet('letterSpacings.caps')};
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Badge')};
-  ${space} ${type} ${color};
+  ${type} ${color};
 
-  ${borderRadius}
+  ${(props) => compose(space, borderRadius)(props)}
 `
 
 Badge.displayName = 'Badge'

--- a/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -17,13 +17,13 @@ exports[`Badge bg blue sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #0068ef;
+  color: #fff;
+  background-color: #0068ef;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #0068ef;
-  color: #fff;
-  background-color: #0068ef;
   border-radius: 9999px;
 }
 
@@ -50,13 +50,13 @@ exports[`Badge bg green sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #0a0;
+  color: #fff;
+  background-color: #0a0;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #0a0;
-  color: #fff;
-  background-color: #0a0;
   border-radius: 9999px;
 }
 
@@ -83,13 +83,13 @@ exports[`Badge bg lightBlue sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #e8f2ff;
+  color: #049;
+  background-color: #e8f2ff;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #e8f2ff;
-  color: #049;
-  background-color: #e8f2ff;
   border-radius: 9999px;
 }
 
@@ -116,13 +116,13 @@ exports[`Badge bg lightGreen sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #ecf7ec;
+  color: #060;
+  background-color: #ecf7ec;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #ecf7ec;
-  color: #060;
-  background-color: #ecf7ec;
   border-radius: 9999px;
 }
 
@@ -149,13 +149,13 @@ exports[`Badge bg lightRed sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #fbebeb;
+  color: #800;
+  background-color: #fbebeb;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #fbebeb;
-  color: #800;
-  background-color: #fbebeb;
   border-radius: 9999px;
 }
 
@@ -182,13 +182,13 @@ exports[`Badge bg orange sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #f68013;
+  color: #001833;
+  background-color: #f68013;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #f68013;
-  color: #001833;
-  background-color: #f68013;
   border-radius: 9999px;
 }
 
@@ -215,13 +215,13 @@ exports[`Badge bg red sets background-color and color 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #c00;
+  color: #fff;
+  background-color: #c00;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #c00;
-  color: #fff;
-  background-color: #c00;
   border-radius: 9999px;
 }
 
@@ -248,12 +248,12 @@ exports[`Badge can escape preset: bg lightBlue sets background-color and color t
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #e8f2ff;
+  color: #001833;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #e8f2ff;
-  color: #001833;
   border-radius: 9999px;
 }
 
@@ -281,12 +281,12 @@ exports[`Badge non-preset: bg text sets background-color and color white sets co
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #001833;
+  color: #fff;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #001833;
-  color: #fff;
   border-radius: 9999px;
 }
 
@@ -314,12 +314,12 @@ exports[`Badge renders 1`] = `
   letter-spacing: 0.025em;
   text-transform: uppercase;
   line-height: 1.4;
+  background-color: #f4f6f8;
+  color: #001833;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #f4f6f8;
-  color: #001833;
   border-radius: 9999px;
 }
 
@@ -341,12 +341,12 @@ exports[`Badge renders small 1`] = `
   font-weight: 700;
   line-height: 1.4;
   line-height: 1.25;
+  background-color: #f4f6f8;
+  color: #001833;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #f4f6f8;
-  color: #001833;
   border-radius: 9999px;
 }
 

--- a/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Banner accepts non-preset colors 1`] = `
 .c0 {
-  text-align: left;
   background-color: #4f6f8f;
   color: #0a0;
+  text-align: left;
 }
 
 .c2 {
@@ -17,14 +17,14 @@ exports[`Banner accepts non-preset colors 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 {
@@ -67,9 +67,9 @@ exports[`Banner renders content from children props 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -82,14 +82,14 @@ exports[`Banner renders content from children props 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -151,9 +151,9 @@ exports[`Banner renders with blue bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #0068ef;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -166,14 +166,14 @@ exports[`Banner renders with blue bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -232,9 +232,9 @@ exports[`Banner renders with custom iconName and size 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -247,14 +247,14 @@ exports[`Banner renders with custom iconName and size 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -313,9 +313,9 @@ exports[`Banner renders with green bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -328,14 +328,14 @@ exports[`Banner renders with green bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -395,9 +395,9 @@ exports[`Banner renders with header node 1`] = `
 }
 
 .c1 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
+  text-align: left;
 }
 
 .c5 {
@@ -410,14 +410,14 @@ exports[`Banner renders with header node 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c6 {
@@ -502,9 +502,9 @@ exports[`Banner renders with lightBlue bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #e8f2ff;
   color: #049;
+  text-align: left;
 }
 
 .c4 {
@@ -517,14 +517,14 @@ exports[`Banner renders with lightBlue bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -583,9 +583,9 @@ exports[`Banner renders with lightGreen bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #ecf7ec;
   color: #060;
+  text-align: left;
 }
 
 .c4 {
@@ -598,14 +598,14 @@ exports[`Banner renders with lightGreen bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -664,9 +664,9 @@ exports[`Banner renders with lightRed bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #fbebeb;
   color: #800;
+  text-align: left;
 }
 
 .c4 {
@@ -679,14 +679,14 @@ exports[`Banner renders with lightRed bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -745,9 +745,9 @@ exports[`Banner renders with no props other than theme 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -760,14 +760,14 @@ exports[`Banner renders with no props other than theme 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -826,9 +826,9 @@ exports[`Banner renders with orange bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #f68013;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -841,14 +841,14 @@ exports[`Banner renders with orange bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -907,9 +907,9 @@ exports[`Banner renders with red bg 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: #c00;
   color: #fff;
+  text-align: left;
 }
 
 .c4 {
@@ -922,14 +922,14 @@ exports[`Banner renders with red bg 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -988,9 +988,9 @@ exports[`Banner renders with text node 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: secondary.base;
   color: text.lightest;
+  text-align: left;
 }
 
 .c4 {
@@ -1003,14 +1003,14 @@ exports[`Banner renders with text node 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {
@@ -1086,9 +1086,9 @@ exports[`Banner renders with text string 1`] = `
 }
 
 .c0 {
-  text-align: left;
   background-color: secondary.base;
   color: text.lightest;
+  text-align: left;
 }
 
 .c4 {
@@ -1101,14 +1101,14 @@ exports[`Banner renders with text string 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c5 {

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -26,6 +26,7 @@ import {
   SpaceProps,
   TextAlignProps,
   WidthProps,
+  compose,
 } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 
@@ -122,13 +123,23 @@ const Box: React.FC<InferProps<typeof boxPropTypes>> = styled.div.attrs((props) 
   ...boxShadowAttrs(props),
 }))`
   ${applyVariations('Box')}
-  ${display} ${height} ${maxHeight} ${maxWidth}
-  ${minHeight} ${minWidth} ${size} ${space} 
-  ${textAlign} ${width} 
   ${color}
 
-  ${borderRadius}
-  ${boxShadow}
+  ${(props) =>
+    compose(
+      width,
+      display,
+      height,
+      maxHeight,
+      maxWidth,
+      minHeight,
+      minWidth,
+      size,
+      space,
+      textAlign,
+      borderRadius,
+      boxShadow
+    )(props)}
 `
 
 Box.displayName = 'Box'

--- a/packages/core/src/Box/__snapshots__/Box.spec.tsx.snap
+++ b/packages/core/src/Box/__snapshots__/Box.spec.tsx.snap
@@ -62,8 +62,8 @@ exports[`Box renders 1`] = `
 
 exports[`Box width and height props set width/height 1`] = `
 .c0 {
-  height: 50%;
   width: 50%;
+  height: 50%;
 }
 
 <div

--- a/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
+++ b/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
@@ -113,9 +113,9 @@ exports[`Breadcrumbs renders with icons 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #4f6f8f;
   margin-right: 8px;
   width: 16px;
-  color: #4f6f8f;
 }
 
 .c7 {
@@ -123,9 +123,9 @@ exports[`Breadcrumbs renders with icons 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #001023;
   margin-right: 8px;
   width: 16px;
-  color: #001023;
 }
 
 .c6 {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -10,6 +10,7 @@ import {
   WidthProps,
   SpaceProps,
   BoxShadowProps,
+  compose,
 } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import { themeGet } from '@styled-system/theme-get'
@@ -169,39 +170,9 @@ const variations = {
     width: 100%;
 
     ${(props) => borders({ ...props, color: undefined })}
-    ${space} ${fontSize} ${borderRadius};
+    ${(props) => compose(space, fontSize, borderRadius)(props)}
   `,
 }
-
-export const buttonStyles = css`
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  vertical-align: middle;
-  text-align: center;
-  text-decoration: none;
-  font-family: inherit;
-  font-weight: ${(props) => props.theme.fontWeights.bold};
-  line-height: 1.5;
-  cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
-  border-radius: ${(props) =>
-    themeGet(`borderRadii.${isValidBorderRadius(props.borderRadius) ? props.borderRadius : 'action-md'}`)(
-      props
-    )};
-  border-width: 0;
-  border-style: solid;
-
-  ${({ theme }) => applySizes(sizes, 'medium', theme.mediaQueries)};
-  ${applyVariations('Button', variations)};
-  ${width};
-  ${space};
-  ${boxShadow}
-
-  &:disabled {
-    cursor: not-allowed;
-    color: ${getPaletteColor('text.light')};
-    background-color: ${getPaletteColor('background.base')};
-  }
-`
 
 const buttonPropTypes = {
   ...propTypes.width,
@@ -233,6 +204,33 @@ export interface IButtonProps
   onMouseEnter?: (unknown) => unknown
 }
 
+export const buttonStyles = css`
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: ${(props) => props.theme.fontWeights.bold};
+  line-height: 1.5;
+  cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
+  border-radius: ${(props) =>
+    themeGet(`borderRadii.${isValidBorderRadius(props.borderRadius) ? props.borderRadius : 'action-md'}`)(
+      props
+    )};
+  border-width: 0;
+  border-style: solid;
+
+  ${({ theme }) => applySizes(sizes, 'medium', theme.mediaQueries)};
+  ${applyVariations('Button', variations)};
+
+  &:disabled {
+    cursor: not-allowed;
+    color: ${getPaletteColor('text.light')};
+    background-color: ${getPaletteColor('background.base')};
+  }
+`
+
 /**
  * Use the <Button /> component to render a primitive button. Use the `variation` prop to change the look of the button.
  */
@@ -246,6 +244,8 @@ const Button: React.FC<IButtonProps> = styled.button.attrs((props) => {
   }
 })`
   ${buttonStyles}
+
+  ${(props) => compose(width, space, boxShadow)(props)}
 `
 
 Button.propTypes = buttonPropTypes

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { space, fontSize } from 'styled-system'
+import { space, fontSize, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 import { getPaletteColor, applySizes } from '../utils'
 import { Box, IBoxProps } from '../Box'
@@ -73,8 +73,8 @@ const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
   border-radius: 2px;
   white-space: nowrap;
   ${({ theme, hasChildren }) => applySizes(getSizes({ hasChildren }), undefined, theme.mediaQueries)};
-  ${space};
-  ${fontSize};
+
+  ${(props) => compose(space, fontSize)(props)}
 `
 
 export { ChipContentWrapper }

--- a/packages/core/src/Divider/Divider.tsx
+++ b/packages/core/src/Divider/Divider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
-import { space, width, SpaceProps, WidthProps, BorderColorProps } from 'styled-system'
+import { space, width, SpaceProps, WidthProps, BorderColorProps, compose } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 
 const dividerPropTypes = {
@@ -25,7 +25,8 @@ const Divider: React.FC<IDividerProps> = styled.hr.attrs(({ mx, ml, mr }) => ({
   border-color: ${(props) => getPaletteColor(props.borderColor || props.color, 'base')(props)};
   background-color: ${(props) => getPaletteColor(props.borderColor || props.color, 'base')(props)};
   ${applyVariations('Divider')}
-  ${space} ${width};
+
+  ${(props) => compose(space, width)(props)}
 `
 
 Divider.displayName = 'Divider'

--- a/packages/core/src/Divider/__snapshots__/Divider.spec.tsx.snap
+++ b/packages/core/src/Divider/__snapshots__/Divider.spec.tsx.snap
@@ -59,9 +59,9 @@ exports[`Divider width prop sets width 1`] = `
   border-bottom-width: 1px;
   border-color: #c0cad5;
   background-color: #c0cad5;
+  width: 50%;
   margin-left: 0px;
   margin-right: 0px;
-  width: 50%;
 }
 
 <hr

--- a/packages/core/src/Flag/__snapshots__/Flag.spec.tsx.snap
+++ b/packages/core/src/Flag/__snapshots__/Flag.spec.tsx.snap
@@ -6,24 +6,24 @@ exports[`Flag renders 1`] = `
 }
 
 .c4 {
+  color: #0a0;
+  width: 4px;
   margin-right: -8px;
   margin-bottom: -8px;
-  width: 4px;
-  color: #0a0;
 }
 
 .c6 {
+  background-color: #0a0;
+  color: #fff;
   padding-left: 4px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #0a0;
-  color: #fff;
 }
 
 .c8 {
-  margin-left: -8px;
-  width: 18px;
   color: #0a0;
+  width: 18px;
+  margin-left: -8px;
 }
 
 .c1 {
@@ -116,29 +116,29 @@ exports[`Flag renders 1`] = `
 
 exports[`Flag renders with theme color as bg color 1`] = `
 .c0 {
-  margin-left: 0px;
   width: 256px;
+  margin-left: 0px;
 }
 
 .c4 {
+  color: #70b;
+  width: 4px;
   margin-right: -8px;
   margin-bottom: -8px;
-  width: 4px;
-  color: #70b;
 }
 
 .c6 {
+  background-color: #70b;
+  color: #fff;
   padding-left: 4px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #70b;
-  color: #fff;
 }
 
 .c8 {
-  margin-left: -8px;
-  width: 18px;
   color: #70b;
+  width: 18px;
+  margin-left: -8px;
 }
 
 .c1 {
@@ -235,29 +235,29 @@ exports[`Flag renders with theme color as bg color 1`] = `
 
 exports[`Flag renders with width prop 1`] = `
 .c0 {
-  margin-left: 0px;
   width: 256px;
+  margin-left: 0px;
 }
 
 .c4 {
+  color: #0a0;
+  width: 4px;
   margin-right: -8px;
   margin-bottom: -8px;
-  width: 4px;
-  color: #0a0;
 }
 
 .c6 {
+  background-color: #0a0;
+  color: #fff;
   padding-left: 4px;
   padding-top: 4px;
   padding-bottom: 4px;
-  background-color: #0a0;
-  color: #fff;
 }
 
 .c8 {
-  margin-left: -8px;
-  width: 18px;
   color: #0a0;
+  width: 18px;
+  margin-left: -8px;
 }
 
 .c1 {

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -12,6 +12,7 @@ import {
   SpaceProps,
   WidthProps,
   AlignContentProps,
+  compose,
 } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 
@@ -48,9 +49,8 @@ const Flex: React.FC<IFlexProps> = styled(Box).attrs(({ wrap, align, justify, ..
 }))`
   display: flex;
   ${applyVariations('Flex')}
-  ${alignItems} ${justifyContent}
-  ${flexDirection}
-  ${flexWrap}
+
+  ${(props) => compose(alignItems, justifyContent, flexDirection, flexWrap)(props)}
 `
 
 Flex.propTypes = flexPropTypes

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -203,9 +203,9 @@ exports[`FormField renders with Icon 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  padding-left: 40px;
   font-size: 16px;
   border-radius: 12px;
+  padding-left: 40px;
 }
 
 .c6::-webkit-input-placeholder {
@@ -385,9 +385,9 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  padding-left: 40px;
   font-size: 16px;
   border-radius: 12px;
+  padding-left: 40px;
 }
 
 .c6::-webkit-input-placeholder {
@@ -505,9 +505,9 @@ exports[`FormField renders with Select  1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #4f6f8f;
   margin-left: -32px;
   width: 24px;
-  color: #4f6f8f;
 }
 
 .c5 {
@@ -564,19 +564,19 @@ exports[`FormField renders with Select  1`] = `
   border-style: solid;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
-  margin: 0px;
   font-size: 16px;
+  margin: 0px;
   border-radius: 12px;
+}
+
+.c3::-ms-expand {
+  display: none;
 }
 
 .c3:focus {
   outline: 0;
   border-color: #0068ef;
   box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c3::-ms-expand {
-  display: none;
 }
 
 @media screen and (min-width:32em) {
@@ -676,9 +676,9 @@ exports[`FormField renders with Select and Icon 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #4f6f8f;
   margin-left: -32px;
   width: 24px;
-  color: #4f6f8f;
 }
 
 .c9 {
@@ -751,19 +751,19 @@ exports[`FormField renders with Select and Icon 1`] = `
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
   padding-left: 40px;
-  margin: 0px;
   font-size: 16px;
+  margin: 0px;
   border-radius: 12px;
+}
+
+.c7::-ms-expand {
+  display: none;
 }
 
 .c7:focus {
   outline: 0;
   border-color: #0068ef;
   box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c7::-ms-expand {
-  display: none;
 }
 
 @media screen and (min-width:32em) {

--- a/packages/core/src/GenericBanner/__snapshots__/GenericBanner.spec.tsx.snap
+++ b/packages/core/src/GenericBanner/__snapshots__/GenericBanner.spec.tsx.snap
@@ -16,10 +16,10 @@ exports[`GenericBanner renders 1`] = `
 }
 
 .c1 {
-  text-align: left;
   background-color: #0a0;
   color: #fff;
   border-radius: 6px;
+  text-align: left;
 }
 
 .c6 {
@@ -37,14 +37,14 @@ exports[`GenericBanner renders 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c8 {

--- a/packages/core/src/Hug/__snapshots__/Hug.spec.tsx.snap
+++ b/packages/core/src/Hug/__snapshots__/Hug.spec.tsx.snap
@@ -12,10 +12,10 @@ exports[`Hug renders with border-radius from theme on top only 1`] = `
 }
 
 .c3 {
-  padding: 8px;
-  padding-left: 12px;
   background-color: #fff;
   color: #001833;
+  padding: 8px;
+  padding-left: 12px;
 }
 
 .c4 {

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { space, fontSize, borderRadius, SpaceProps, FontSizeProps } from 'styled-system'
+import { space, fontSize, borderRadius, SpaceProps, FontSizeProps, compose } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import PropTypes from 'prop-types'
 import { Text, ITextProps } from '../Text'
@@ -49,7 +49,9 @@ const StyledInput = styled.input.attrs(borderRadiusAttrs)`
 
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Input')}
-  ${borders} ${space} ${fontSize} ${borderRadius};
+  ${borders}
+
+  ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
 const INPUT_ERROR_TEXT = 'InputHelperText'

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -20,10 +20,12 @@ export interface IInputGroupProps extends SpaceProps {
 const InputGroup: React.FC<IInputGroupProps> = styled.div`
   display: flex;
   align-items: center;
-  border-radius: ${themeGet('radius')};
+  border-radius: ${themeGet('borderRadii.xl')};
   border-width: 1px;
   border-style: solid;
-  border-color: ${(props) => getPaletteColor(props.borderColor, 'base')(props)} ${space} & > ${Box} {
+  border-color: ${(props) => getPaletteColor(props.borderColor, 'base')(props)};
+
+  & > ${Box} {
     width: 100%;
     flex: 1 1 auto;
   }
@@ -32,6 +34,8 @@ const InputGroup: React.FC<IInputGroupProps> = styled.div`
     border: 0;
     box-shadow: none;
   }
+
+  ${space}
 `
 
 InputGroup.propTypes = inputGroupPropTypes

--- a/packages/core/src/InputGroup/__snapshots__/InputGroup.spec.tsx.snap
+++ b/packages/core/src/InputGroup/__snapshots__/InputGroup.spec.tsx.snap
@@ -11,9 +11,10 @@ exports[`InputGroup renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 2px;
+  border-radius: 16px;
   border-width: 1px;
   border-style: solid;
+  border-color: #c0cad5;
 }
 
 .c1 input {

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { width, space, WidthProps, SpaceProps } from 'styled-system'
+import { width, space, WidthProps, SpaceProps, compose } from 'styled-system'
 
 import { buttonStyles } from '../Button'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
@@ -65,7 +65,6 @@ const Link: React.FC<ILinkProps> = styled.a.attrs(({ color, disabled, href, targ
   ...props,
 }))`
   ${applyVariations('Link', variations)}
-  ${width} ${space};
 
   ${(props) =>
     props.disabled &&
@@ -76,6 +75,8 @@ const Link: React.FC<ILinkProps> = styled.a.attrs(({ color, disabled, href, targ
       text-decoration: none;
     }
   `}
+
+  ${(props) => compose(space, width)(props)}
 `
 
 Link.displayName = 'Link'

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { fontSize, space, width } from 'styled-system'
+import { fontSize, space, width, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 import { getPaletteColor } from '../utils'
 
@@ -11,9 +11,7 @@ const BaseCSS = css`
     margin: ${themeGet('space.1')} 0;
   }
 
-  ${fontSize};
-  ${space};
-  ${width};
+  ${(props) => compose(fontSize, space, width)(props)}
 `
 
 const Ordered = styled('ol')`

--- a/packages/core/src/RatingBadge/RatingBadge.tsx
+++ b/packages/core/src/RatingBadge/RatingBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { InferProps } from 'prop-types'
-import { fontWeight, borderRadius } from 'styled-system'
+import { fontWeight, borderRadius, compose } from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import { Box } from '../Box'
 import { deprecatedColorValue, borderRadiusAttrs } from '../utils'
@@ -45,7 +45,7 @@ const RatingBadge: React.FC<InferProps<typeof ratingBadgePropTypes>> = styled(Bo
 }))`
   display: inline-block;
   line-height: 1.5;
-  ${fontWeight} ${borderRadius};
+  ${(props) => compose(fontWeight, borderRadius)(props)}
 `
 
 RatingBadge.defaultProps = defaultProps

--- a/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.tsx.snap
+++ b/packages/core/src/RatingBadge/__snapshots__/RatingBadge.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`RatingBadge renders 1`] = `
 <DocumentFragment>
   .c1 {
-  padding-left: 8px;
-  padding-right: 8px;
   background-color: #f68013;
   color: #fff;
+  padding-left: 8px;
+  padding-right: 8px;
   border-radius: 8px;
 }
 

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { InferProps } from 'prop-types'
 import styled, { css } from 'styled-components'
-import { space, fontSize, borderRadius, SpaceProps, FontSizeProps } from 'styled-system'
+import { space, fontSize, borderRadius, SpaceProps, FontSizeProps, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 import { ChevronDown } from 'pcln-icons'
 import { borders, deprecatedColorValue, applySizes, borderRadiusAttrs } from '../utils'
@@ -42,11 +42,15 @@ const SelectBase: React.FC<InferProps<typeof propTypes>> = styled.select.attrs(b
   border-width: 1px;
   border-style: solid;
 
-  ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
-  ${borders} ${space} ${fontSize} ${borderRadius}
   ::-ms-expand {
     display: none;
   }
+
+  ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
+
+  ${borders}
+
+  ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
 SelectBase.defaultProps = {

--- a/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
@@ -6,9 +6,9 @@ exports[`Select renders 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #4f6f8f;
   margin-left: -32px;
   width: 24px;
-  color: #4f6f8f;
 }
 
 .c4 {
@@ -48,19 +48,19 @@ exports[`Select renders 1`] = `
   border-style: solid;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
-  margin: 0px;
   font-size: 16px;
+  margin: 0px;
   border-radius: 12px;
+}
+
+.c2::-ms-expand {
+  display: none;
 }
 
 .c2:focus {
   outline: 0;
   border-color: #0068ef;
   box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c2::-ms-expand {
-  display: none;
 }
 
 @media screen and (min-width:32em) {

--- a/packages/core/src/Stamp/Stamp.tsx
+++ b/packages/core/src/Stamp/Stamp.tsx
@@ -1,7 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { space, fontSize, borderRadius, SpaceProps, FontSizeProps, BorderRadiusProps } from 'styled-system'
+import {
+  space,
+  fontSize,
+  borderRadius,
+  SpaceProps,
+  FontSizeProps,
+  BorderRadiusProps,
+  compose,
+} from 'styled-system'
 import propTypes from '@styled-system/prop-types'
 import themeGet from '@styled-system/theme-get'
 import {
@@ -89,7 +97,8 @@ const Stamp: React.FC<IStampPropTypes> = styled.div.attrs(borderRadiusAttrs)`
 
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Stamp', variations)};
-  ${space} ${fontSize} ${borderRadius};
+
+  ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
 Stamp.displayName = 'Stamp'

--- a/packages/core/src/Step/__snapshots__/Step.spec.tsx.snap
+++ b/packages/core/src/Step/__snapshots__/Step.spec.tsx.snap
@@ -100,9 +100,9 @@ exports[`Step should render a completed step correctly 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #0068ef;
   margin-right: 4px;
   width: 16px;
-  color: #0068ef;
 }
 
 .c4 {
@@ -224,9 +224,9 @@ exports[`Step should render a step that is "active" and "completed" correctly 1`
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #0068ef;
   margin-right: 4px;
   width: 16px;
-  color: #0068ef;
 }
 
 .c4 {

--- a/packages/core/src/Stepper/__snapshots__/Stepper.spec.tsx.snap
+++ b/packages/core/src/Stepper/__snapshots__/Stepper.spec.tsx.snap
@@ -6,9 +6,9 @@ exports[`Stepper renders with children 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  color: #0068ef;
   margin-right: 4px;
   width: 16px;
-  color: #0068ef;
 }
 
 .c5 {

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -35,6 +35,7 @@ import {
   TextStyleProps,
   WidthProps,
   ZIndexProps,
+  compose,
 } from 'styled-system'
 
 import {
@@ -129,30 +130,33 @@ const textProps: React.FC<ITextProps> = css`
   color: ${getPaletteColor('base')};
   ${(props) => (props.bg ? `background-color: ${getPaletteColor(props.bg, 'base')(props)};` : '')}
 
-  ${display}
-  ${height}
-  ${maxHeight}
-  ${maxWidth}
-  ${minHeight}
-  ${minWidth}
-  ${overflow}
-  ${space}
-  ${width}
-
   ${caps}
   ${regular}
   ${bold}
-
-  ${fontSize}
-  ${fontStyle}
-  ${fontWeight}
-  ${lineHeight}
-  ${letterSpacing}
-  ${textAlign}
   ${textDecoration}
   ${textShadow}
-  ${textStyle}
-  ${zIndex}
+
+
+  ${(props) =>
+    compose(
+      display,
+      height,
+      maxHeight,
+      maxWidth,
+      minHeight,
+      minWidth,
+      overflow,
+      space,
+      width,
+      fontSize,
+      fontStyle,
+      fontWeight,
+      lineHeight,
+      letterSpacing,
+      textAlign,
+      textStyle,
+      zIndex
+    )(props)}
 `
 
 const textAttrs = (props) => ({

--- a/packages/core/src/Text/__snapshots__/Text.spec.tsx.snap
+++ b/packages/core/src/Text/__snapshots__/Text.spec.tsx.snap
@@ -48,10 +48,10 @@ exports[`Text height and width 1`] = `
 
 exports[`Text min/max values 1`] = `
 .c0 {
-  max-height: 400px;
-  max-width: 400px;
   min-height: 200px;
+  max-height: 400px;
   min-width: 200px;
+  max-width: 400px;
 }
 
 <div

--- a/packages/core/src/ThemeProvider/ThemeProvider.stories.tsx
+++ b/packages/core/src/ThemeProvider/ThemeProvider.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { ThemeProvider, Box, Text } from '..'
+
+export default {
+  title: 'ThemeProvider',
+  component: ThemeProvider,
+}
+
+// We could create a function to generate these arrays dynamically
+const mediaSizes = {
+  xs: ['99999em', '99999em', '99999em', '99999em', '99999em'],
+  sm: ['32em', '99999em', '99999em', '99999em', '99999em'],
+  md: ['0em', '40em', '99999em', '99999em', '99999em'],
+  lg: ['0em', '0em', '48em', '99999em', '99999em'],
+  xl: ['0em', '0em', '0em', '64em', '99999em'],
+  xxl: ['0em', '0em', '0em', '0em', '80em'],
+}
+
+/** @public */
+const FixedThemeWrapper = ({ children, size }) => {
+  const customBreakpoints = mediaSizes[size]
+  if (!children) return null
+  if (!customBreakpoints) return children
+  return (
+    <ThemeProvider customBreakpoints={customBreakpoints} data-testid='theme-provider'>
+      {children}
+    </ThemeProvider>
+  )
+}
+
+export const CustomBreakpoints = () => {
+  return ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].map((size) => (
+    <FixedThemeWrapper size={size} key='size'>
+      <Box my={2} key={size} color='white' bg='primary' width={[1, 1 / 2, 1 / 4]}>
+        <Box width='350px' mr={3}>
+          <Text fontSize={[3, null, null, 5]}>TEST - {size}</Text>
+        </Box>
+      </Box>
+    </FixedThemeWrapper>
+  ))
+}

--- a/packages/core/src/ToggleBadge/ToggleBadge.tsx
+++ b/packages/core/src/ToggleBadge/ToggleBadge.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import propTypes from '@styled-system/prop-types'
-import { space, fontSize, borderRadius, SpaceProps, FontSizeProps } from 'styled-system'
+import { space, fontSize, borderRadius, SpaceProps, FontSizeProps, compose } from 'styled-system'
 import { applyVariations, getPaletteColor, deprecatedColorValue, borderRadiusAttrs } from '../utils'
 
 const toggleBadgePropTypes = {
@@ -39,7 +39,8 @@ const ToggleBadge: React.FC<IToggleBadgeProps> = styled.button.attrs(borderRadiu
     background-color: ${(props) => getPaletteColor(props.bg || props.color, 'light')(props)};
   }
   ${applyVariations('ToggleBadge')}
-  ${space} ${fontSize} ${borderRadius};
+
+  ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
 ToggleBadge.displayName = 'ToggleBadge'

--- a/packages/core/src/ToggleBadge/__snapshots__/ToggleBadge.spec.tsx.snap
+++ b/packages/core/src/ToggleBadge/__snapshots__/ToggleBadge.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`ToggleBadge selected ToggleBadge renders with default props 1`] = `
   cursor: pointer;
   background-color: #e8f2ff;
   color: #0068ef;
+  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -19,7 +20,6 @@ exports[`ToggleBadge selected ToggleBadge renders with default props 1`] = `
   margin-top: 4px;
   margin-bottom: 4px;
   font-size: 12px;
-  border-radius: 9999px;
 }
 
 .c0:hover {
@@ -44,6 +44,8 @@ exports[`ToggleBadge selected one with background-color and text color passed as
   cursor: pointer;
   background-color: #0a0;
   color: #c00;
+  font-size: 14px;
+  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -52,8 +54,6 @@ exports[`ToggleBadge selected one with background-color and text color passed as
   margin-right: 4px;
   margin-top: 4px;
   margin-bottom: 4px;
-  font-size: 14px;
-  border-radius: 9999px;
 }
 
 .c0:hover {
@@ -78,6 +78,7 @@ exports[`ToggleBadge unselected ToggleBadge renders with default props 1`] = `
   cursor: pointer;
   background-color: transparent;
   color: #0068ef;
+  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -87,7 +88,6 @@ exports[`ToggleBadge unselected ToggleBadge renders with default props 1`] = `
   margin-top: 4px;
   margin-bottom: 4px;
   font-size: 12px;
-  border-radius: 9999px;
 }
 
 .c0:hover {

--- a/packages/core/src/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
+++ b/packages/core/src/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Tooltip bottom center 1`] = `
 .c0 {
+  background-color: #fff;
+  color: #001833;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #fff;
-  color: #001833;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -71,11 +71,11 @@ exports[`Tooltip bottom center 1`] = `
 
 exports[`Tooltip bottom left 1`] = `
 .c0 {
+  background-color: #fff;
+  color: #001833;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #fff;
-  color: #001833;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -135,11 +135,11 @@ exports[`Tooltip bottom left 1`] = `
 
 exports[`Tooltip bottom right 1`] = `
 .c0 {
+  background-color: #fff;
+  color: #001833;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #fff;
-  color: #001833;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -200,11 +200,11 @@ exports[`Tooltip bottom right 1`] = `
 
 exports[`Tooltip renders 1`] = `
 .c0 {
+  background-color: #fff;
+  color: #001833;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #fff;
-  color: #001833;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -264,11 +264,11 @@ exports[`Tooltip renders 1`] = `
 
 exports[`Tooltip top center 1`] = `
 .c0 {
+  background-color: #0068ef;
+  color: #fff;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #0068ef;
-  color: #fff;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -333,11 +333,11 @@ exports[`Tooltip top center 1`] = `
 
 exports[`Tooltip top left 1`] = `
 .c0 {
+  background-color: #0068ef;
+  color: #fff;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #0068ef;
-  color: #fff;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }
@@ -397,11 +397,11 @@ exports[`Tooltip top left 1`] = `
 
 exports[`Tooltip top right 1`] = `
 .c0 {
+  background-color: #c00;
+  color: #fff;
   padding: 8px;
   margin-bottom: 16px;
   margin-top: 8px;
-  background-color: #c00;
-  color: #fff;
   border-radius: 8px;
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 2px 0 rgba(0,0,0,0.2),0 4px 2px -2px rgba(0,0,0,0.12),0 4px 8px -1px rgba(0,0,0,0.16);
 }

--- a/packages/core/src/utils/createTheme.ts
+++ b/packages/core/src/utils/createTheme.ts
@@ -29,6 +29,7 @@ const createTheme = (theme = {}, customBreakpoints = null, existingTheme = defau
   const mediaQueries = customBreakpoints
     ? createMediaQueries(customBreakpoints)
     : finalMergedTheme.mediaQueries
+
   return {
     ...finalMergedTheme,
     contrastRatio: finalMergedTheme.contrastRatio || 2.6,

--- a/packages/icons/src/Svg.js
+++ b/packages/icons/src/Svg.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { space, width } from 'styled-system'
+import { space, width, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 
 /**
@@ -60,10 +60,10 @@ const Svg = styled('svg')`
   flex: none;
   line-height: 1;
 
-  ${space}
-  ${width}
   ${color}
   ${bg}
+
+  ${(props) => compose(space, width)(props)}
 `
 
 Svg.propTypes = {

--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
-import { color, width, height } from 'styled-system'
+import { color, width, height, compose } from 'styled-system'
 import { themeGet } from '@styled-system/theme-get'
 import { DialogOverlay, DialogContent } from '@reach/dialog'
 import { Box, CloseButton, deprecatedColorValue, Flex } from 'pcln-design-system'
@@ -49,9 +49,6 @@ const Overlay = styled(DialogOverlay)`
 `
 
 const Dialog = styled(DialogContent)`
-  ${color}
-  ${width}
-  ${height}
   position: relative;
   margin-left: auto;
   margin-right: auto;
@@ -76,6 +73,8 @@ const Dialog = styled(DialogContent)`
     max-height: none;
   `}
   ${getAnimation}
+
+  ${(props) => compose(color, width, height)(props)}
 `
 
 const HeaderWrapper = styled.div`
@@ -162,7 +161,7 @@ const Modal = ({
   if (enableOverflow) {
     dialogHeight = null
   } else if (fullScreen) {
-    dialogHeight = [1]
+    dialogHeight = '100vh'
   }
 
   return (
@@ -179,7 +178,7 @@ const Modal = ({
           <OverlayWrapper>
             <DialogWrapper enableoverflow={enableOverflow} verticalAlignment={verticalAlignment}>
               <Dialog
-                width={fullScreen ? 1 : width}
+                width={fullScreen ? '100vw' : width}
                 bg={bg}
                 height={dialogHeight}
                 transitionstate={state}

--- a/packages/modal/src/__snapshots__/Headers.spec.js.snap
+++ b/packages/modal/src/__snapshots__/Headers.spec.js.snap
@@ -2,12 +2,12 @@
 
 exports[`ModalHeader render 1`] = `
 .c1 {
-  height: 40px;
-  padding-left: 16px;
-  padding-right: 16px;
   background-color: #0a0;
   color: #fff;
   border-radius: 16px 16px 0 0;
+  height: 40px;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .c2 {
@@ -22,8 +22,8 @@ exports[`ModalHeader render 1`] = `
 }
 
 .c3 {
-  font-size: 14px;
   font-weight: 700;
+  font-size: 14px;
   line-height: 16px;
 }
 

--- a/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
+++ b/packages/popover/src/Popover/__snapshots__/Popover.spec.js.snap
@@ -89,10 +89,10 @@ exports[`Popover Trigger Element renders with FocusLock 1`] = `
 
 exports[`Popover UI Positioning Bottom 1`] = `
 .c0 {
+  border-radius: 16px;
+  width: 400px;
   display: inline-block;
   padding: 8px;
-  width: 400px;
-  border-radius: 16px;
 }
 
 .c4 {
@@ -206,10 +206,10 @@ exports[`Popover UI Positioning Bottom 1`] = `
 
 exports[`Popover UI Positioning Bottom End 1`] = `
 .c0 {
+  border-radius: 16px;
+  width: 400px;
   display: inline-block;
   padding: 8px;
-  width: 400px;
-  border-radius: 16px;
 }
 
 .c4 {
@@ -323,10 +323,10 @@ exports[`Popover UI Positioning Bottom End 1`] = `
 
 exports[`Popover UI Positioning Bottom Start 1`] = `
 .c0 {
+  border-radius: 16px;
+  width: 400px;
   display: inline-block;
   padding: 8px;
-  width: 400px;
-  border-radius: 16px;
 }
 
 .c4 {


### PR DESCRIPTION
This fixes a bug when passing `customBreakpoints` to `<ThemeProvider>` and using responsive props arrays. Some changes internally to Styled System 5 seem to have caused this behavior change, but using Styled System's `compose` function fixes it.