### PR TITLE
Rename docs-utils package to avoid NPM fees

### DIFF
--- a/packages/docs-utils/README.md
+++ b/packages/docs-utils/README.md
@@ -1,3 +1,3 @@
-# @priceline/docs-utils
+# pcln-docs-utils
 
 This package is a collection of components that are used to build the Storybook docs for the Priceline Design System

--- a/packages/docs-utils/package.json
+++ b/packages/docs-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@priceline/docs-utils",
+  "name": "pcln-docs-utils",
   "version": "0.0.1",
   "main": "lib-commonjs/index.js",
   "module": "lib-esm/index.js",

--- a/rush.json
+++ b/rush.json
@@ -332,7 +332,7 @@
 
   "projects": [
     {
-      "packageName": "@priceline/docs-utils",
+      "packageName": "pcln-docs-utils",
       "projectFolder": "packages/docs-utils",
       "reviewCategory": "packages",
       "shouldPublish": true


### PR DESCRIPTION
Resolves the following error when publishing:

<img width="1128" alt="CleanShot 2023-03-20 at 14 27 02@2x" src="https://user-images.githubusercontent.com/3260642/226435006-f7ebb159-52a3-4008-80fe-d839cf43a7a4.png">
