### PR TITLE
Update icon package peer dependency

### DIFF
--- a/common/changes/pcln-icons/update-icon-package-peer-dependency_2023-04-10-19-54.json
+++ b/common/changes/pcln-icons/update-icon-package-peer-dependency_2023-04-10-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "Update pcln-design-system peer dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-icons"
+}

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -59,7 +59,7 @@
     "styled-components": "^5.3.9"
   },
   "peerDependencies": {
-    "pcln-design-system": "^4.12.1",
+    "pcln-design-system": "^5.7.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
     "styled-components": ">=5 <5.3.4 || >5.3.7 <6"


### PR DESCRIPTION
David brought to my attention in Slack that pcln-icons v5 is using pcln-design-system v4 as a peer dependency.

Seems like this was a mistake made when we merged v5 but someone correct me if I'm wrong.