### PR TITLE
Use withTheme instead of useTheme in ToastProvider

### DIFF
--- a/common/changes/pcln-design-system/replace-use-of-usetheme_2023-04-11-16-13.json
+++ b/common/changes/pcln-design-system/replace-use-of-usetheme_2023-04-11-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Use withTheme instead of useTheme in ToastProvider to restore Styled Components 4 compatibility",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-design-system/replace-use-of-usetheme_2023-04-11-16-55.json
+++ b/common/changes/pcln-design-system/replace-use-of-usetheme_2023-04-11-16-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Loosen styled-components peerDependency to allow v4",
+      "type": "patch",
+      "packageName": "pcln-design-system"
+    }
+  ],
+  "packageName": "pcln-design-system",
+  "email": "craig.palermo@priceline.com"
+}

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -77,7 +77,7 @@
   "peerDependencies": {
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "pcln-design-system": "^5.7.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -129,7 +129,7 @@
   "peerDependencies": {
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "framer-motion": ">=6.5.1"
   }
 }

--- a/packages/core/src/ToastProvider/ToastProvider.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
-import { useTheme } from 'styled-components'
+import { withTheme } from 'styled-components'
 import { createPortal } from 'react-dom'
 import { Absolute } from '../Absolute'
 import { Animate, MotionVariant } from '../Animate'
@@ -32,6 +32,7 @@ interface IToastProvider {
   exitAnimation?: MotionVariant
   lifespan?: number
   maxToasts?: number
+  theme: unknown
 }
 
 let id = 0
@@ -43,8 +44,8 @@ function ToastProvider({
   exitAnimation = 'slideOutLeft',
   lifespan,
   maxToasts = 3,
+  theme,
 }: IToastProvider) {
-  const theme = useTheme()
   const [toasts, setToasts] = useState<IToastOptions[]>([])
 
   const addToast = useCallback((options: IToastOptions) => {
@@ -97,4 +98,4 @@ function ToastProvider({
   )
 }
 
-export default ToastProvider
+export default withTheme(ToastProvider)

--- a/packages/docs-utils/package.json
+++ b/packages/docs-utils/package.json
@@ -91,7 +91,7 @@
   "peerDependencies": {
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "framer-motion": ">=6.5.1",
     "pcln-design-system": "^5"
   }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -55,7 +55,7 @@
     "pcln-popover": "^5.1.1",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "styled-system": "^4.2.4"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -55,7 +55,7 @@
     "pcln-design-system": "^5.7.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "styled-system": "^4.2.4"
   }
 }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -60,7 +60,7 @@
     "pcln-design-system": "^5.7.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
     "styled-system": "^4.2.4"
   }
 }


### PR DESCRIPTION
Using `useTheme` broke backward compatibility with Styled Components 4.

<img width="247" alt="CleanShot 2023-04-11 at 12 14 04@2x" src="https://user-images.githubusercontent.com/3260642/231224788-7e7c64da-932d-42b6-bf3a-f6ee6831e0c2.png">
