### PR TITLE
Create Toast border variation and fix styles being overwritten

### DIFF
--- a/common/changes/pcln-design-system/PPN-62379-create-toast-border-variation-and-fix-styles-being-overwritten_2023-04-24-18-10.json
+++ b/common/changes/pcln-design-system/PPN-62379-create-toast-border-variation-and-fix-styles-being-overwritten_2023-04-24-18-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Create Toast border variation and fix overwritten styles",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Toast/Toast.spec.tsx
+++ b/packages/core/src/Toast/Toast.spec.tsx
@@ -2,6 +2,7 @@ jest.useFakeTimers()
 
 import React from 'react'
 import { fireEvent, render, screen } from '../__test__/testing-library'
+import { Success } from 'pcln-icons'
 import { Toast } from '../Toast'
 
 describe('Toast', () => {
@@ -48,5 +49,22 @@ describe('Toast', () => {
       </Toast>
     )
     expect(screen.getByText('Information Message')).toBeInTheDocument()
+  })
+
+  it('renders a success border toast', () => {
+    render(
+      <Toast id={10} color='success' icon={<Success data-testid='success-icon' />} variation='border'>
+        Success Border Message
+      </Toast>
+    )
+    const toast = screen.getByText('Success Border Message')
+    expect(toast).toBeInTheDocument()
+    expect(toast.parentNode.parentNode).toHaveStyleRule('background-color', '#fff')
+    expect(toast.parentNode.parentNode).toHaveStyleRule('color', '#001833')
+    expect(toast.parentNode.parentNode).toHaveStyleRule('border-left', '12px solid #0a0')
+
+    const icon = screen.getByTestId('success-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveStyleRule('color', '#0a0')
   })
 })

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -1,29 +1,46 @@
 import React, { useEffect } from 'react'
 import { themeGet } from '@styled-system/theme-get'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Close as CloseIcon } from 'pcln-icons'
 import { Absolute } from '../Absolute'
 import { Flex, IFlexProps } from '../Flex'
 import { IconButton } from '../IconButton'
 import { Relative } from '../Relative'
 import { Text } from '../Text'
-import { getPaletteColor } from '../utils'
+import { applyVariations, getPaletteColor } from '../utils'
+
+const variations = {
+  border: css`
+    background-color: ${getPaletteColor('background.lightest')};
+    color: ${getPaletteColor('text.base')};
+    border-left: ${themeGet('borderRadii.lg')} solid ${(props) => getPaletteColor(props.color, 'base')(props)};
+  `,
+  fill: css``,
+}
+
+const LeftBorderFlex = styled(Flex)`
+  ${applyVariations('Toast', variations)};
+`
 
 const RoundIconButton = styled(IconButton)`
-  background-color: ${getPaletteColor('background.lightest')};
-  padding: ${themeGet('space.1')};
-
-  &:hover {
+  &&& {
     background-color: ${getPaletteColor('background.lightest')};
+    padding: ${themeGet('space.1')};
+    pointer-events: auto;
+
+    &:hover {
+      background-color: ${getPaletteColor('background.lightest')};
+    }
   }
 `
 
 export interface IToastProps extends Omit<IFlexProps, 'id'> {
   children: React.ReactNode
   hideClose?: boolean
-  icon?: React.ReactNode
+  icon?: React.ReactElement
   id?: number
   lifespan?: number
+  variation?: 'border' | 'fill'
   onRemoveClick?: (id: number) => void
 }
 
@@ -34,6 +51,7 @@ function Toast({
   icon,
   id,
   lifespan,
+  variation = 'fill',
   onRemoveClick,
   ...props
 }: IToastProps) {
@@ -53,20 +71,17 @@ function Toast({
 
   return (
     <Relative>
-      <Flex
+      <LeftBorderFlex
         {...props}
+        alignItems='center'
         borderRadius='lg'
         boxShadowSize='xl'
         color={color}
         justifyContent='space-between'
-        alignItems='center'
+        variation={variation}
         p={3}
       >
-        {icon && (
-          <Flex mr={3}>
-            {icon}
-          </Flex>
-        )}
+        {icon && <Flex mr={3}>{React.cloneElement(icon, { color: variation === 'border' && color })}</Flex>}
         <Flex width='100%'>
           {typeof children === 'string' ? <Text textStyle='paragraph'>{children}</Text> : children}
         </Flex>
@@ -80,7 +95,7 @@ function Toast({
             />
           </Absolute>
         )}
-      </Flex>
+      </LeftBorderFlex>
     </Relative>
   )
 }

--- a/packages/core/src/ToastProvider/ToastProvider.stories.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.stories.tsx
@@ -9,12 +9,17 @@ export default {
     lifespan: {
       description: 'Lifespan in milliseconds before the Toast closes.',
     },
+    variation: {
+      control: 'select',
+      options: ['border', 'fill'],
+      defaultValue: 'fill',
+    },
   },
 }
 
 const Template = (args) => (
   <ToastProvider {...args}>
-    <MockToastChildren />
+    <MockToastChildren variation={args.variation} />
   </ToastProvider>
 )
 

--- a/packages/core/src/ToastProvider/ToastProvider.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
-import { withTheme } from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 import { createPortal } from 'react-dom'
 import { Absolute } from '../Absolute'
 import { Animate, MotionVariant } from '../Animate'
@@ -17,6 +17,10 @@ interface IToastContextProps {
   addToast: (options: IToastOptions) => void
   removeToast: (id: number) => void
 }
+
+const ClickthroughAbsolute = styled(Absolute)`
+  pointer-events: none;
+`
 
 /* istanbul ignore next */
 export const ToastContext = createContext<IToastContextProps>({ addToast: () => {}, removeToast: () => {} })
@@ -75,7 +79,7 @@ function ToastProvider({
       {children}
       {createPortal(
         <ThemeProvider theme={theme}>
-          <Absolute bottom={20} width='100%'>
+          <ClickthroughAbsolute bottom={20} width='100%'>
             <Flex justifyContent='center' width='100%'>
               <Flex flexDirection='column-reverse' justifyContent='center' minWidth='300px'>
                 {toastsToRender.map((toast) => {
@@ -90,7 +94,7 @@ function ToastProvider({
                 })}
               </Flex>
             </Flex>
-          </Absolute>
+          </ClickthroughAbsolute>
         </ThemeProvider>,
         document.getElementById(domRootId)
       )}

--- a/packages/core/src/__test__/mocks/toasts.tsx
+++ b/packages/core/src/__test__/mocks/toasts.tsx
@@ -37,21 +37,21 @@ export const customOptions = {
   lifespan: 2000,
 }
 
-export const MockToastChildren = () => {
+export const MockToastChildren = ({ variation }: { variation: 'border' | 'fill' }) => {
   const { addToast } = useToast()
 
   return (
     <Flex>
-      <Button color='error' onClick={() => addToast(errorOptions)}>
+      <Button color='error' onClick={() => addToast({ ...errorOptions, variation })}>
         Add Error Toast
       </Button>
-      <Button onClick={() => addToast(informationOptions)} mx={3}>
+      <Button onClick={() => addToast({ ...informationOptions, variation })} mx={3}>
         Add Information Toast
       </Button>
-      <Button color='success' onClick={() => addToast(successOptions)}>
+      <Button color='success' onClick={() => addToast({ ...successOptions, variation })}>
         Add Success Toast
       </Button>
-      <Button color='text.light' onClick={() => addToast(customOptions)} ml={3}>
+      <Button color='text.light' onClick={() => addToast({ ...customOptions, variation })} ml={3}>
         Add Custom Toast
       </Button>
     </Flex>


### PR DESCRIPTION
Created a new border variation that just highlights the left border, this is a slightly cleaner looking Toast that suits the app I'm working on better. I also fixed the css being overwritten by adding `&&&` and set `pointer-events: none` to prevent the invisible absolute banner that positions the Toasts from affecting clicking behind it.

Storybook: https://5a85e56213417800200978ab-lxuugdthql.chromatic.com/?path=/story/core-toast--toast&args=variation:border