### PR TITLE
Tweak toast border variation design

### DIFF
--- a/common/changes/pcln-design-system/tweak-toast-border-variation-design_2023-04-25-16-12.json
+++ b/common/changes/pcln-design-system/tweak-toast-border-variation-design_2023-04-25-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Tweak the border variation design for Toast",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Toast/Toast.spec.tsx
+++ b/packages/core/src/Toast/Toast.spec.tsx
@@ -59,9 +59,9 @@ describe('Toast', () => {
     )
     const toast = screen.getByText('Success Border Message')
     expect(toast).toBeInTheDocument()
-    expect(toast.parentNode.parentNode).toHaveStyleRule('background-color', '#fff')
+    expect(toast.parentNode.parentNode).toHaveStyleRule('background-color', '#ecf7ec')
     expect(toast.parentNode.parentNode).toHaveStyleRule('color', '#001833')
-    expect(toast.parentNode.parentNode).toHaveStyleRule('border-left', '12px solid #0a0')
+    expect(toast.parentNode.parentNode).toHaveStyleRule('border-left', '4px solid #0a0')
 
     const icon = screen.getByTestId('success-icon')
     expect(icon).toBeInTheDocument()

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -11,9 +11,9 @@ import { applyVariations, getPaletteColor } from '../utils'
 
 const variations = {
   border: css`
-    background-color: ${getPaletteColor('background.lightest')};
+    background-color: ${(props) => getPaletteColor(props.color, 'light')(props)};
     color: ${getPaletteColor('text.base')};
-    border-left: ${themeGet('borderRadii.lg')} solid ${(props) => getPaletteColor(props.color, 'base')(props)};
+    border-left: ${themeGet('borderRadii.sm')} solid ${(props) => getPaletteColor(props.color, 'base')(props)};
   `,
   fill: css``,
 }


### PR DESCRIPTION
Before:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/62619213/234340703-260f6778-3107-4a05-b7c0-377f772efd1b.png">


After:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/62619213/234338449-29314b05-d2d6-4343-b815-e57b75501771.png">
