### PR TITLE
Update Link and Button component with changes to hover state in subtle, plain and white

### DIFF
--- a/common/changes/pcln-design-system/feature-add-subtle-type-link_2023-04-27-18-02.json
+++ b/common/changes/pcln-design-system/feature-add-subtle-type-link_2023-04-27-18-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "update Link with subtle, plain & white type. Also update bgcolor when button is hovered in subtle, plain & white",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Button/Button.spec.tsx
+++ b/packages/core/src/Button/Button.spec.tsx
@@ -363,7 +363,7 @@ describe('Button', () => {
         expect(button).toHaveStyleRule('color', theme.palette.primary.dark, {
           modifier: ':hover',
         })
-        expect(button).toHaveStyleRule('background-color', theme.palette.background.light, {
+        expect(button).toHaveStyleRule('background-color', theme.palette.background.tint, {
           modifier: ':hover',
         })
         expect(button).toHaveStyleRule('outline', `0px solid ${theme.palette.primary.dark}`, {
@@ -417,7 +417,7 @@ describe('Button', () => {
         expect(button).toHaveStyleRule('color', theme.palette.primary.dark, {
           modifier: ':hover',
         })
-        expect(button).toHaveStyleRule('background-color', theme.palette.background.light, {
+        expect(button).toHaveStyleRule('background-color', theme.palette.background.base, {
           modifier: ':hover',
         })
         expect(button).toHaveStyleRule('outline', `0px solid ${theme.palette.primary.dark}`, {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -109,7 +109,7 @@ const variations = {
     background-color: transparent;
     color: ${getPaletteColor('base')};
     &:hover {
-      background-color: ${getPaletteColor('background.light')};
+      background-color: ${getPaletteColor('background.base')};
       color: ${getPaletteColor('dark')};
     }
     &:focus {
@@ -121,7 +121,7 @@ const variations = {
     background-color: ${getPaletteColor('background.base')};
     color: ${getPaletteColor('base')};
     &:hover {
-      background-color: ${getPaletteColor('background.light')};
+      background-color: ${getPaletteColor('background.tint')};
       color: ${getPaletteColor('dark')};
     }
     &:focus {
@@ -133,7 +133,7 @@ const variations = {
     background-color: ${getPaletteColor('background.lightest')};
     color: ${getPaletteColor('base')};
     &:hover {
-      background-color: ${getPaletteColor('background.light')};
+      background-color: ${getPaletteColor('background.base')};
       color: ${getPaletteColor('dark')};
     }
     &:focus {

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -27,6 +27,12 @@ export function ForwardRefs() {
           I am a link!
         </Link>
         <br />
+        <Link variation='subtle'>subtle</Link>
+        <br />
+        <Link variation='plain'>plain</Link>
+        <br />
+        <Link variation='white'>white</Link>
+        <br />
         <Button color='error' onClick={onClick} mt={4}>
           Click to update link text via ref
         </Button>

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -5,7 +5,7 @@ import { Box, Button, getLinkStylesOn, IButtonProps, Layout, Link, Text } from '
 import { ILinkProps } from './Link'
 import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
-import { colors, shadows } from '../storybook/args'
+import { colors } from '../storybook/args'
 
 const sizeOptions = ['small', 'medium', 'large', 'extraLarge']
 

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box, Button, Layout, Link, Text, getLinkStylesOn } from '..'
+import { StoryObj } from '@storybook/react'
+import { Box, Button, getLinkStylesOn, IButtonProps, Layout, Link, Text } from '..'
 import { ILinkProps } from './Link'
 import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
+import { colors, shadows } from '../storybook/args'
+
+const sizeOptions = ['small', 'medium', 'large', 'extraLarge']
 
 export default {
   title: 'Link',
@@ -16,25 +20,53 @@ const Template = (args: ILinkProps) => <Link {...args} />
 
 export const _Link = Template.bind({})
 
-export function AllLinkExamples() {
+type ButtonStory = StoryObj<IButtonProps>
+
+export const Playground: ButtonStory = {
+  render: (args) => <Button {...args}>Button</Button>,
+  argTypes: {
+    color: {
+      control: 'select',
+      options: colors,
+      defaultValue: Button.defaultProps.color,
+    },
+    size: {
+      control: 'select',
+      options: sizeOptions,
+      defaultValue: Button.defaultProps.size,
+    },
+    disabled: {
+      defaultValue: false,
+      type: 'boolean',
+    },
+  },
+}
+
+export function AllLinkExamples(args) {
   return (
     <>
-      <Text textStyle='heading3'>Primary Link Examples</Text>
+      <Text textStyle='heading3' mb={2}>
+        Link Variations
+      </Text>
       <Layout variation='100' gap={1} rowGap={2} bg='background.tone' p={4}>
-        <Link variation='fill' mb={4}>
+        <Link {...args} variation='fill' mb={4}>
           fill
         </Link>
-        <Link variation='subtle' mb={4}>
+        <Link {...args} variation='subtle' mb={4}>
           subtle
         </Link>
-        <Link variation='link'>link</Link>
-        <Link variation='outline' my={4}>
+        <Link {...args} variation='link'>
+          link
+        </Link>
+        <Link {...args} variation='outline' my={4}>
           outline
         </Link>
-        <Link variation='plain' mb={4}>
+        <Link {...args} variation='plain' mb={4}>
           plain
         </Link>
-        <Link variation='white'>white</Link>
+        <Link {...args} variation='white'>
+          white
+        </Link>
       </Layout>
     </>
   )

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box, Button, Link, Text, getLinkStylesOn } from '..'
+import { Box, Button, Layout, Link, Text, getLinkStylesOn } from '..'
 import { ILinkProps } from './Link'
 import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
@@ -16,6 +16,30 @@ const Template = (args: ILinkProps) => <Link {...args} />
 
 export const _Link = Template.bind({})
 
+export function AllLinkExamples() {
+  return (
+    <>
+      <Text textStyle='heading3'>Primary Link Examples</Text>
+      <Layout variation='100' gap={1} rowGap={2} bg='background.tone' p={4}>
+        <Link variation='fill' mb={4}>
+          fill
+        </Link>
+        <Link variation='subtle' mb={4}>
+          subtle
+        </Link>
+        <Link variation='link'>link</Link>
+        <Link variation='outline' my={4}>
+          outline
+        </Link>
+        <Link variation='plain' mb={4}>
+          plain
+        </Link>
+        <Link variation='white'>white</Link>
+      </Layout>
+    </>
+  )
+}
+
 export function ForwardRefs() {
   function refChild(dsRef) {
     function onClick() {
@@ -26,12 +50,6 @@ export function ForwardRefs() {
         <Link color='text.dark' ref={dsRef}>
           I am a link!
         </Link>
-        <br />
-        <Link variation='subtle'>subtle</Link>
-        <br />
-        <Link variation='plain'>plain</Link>
-        <br />
-        <Link variation='white'>white</Link>
         <br />
         <Button color='error' onClick={onClick} mt={4}>
           Click to update link text via ref

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -14,6 +14,14 @@ const variations = {
 
     ${buttonStyles}
   `,
+  subtle: css`
+    ${buttonStyles}
+
+    &:hover {
+      text-decoration: none;
+      background-color: ${getPaletteColor('background.tint')};
+    }
+  `,
   link: css`
     cursor: pointer;
     text-decoration: none;
@@ -30,6 +38,22 @@ const variations = {
     }
 
     ${buttonStyles}
+  `,
+  plain: css`
+    ${buttonStyles}
+
+    &:hover {
+      text-decoration: none;
+      background-color: ${getPaletteColor('background.base')};
+    }
+  `,
+  white: css`
+    ${buttonStyles}
+
+    &:hover {
+      text-decoration: none;
+      background-color: ${getPaletteColor('background.base')};
+    }
   `,
 }
 
@@ -50,7 +74,7 @@ export interface ILinkProps
   href?: string
   size?: 'small' | 'medium' | 'large'
   target?: string
-  variation?: 'fill' | 'link' | 'outline'
+  variation?: 'fill' | 'link' | 'outline' | 'subtle' | 'plain' | 'white'
   onClick?: (unknown) => unknown
   onFocus?: (unknown) => unknown
 }


### PR DESCRIPTION
I'm currently working on this ticket https://priceline.atlassian.net/browse/SITE-20524. I've to use the `Link` with `subtle` type. Which is currently not available. This change will allow us to use it.

Also , there are changes to the `background-color` of hover state in Button. To match the specs in here https://www.figma.com/file/1lLCo0ZnO1RyMDEbnnS0by/Web-Design-System?type=design&node-id=145-21874&t=mqAZdqJ3WFQmYcB2-0 , for subtle, palin and white type

