### PR TITLE
feat(HTL-XXX): fix outline color

### DIFF
--- a/common/changes/pcln-design-system/HTL-XXX-pass-color-props_2023-05-17-21-44.json
+++ b/common/changes/pcln-design-system/HTL-XXX-pass-color-props_2023-05-17-21-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "pass props to ChipButton outline so it can have color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -61,8 +61,9 @@ export interface IButtonChipProps extends SpaceProps, FontSizeProps {
 }
 
 const ButtonChip: React.FC<IButtonChipProps> = React.forwardRef(
-  ({ id, m, disabled, expanded, children, onClick, label, showActionIcon, ...props }, ref) => (
+  ({ color, id, m, disabled, expanded, children, onClick, label, showActionIcon, ...props }, ref) => (
     <ChipButton
+      color={color}
       id={id}
       data-testid={id}
       ref={ref}


### PR DESCRIPTION
No color is showing on `focus` for ButtonChip. I'm passing props as outlined in the docs here https://priceline.github.io/design-system/utilities/getPaletteColor#palette-color-driven-from-other-prop