### PR TITLE
Feat/site 20882 carousel props

### DIFF
--- a/common/changes/pcln-carousel/feat-SITE-20882-carousel-props_2023-06-16-17-26.json
+++ b/common/changes/pcln-carousel/feat-SITE-20882-carousel-props_2023-06-16-17-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "prevent carousel scroll if all slides shown",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -88,7 +88,7 @@ export const Carousel = ({
         naturalSlideHeight={naturalSlideHeight}
         totalSlides={children.length}
         visibleSlides={layoutSize || responsiveVisibleSlides}
-        dragEnabled
+        dragEnabled={children.length <= (layoutSize || responsiveVisibleSlides) ? false : true}
         isIntrinsicHeight={isIntrinsicHeight}
         step={layoutSize || step}
         dragStep={layoutSize || step}
@@ -185,7 +185,8 @@ Carousel.propTypes = {
    * this will be overridden by the number of items in the layout.
    * Can also be sent as array to set responsive sizes:
    * [below 768px, below 1024px, above 1020px]
-   * E.g. `layout={'25-50-25'}` will result in 3 slides shown per page. */
+   * E.g. `layout={'25-50-25'}` will result in 3 slides shown per page.
+   * Note: decimal values are accepted too E.g. `[1,2.5,3.2]`*/
   visibleSlides: PropTypes.any,
   /** Show clickable navigation dots */
   showDots: PropTypes.bool,

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -88,7 +88,7 @@ export const Carousel = ({
         naturalSlideHeight={naturalSlideHeight}
         totalSlides={children.length}
         visibleSlides={layoutSize || responsiveVisibleSlides}
-        dragEnabled={children.length <= (layoutSize || responsiveVisibleSlides) ? false : true}
+        dragEnabled={children.length > (layoutSize || responsiveVisibleSlides)}
         isIntrinsicHeight={isIntrinsicHeight}
         step={layoutSize || step}
         dragStep={layoutSize || step}


### PR DESCRIPTION
Description- While working on [SITE-20882](https://priceline.atlassian.net/browse/SITE-20882), I came across this issue when trying to make the Carousel responsive. If all the available slides are shown in the carousel, we can still drag the slides (see below video). I am not sure if this is expected behavior but i was thinking of using the prop dragEnabled to fix this. 

https://github.com/priceline/design-system/assets/24214569/561c2886-8761-4b4e-b8bc-2d3357c5b878

