### PR TITLE
Update Hero story image

### DIFF
--- a/common/changes/pcln-design-system/update-hero-image_2023-06-16-21-52.json
+++ b/common/changes/pcln-design-system/update-hero-image_2023-06-16-21-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "change the image used in the Hero story",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/DocsUtils/Hero/Hero.stories.tsx
+++ b/packages/core/src/DocsUtils/Hero/Hero.stories.tsx
@@ -5,7 +5,8 @@ import React from 'react'
 import { Hero, HeroProps } from '.'
 
 const exampleProps: HeroProps = {
-  img: 'https://source.unsplash.com/random/?superhero/',
+  img:
+    'https://s1.pclncdn.com/design-assets/hero/beach.jpg?opto&optimize=medium&auto=jpg&width=600&height=450&fit=crop',
   name: 'Hero',
   children: `Doloremque nisi excepturi. Dicta ut esse quas. Voluptatum ab veniam suscipit libero assumenda voluptate a mollitia. Ut ab consequuntur veritatis illum ullam minima pariatur sint quas. Necessitatibus doloribus natus voluptas.`,
 }


### PR DESCRIPTION
This PR changes the `src` url for the image that is used in the  `Hero` component's story. 

Q: Why?
A: The previous `url` would load a random image from [unsplash](https://source.unsplash.com/random/?superhero/), and the new url loads a static Priceline image asset. With a static asset, we can ensure that chromatic snapshots do no produce a visual diff just because a random image was loaded on every build.