### PR TITLE
update hug to use same background color as header

### DIFF
--- a/common/changes/pcln-design-system/fix-hug-background-color-gap_2023-07-10-15-58.json
+++ b/common/changes/pcln-design-system/fix-hug-background-color-gap_2023-07-10-15-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "update hug to have same background color as header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Hug/Hug.tsx
+++ b/packages/core/src/Hug/Hug.tsx
@@ -50,7 +50,7 @@ const Hug: React.FC<IHugProps> = ({ bg, color, p, fontSize, icon, iconDisplay, .
   }
 
   return (
-    <HugCard {...props} borderColor={bg || color}>
+    <HugCard {...props} borderColor={bg || color} color={color}>
       <Flex bg={bg} color={color} p={p} pl='12px' alignItems='center'>
         {!!iconClone && iconClone}
         <Text fontSize={fontSize}>{props.text}</Text>

--- a/packages/core/src/Hug/__snapshots__/Hug.spec.tsx.snap
+++ b/packages/core/src/Hug/__snapshots__/Hug.spec.tsx.snap
@@ -8,6 +8,8 @@ exports[`Hug renders text, icon, and Child 1`] = `[Function]`;
 
 exports[`Hug renders with border-radius from theme on top only 1`] = `
 .c0 {
+  background-color: #fff;
+  color: #001833;
   border-radius: 16px;
 }
 
@@ -47,6 +49,7 @@ exports[`Hug renders with border-radius from theme on top only 1`] = `
 
 <div
   className="c0 c1 c2"
+  color="text.lightest"
 >
   <div
     className="c3 c4"


### PR DESCRIPTION

- currently when a hug holds a card with a border radius, we see a gap in the corners
- updating the hug to have the same background color as the header, by passing `color` on the hug so it can be used in `applyVariations`

Before: 
<img width="1007" alt="Screenshot 2023-07-10 at 11 03 28 AM" src="https://github.com/priceline/design-system/assets/65993822/086d9d87-5474-490d-8998-1a5819a2acdd">
<img width="552" alt="Screenshot 2023-07-10 at 11 12 42 AM" src="https://github.com/priceline/design-system/assets/65993822/0a990b32-9831-4296-a964-495721445641">


After: 
<img width="1027" alt="Screenshot 2023-07-10 at 11 02 33 AM" src="https://github.com/priceline/design-system/assets/65993822/2e07dcac-c556-405e-bf81-278cf3fc66b7">
<img width="432" alt="Screenshot 2023-07-10 at 11 13 54 AM" src="https://github.com/priceline/design-system/assets/65993822/eb5b5717-8f25-46b6-9f88-20f47a71144a">

