### PR TITLE
add support for overflow to Box

### DIFF
--- a/common/changes/pcln-design-system/add-overflow-prop-to-box_2023-07-10-21-26.json
+++ b/common/changes/pcln-design-system/add-overflow-prop-to-box_2023-07-10-21-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add overflow support to Box",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Box/Box.spec.tsx
+++ b/packages/core/src/Box/Box.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { render } from '../__test__/testing-library'
 
 import { theme, Box } from '..'
 
@@ -48,5 +49,11 @@ describe('Box', () => {
     const json = rendererCreateWithTheme(<Box boxShadowSize='sm' />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('box-shadow', theme.shadows.sm)
+  })
+
+  test('overflow prop sets overflow', () => {
+    const { asFragment, getByTestId } = render(<Box overflow='scroll' data-testid='Box' />)
+    expect(asFragment()).toMatchSnapshot()
+    expect(getByTestId('Box')).toHaveStyleRule('overflow', 'scroll')
   })
 })

--- a/packages/core/src/Box/Box.stories.tsx
+++ b/packages/core/src/Box/Box.stories.tsx
@@ -152,6 +152,26 @@ export const DirectionalMargin = () => (
   </Box>
 )
 
+export const Overflow = () => (
+  <Box p={3}>
+    <Box overflow='hidden' maxHeight='100px' maxWidth='100px' mb={3} color='background.darkest' bg='primary'>
+      This is a box with hidden overflow. This is a box with hidden overflow.
+    </Box>
+    <Box overflow='clip' maxHeight='100px' maxWidth='100px' mb={3} color='background.darkest' bg='primary'>
+      This is a box with clip overflow. This is a box with clip overflow.
+    </Box>
+    <Box overflow='scroll' maxHeight='100px' maxWidth='100px' mb={3} color='background.darkest' bg='primary'>
+      This is a box with scroll overflow. This is a box with scroll overflow.
+    </Box>
+    <Box overflow='auto' maxHeight='100px' maxWidth='100px' mb={3} color='background.darkest' bg='primary'>
+      This is a box with auto overflow. This is a box with auto overflow.
+    </Box>
+    <Box overflow='visible' maxHeight='100px' maxWidth='100px' mb={3} color='background.darkest' bg='primary'>
+      This is a box with visible overflow. This is a box with visible overflow.
+    </Box>
+  </Box>
+)
+
 export const ThemeUserCaseColorText = () => (
   <React.Fragment>
     <Box p={3}>

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components'
 import PropTypes, { InferProps } from 'prop-types'
 import {
   borderRadius,
+  boxShadow,
   display,
   height,
   maxHeight,
   maxWidth,
   minHeight,
   minWidth,
-  boxShadow,
+  overflow,
   size,
   space,
   textAlign,
@@ -17,11 +18,12 @@ import {
   BorderRadiusProps,
   BoxShadowProps,
   DisplayProps,
+  HeightProps,
   MaxHeightProps,
   MaxWidthProps,
   MinHeightProps,
-  HeightProps,
   MinWidthProps,
+  OverflowProps,
   SizeProps,
   SpaceProps,
   TextAlignProps,
@@ -47,11 +49,12 @@ import { ColorSchemes } from '../theme'
 export const boxPropTypes = {
   ...propTypes.boxShadow,
   ...propTypes.display,
+  ...propTypes.height,
   ...propTypes.maxHeight,
   ...propTypes.maxWidth,
   ...propTypes.minHeight,
   ...propTypes.minWidth,
-  ...propTypes.height,
+  ...propTypes.overflow,
   ...propTypes.size,
   ...propTypes.space,
   ...propTypes.textAlign,
@@ -68,11 +71,12 @@ export interface IBoxProps
   extends BorderRadiusProps,
     BoxShadowProps,
     DisplayProps,
+    HeightProps,
     MaxHeightProps,
     MaxWidthProps,
     MinHeightProps,
     MinWidthProps,
-    HeightProps,
+    OverflowProps,
     SizeProps,
     SpaceProps,
     TextAlignProps,
@@ -141,7 +145,8 @@ const Box: React.FC<InferProps<typeof boxPropTypes>> = styled.div.attrs((props) 
       space,
       textAlign,
       borderRadius,
-      boxShadow
+      boxShadow,
+      overflow
     )(props)}
 `
 

--- a/packages/core/src/Box/__snapshots__/Box.spec.tsx.snap
+++ b/packages/core/src/Box/__snapshots__/Box.spec.tsx.snap
@@ -44,6 +44,34 @@ exports[`Box maxHeight, maxWidth, minHeight, minWidth 1`] = `
 />
 `;
 
+exports[`Box overflow prop sets overflow 1`] = `
+<DocumentFragment>
+  .c1 {
+  overflow: scroll;
+}
+
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+  font-weight: 500;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      data-testid="Box"
+      overflow="scroll"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Box p prop sets padding 1`] = `
 .c0 {
   padding: 8px;


### PR DESCRIPTION

- Adding support for overflow as a prop to `Box`
- Alphabetized some imports/propTypes

Storybook: 
<img width="616" alt="Screenshot 2023-07-10 at 4 31 44 PM" src="https://github.com/priceline/design-system/assets/65993822/e4a0e397-df0d-4fe2-8b8d-b7f07bb5bdf2">
