### PR TITLE
feat(uxpt-4952): updated the toggle states

### DIFF
--- a/common/changes/pcln-design-system/uxpt-4952-update-toggle-states_2023-07-10-20-50.json
+++ b/common/changes/pcln-design-system/uxpt-4952-update-toggle-states_2023-07-10-20-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Updated the toggle states",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Toggle/Toggle.spec.tsx
+++ b/packages/core/src/Toggle/Toggle.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Toggle } from '.'
 import { createTheme } from '..'
 import { render, fireEvent } from '../__test__/testing-library'
+import { theme as customThemes } from '../theme/theme'
 
 const theme = createTheme()
 
@@ -31,5 +32,21 @@ describe('Toggle', () => {
     const input = getByLabelText('Total price toggle')
     fireEvent.click(input)
     expect(cb).toHaveBeenCalled()
+  })
+
+  test('add boxshadow and bgColor when hover over the selected states', () => {
+    const { getByTestId, getByRole } = render(<Toggle label='Total price toggle' isOn={true} />)
+    const wrapper = getByRole('switch').parentNode
+    const circleHandle = getByTestId('handle-div')
+    expect(wrapper).toHaveStyleRule('background-color', theme.palette.primary.base)
+    expect(circleHandle).toHaveStyleRule('box-shadow', customThemes.shadows.sm)
+
+    // when it is hover
+    expect(wrapper).toHaveStyleRule('background-color', theme.palette.primary.dark, {
+      modifier: ':hover:not([disabled])',
+    })
+    expect(wrapper).toHaveStyleRule('box-shadow', customThemes.shadows.xl, {
+      modifier: ':hover:not([disabled]) > #circle-handle',
+    })
   })
 })

--- a/packages/core/src/Toggle/Toggle.stories.tsx
+++ b/packages/core/src/Toggle/Toggle.stories.tsx
@@ -25,6 +25,8 @@ export const ToggleComponent = () => {
       <Toggle label='With Icon' isOn={isOn} onToggle={onToggle} icon={icon} />
       <h4>Large With Icon</h4>
       <Toggle label='Large With Icon' isOn={isOn} onToggle={onToggle} height={50} icon={largeIcon} />
+      <h4>Disabled</h4>
+      <Toggle label='Default' isOn={isOn} onToggle={onToggle} disabled={true} />
     </>
   )
 }

--- a/packages/core/src/Toggle/Toggle.tsx
+++ b/packages/core/src/Toggle/Toggle.tsx
@@ -7,14 +7,14 @@ const alphaColor = (color: string, props) => `${getPaletteColor(color)(props)}4C
 
 const AbsoluteInput = styled(Input)`
   position: absolute;
-  z-index: 5;
+  z-index: 1;
   opacity: 0;
   width: 100%;
   height: 100%;
   top: 0;
   left: 0;
   margin: 0;
-  cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
 `
 
 const OutlineAbsolute = styled(Absolute)`
@@ -28,18 +28,28 @@ const CircleAbsolute = styled(Absolute)`
   justify-content: center;
   align-items: center;
   height: ${(props) => props.width};
-  pointer-events: none;
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
+  z-index: 2;
   transition: left 0.3s;
 `
 
 const WrapperBox = styled(Box)`
   position: relative;
   height: ${(props) => props.height}px;
-  transition: background-color 0.3s;
+  transition: background-color 0.15s ease 0s;
   min-width: ${(props) => props.width}px;
 
-  ${AbsoluteInput}:focus + ${OutlineAbsolute} {
+  ${AbsoluteInput}:focus-visible + ${OutlineAbsolute} {
     opacity: 1;
+  }
+
+  &:hover:not([disabled]) {
+    background-color: ${(props) =>
+      `${getPaletteColor(props.isOn ? 'primary.dark' : 'background.tone')(props)}`};
+  }
+
+  &:hover:not([disabled]) > #circle-handle {
+    box-shadow: ${(props) => props.theme.shadows.xl};
   }
 `
 
@@ -77,13 +87,14 @@ const Toggle: React.FC<IToggleProps> = ({ isOn, label, onToggle, disabled, heigh
       height={height}
       isOn={isOn}
       width={width}
+      disabled={disabled}
+      onClick={disabled ? null : onToggle}
     >
       <AbsoluteInput
         aria-checked={isOn}
         aria-label={label}
         checked={isOn}
         disabled={disabled}
-        onClick={disabled ? null : onToggle}
         onChange={() => {}}
         p={0}
         role='switch'
@@ -99,7 +110,11 @@ const Toggle: React.FC<IToggleProps> = ({ isOn, label, onToggle, disabled, heigh
         color='background.lightest'
         left={isOn ? leftToggleOnPosition : '2px'}
         top='2px'
+        id='circle-handle' // added for testing purpose
         width={`${circleAbsoluteSize}px`}
+        boxShadowSize='sm'
+        disabled={disabled}
+        data-testid='handle-div'
       >
         {icon}
       </CircleAbsolute>


### PR DESCRIPTION
**Confirmed disabled states for both disabled on and off**
Disabled ON
<img width="137" alt="image" src="https://github.com/priceline/design-system/assets/110497266/3ead6bc6-9842-4276-97d6-0a44c49fab28">

Disabled OFF
<img width="143" alt="image" src="https://github.com/priceline/design-system/assets/110497266/16ed4f35-d0e6-4771-803d-e658afdef24b">

**Added hover states when toggle is selected and enabled**
<img width="117" alt="image" src="https://github.com/priceline/design-system/assets/110497266/bfa95a58-b7ef-4b63-9424-ffe04429789d">

**Updated the focus to focus-visible for keyed events**
<img width="174" alt="image" src="https://github.com/priceline/design-system/assets/110497266/e1e9dcb6-c345-40d8-a3b9-4aff81970c33">

**Added boxShadowSize to handle (sm for off/on, xl for off/on hover)** 

xl for off/on hover
<img width="142" alt="image" src="https://github.com/priceline/design-system/assets/110497266/b84579e2-6286-4c6f-9c98-98c50c8187e6">

sm for off/on
<img width="121" alt="image" src="https://github.com/priceline/design-system/assets/110497266/6537feb4-e92b-4ed7-b105-1bc7bc3bbb6b">
