### PR TITLE
add Dialog component

### DIFF
--- a/common/changes/pcln-design-system/UXPT-4882--Dialog_2023-08-03-18-16.json
+++ b/common/changes/pcln-design-system/UXPT-4882--Dialog_2023-08-03-18-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add dialog component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-design-system/UXPT-4882--Dialog_2023-08-04-16-28.json
+++ b/common/changes/pcln-design-system/UXPT-4882--Dialog_2023-08-04-16-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add neutralDarkOnLightest to colorScheme",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -472,6 +472,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.0.4
         version: 1.0.4(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-visually-hidden':
+        specifier: ^1.0.3
+        version: 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
       '@styled-system/prop-types':
         specifier: ^5.1.5
         version: 5.1.5(styled-system@5.1.5)
@@ -6844,6 +6847,26 @@ packages:
       '@babel/runtime': 7.22.6
       '@types/react': 17.0.62
       react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-visually-hidden@1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-primitive': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@types/react': 17.0.62
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@reach/component-component@0.16.0(react-dom@17.0.2)(react@17.0.2):

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ~1.1.2
         version: 1.1.2(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-dialog':
+        specifier: ^1.0.4
+        version: 1.0.4(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
       '@styled-system/prop-types':
         specifier: ^5.1.5
         version: 5.1.5(styled-system@5.1.5)
@@ -6587,6 +6590,39 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@radix-ui/react-dialog@1.0.4(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-context': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-id': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-portal': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-presence': 1.0.1(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-slot': 1.0.2(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@types/react': 17.0.62
+      aria-hidden: 1.2.3
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-remove-scroll: 2.5.5(@types/react@17.0.62)(react@17.0.2)
+    dev: false
+
   /@radix-ui/react-direction@1.0.1(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
     peerDependencies:
@@ -6599,6 +6635,66 @@ packages:
       '@babel/runtime': 7.22.6
       '@types/react': 17.0.62
       react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.0.4(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@17.0.62)(react@17.0.2)
+      '@types/react': 17.0.62
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@radix-ui/react-focus-guards@1.0.1(@types/react@17.0.62)(react@17.0.2):
+    resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@types/react': 17.0.62
+      react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-focus-scope@1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@types/react': 17.0.62
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@radix-ui/react-id@1.0.1(@types/react@17.0.62)(react@17.0.2):
@@ -6614,6 +6710,26 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@17.0.62)(react@17.0.2)
       '@types/react': 17.0.62
       react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-portal@1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-primitive': 1.0.3(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2)
+      '@types/react': 17.0.62
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@radix-ui/react-presence@1.0.1(@types/react@17.0.62)(react-dom@17.0.2)(react@17.0.2):
@@ -6688,6 +6804,21 @@ packages:
 
   /@radix-ui/react-use-controllable-state@1.0.1(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@17.0.62)(react@17.0.2)
+      '@types/react': 17.0.62
+      react: 17.0.2
+    dev: false
+
+  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@17.0.62)(react@17.0.2):
+    resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0
@@ -18501,8 +18632,8 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-clientside-effect: 1.2.6(react@17.0.2)
-      use-callback-ref: 1.3.0(react@17.0.2)
-      use-sidecar: 1.1.2(react@17.0.2)
+      use-callback-ref: 1.3.0(@types/react@17.0.62)(react@17.0.2)
+      use-sidecar: 1.1.2(@types/react@17.0.62)(react@17.0.2)
     dev: false
 
   /react-focus-lock@2.9.5(react@17.0.2):
@@ -18519,8 +18650,8 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-clientside-effect: 1.2.6(react@17.0.2)
-      use-callback-ref: 1.3.0(react@17.0.2)
-      use-sidecar: 1.1.2(react@17.0.2)
+      use-callback-ref: 1.3.0(@types/react@17.0.62)(react@17.0.2)
+      use-sidecar: 1.1.2(@types/react@17.0.62)(react@17.0.2)
     dev: false
 
   /react-inspector@6.0.2(react@17.0.2):
@@ -18590,7 +18721,7 @@ packages:
     resolution: {integrity: sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==}
     engines: {node: '>=0.10.0'}
 
-  /react-remove-scroll-bar@2.3.4(react@17.0.2):
+  /react-remove-scroll-bar@2.3.4(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -18600,9 +18731,29 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.62
       react: 17.0.2
-      react-style-singleton: 2.2.1(react@17.0.2)
+      react-style-singleton: 2.2.1(@types/react@17.0.62)(react@17.0.2)
       tslib: 2.6.0
+    dev: false
+
+  /react-remove-scroll@2.5.5(@types/react@17.0.62)(react@17.0.2):
+    resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.62
+      react: 17.0.2
+      react-remove-scroll-bar: 2.3.4(@types/react@17.0.62)(react@17.0.2)
+      react-style-singleton: 2.2.1(@types/react@17.0.62)(react@17.0.2)
+      tslib: 2.6.0
+      use-callback-ref: 1.3.0(@types/react@17.0.62)(react@17.0.2)
+      use-sidecar: 1.1.2(@types/react@17.0.62)(react@17.0.2)
     dev: false
 
   /react-remove-scroll@2.5.6(react@17.0.2):
@@ -18616,11 +18767,11 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
-      react-remove-scroll-bar: 2.3.4(react@17.0.2)
-      react-style-singleton: 2.2.1(react@17.0.2)
+      react-remove-scroll-bar: 2.3.4(@types/react@17.0.62)(react@17.0.2)
+      react-style-singleton: 2.2.1(@types/react@17.0.62)(react@17.0.2)
       tslib: 2.6.0
-      use-callback-ref: 1.3.0(react@17.0.2)
-      use-sidecar: 1.1.2(react@17.0.2)
+      use-callback-ref: 1.3.0(@types/react@17.0.62)(react@17.0.2)
+      use-sidecar: 1.1.2(@types/react@17.0.62)(react@17.0.2)
     dev: false
 
   /react-resize-detector@7.1.2(react-dom@17.0.2)(react@17.0.2):
@@ -18644,7 +18795,7 @@ packages:
       react-is: 17.0.2
     dev: true
 
-  /react-style-singleton@2.2.1(react@17.0.2):
+  /react-style-singleton@2.2.1(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -18654,6 +18805,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.62
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 17.0.2
@@ -19906,7 +20058,6 @@ packages:
 
   /storybook-addon-designs@7.0.0-beta.2(@storybook/addon-docs@7.0.27)(@storybook/addons@7.0.27)(@storybook/api@7.0.27)(@storybook/components@7.0.27)(@storybook/theming@7.0.27)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==}
-    deprecated: Newer versions of this package is available under `@storybook/addon-designs`
     peerDependencies:
       '@storybook/addon-docs': ^6.4.0 || ^7.0.0
       '@storybook/addons': ^6.4.0 || ^7.0.0
@@ -21097,7 +21248,7 @@ packages:
     engines: {node: '>= 0.4.1'}
     dev: true
 
-  /use-callback-ref@1.3.0(react@17.0.2):
+  /use-callback-ref@1.3.0(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -21107,6 +21258,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.62
       react: 17.0.2
       tslib: 2.6.0
     dev: false
@@ -21165,7 +21317,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /use-sidecar@1.1.2(react@17.0.2):
+  /use-sidecar@1.1.2(@types/react@17.0.62)(react@17.0.2):
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -21175,6 +21327,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@types/react': 17.0.62
       detect-node-es: 1.1.0
       react: 17.0.2
       tslib: 2.6.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,7 @@
   "license": "MIT",
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.4",
+    "@radix-ui/react-visually-hidden": "^1.0.3",
     "@styled-system/prop-types": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@types/styled-system": "^5.1.16",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.4",
     "@styled-system/prop-types": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@types/styled-system": "^5.1.16",

--- a/packages/core/src/Dialog/Dialog.spec.tsx
+++ b/packages/core/src/Dialog/Dialog.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render } from '../__test__/testing-library'
+
+import { Dialog } from '.'
+
+describe('Dialog', () => {
+  it('should render correctly', () => {
+    const { asFragment } = render(<Dialog>Dialog</Dialog>)
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        .c0 {
+        font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+        line-height: 1.4;
+        font-weight: 500;
+      }
+
+      .c0 * {
+        box-sizing: border-box;
+      }
+
+      <div
+          class="c0"
+        />
+      </DocumentFragment>
+    `)
+  })
+})

--- a/packages/core/src/Dialog/Dialog.spec.tsx
+++ b/packages/core/src/Dialog/Dialog.spec.tsx
@@ -1,28 +1,71 @@
+import { render, screen } from '@testing-library/react'
 import React from 'react'
-import { render } from '../__test__/testing-library'
+import { Dialog } from '..'
 
-import { Dialog } from '.'
+const triggerText = 'Open Dialog'
+const contentText = 'Dialog Content'
 
 describe('Dialog', () => {
-  it('should render correctly', () => {
-    const { asFragment } = render(<Dialog>Dialog</Dialog>)
+  it('renders the trigger node', () => {
+    render(
+      <Dialog triggerNode={<button>{triggerText}</button>} ariaDescription='Description' ariaTitle='Title'>
+        {contentText}
+      </Dialog>
+    )
 
-    expect(asFragment()).toMatchInlineSnapshot(`
-      <DocumentFragment>
-        .c0 {
-        font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-        line-height: 1.4;
-        font-weight: 500;
-      }
+    const triggerNode = screen.getByText(triggerText)
+    expect(triggerNode).toBeInTheDocument()
+  })
 
-      .c0 * {
-        box-sizing: border-box;
-      }
+  it('renders the dialog content when trigger is clicked', () => {
+    render(
+      <Dialog triggerNode={<button>{triggerText}</button>} ariaDescription='Description' ariaTitle='Title'>
+        {contentText}
+      </Dialog>
+    )
 
-      <div
-          class="c0"
-        />
-      </DocumentFragment>
-    `)
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    const contentNode = screen.getByText(contentText)
+    expect(contentNode).toBeInTheDocument()
+  })
+
+  it('calls onOpenChange when trigger is clicked', () => {
+    const onOpenChange = jest.fn()
+    render(
+      <Dialog
+        triggerNode={<button>{triggerText}</button>}
+        ariaDescription='Description'
+        ariaTitle='Title'
+        onOpenChange={onOpenChange}
+      >
+        {contentText}
+      </Dialog>
+    )
+
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+  })
+
+  it('handles controlled state when open', () => {
+    render(
+      <Dialog
+        triggerNode={<button>{triggerText}</button>}
+        ariaDescription='Description'
+        ariaTitle='Title'
+        open={false}
+      >
+        {contentText}
+      </Dialog>
+    )
+
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    const contentNode = screen.queryByText(contentText)
+    expect(contentNode).not.toBeVisible()
   })
 })

--- a/packages/core/src/Dialog/Dialog.spec.tsx
+++ b/packages/core/src/Dialog/Dialog.spec.tsx
@@ -17,7 +17,7 @@ describe('Dialog', () => {
     expect(triggerNode).toBeInTheDocument()
   })
 
-  it('renders the dialog content when trigger is clicked', () => {
+  it('renders the dialog content when trigger is clicked', async () => {
     render(
       <Dialog triggerNode={<button>{triggerText}</button>} ariaDescription='Description' ariaTitle='Title'>
         {contentText}
@@ -26,6 +26,8 @@ describe('Dialog', () => {
 
     const triggerNode = screen.getByText(triggerText)
     triggerNode.click()
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
 
     const contentNode = screen.getByText(contentText)
     expect(contentNode).toBeInTheDocument()

--- a/packages/core/src/Dialog/Dialog.stories.args.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.args.tsx
@@ -1,0 +1,50 @@
+import { ArgTypes } from '@storybook/react'
+import React from 'react'
+import type { IDialogProps } from '.'
+import { borderRadii, Button, colorSchemeNames, Grid, paletteColors, Text } from '..'
+import { DialogSizes } from './Dialog.styled'
+
+export const argTypes: Partial<ArgTypes<IDialogProps>> = {
+  borderRadius: { control: { type: 'select' }, options: Object.keys(borderRadii) },
+  children: { control: { type: 'none' } },
+  fullWidth: { control: { type: 'boolean' } },
+  headerColorScheme: { control: { type: 'select' }, options: colorSchemeNames },
+  headerContent: { type: 'string' },
+  headerIcon: { type: 'boolean' },
+  headerShowCloseButton: { type: 'boolean' },
+  hugColor: { control: { type: 'select' }, options: paletteColors },
+  open: { control: { type: 'boolean' } },
+  sheet: { control: { type: 'boolean' } },
+  showCloseButton: { control: { type: 'boolean' } },
+  size: { control: { type: 'select' }, options: DialogSizes },
+  triggerNode: { control: { type: 'none' } },
+}
+
+export const defaultArgs: Partial<IDialogProps> = {
+  ariaDescription: 'This is a description',
+  ariaTitle: 'This is a title',
+  borderRadius: '2xl',
+  children: (
+    <Grid p={[3, 3, 3, 3, '24px', '24px']} gap={3}>
+      <Text>
+        The quick brown fox jumps over the lazy dog to discover new deals every day. Lorem ipsum dolor sit
+        amet, consectetur adipiscing elit.
+      </Text>
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras id erat nec ante semper eleifend. In ex
+        mi, eleifend non ultricies sed, ullamcorper a sem. Aenean mollis mi eget libero commodo, non auctor
+        dui fermentum. Aliquam ultrices nisi in odio sodales, vel feugiat libero gravida.
+      </Text>
+    </Grid>
+  ),
+  fullWidth: false,
+  headerColorScheme: 'neutralDarkOnLightest',
+  headerIcon: false,
+  headerShowCloseButton: false,
+  scrimDismiss: true,
+  scrimColor: 'dark',
+  sheet: false,
+  showCloseButton: true,
+  size: 'md',
+  triggerNode: <Button>Open Dialog</Button>,
+}

--- a/packages/core/src/Dialog/Dialog.stories.args.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.args.tsx
@@ -2,7 +2,7 @@ import { ArgTypes } from '@storybook/react'
 import React from 'react'
 import type { IDialogProps } from '.'
 import { borderRadii, Button, colorSchemeNames, Grid, paletteColors, Text } from '..'
-import { DialogSizes } from './Dialog.styled'
+import { dialogSizes } from './Dialog.styled'
 
 export const argTypes: Partial<ArgTypes<IDialogProps>> = {
   borderRadius: { control: { type: 'select' }, options: Object.keys(borderRadii) },
@@ -16,7 +16,7 @@ export const argTypes: Partial<ArgTypes<IDialogProps>> = {
   open: { control: { type: 'boolean' } },
   sheet: { control: { type: 'boolean' } },
   showCloseButton: { control: { type: 'boolean' } },
-  size: { control: { type: 'select' }, options: DialogSizes },
+  size: { control: { type: 'select' }, options: dialogSizes },
   triggerNode: { control: { type: 'none' } },
 }
 

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -1,159 +1,204 @@
+/* eslint-disable no-script-url */
 import type { Meta, StoryObj } from '@storybook/react'
-import type { IDialogProps } from './Dialog'
+import type { IDialogProps, IGridProps } from '..'
 
-import { User } from 'pcln-icons'
-import React from 'react'
-import { Dialog } from '.'
-import { Box } from '../Box'
-import { Button } from '../Button'
-import { Container } from '../Container'
-import { StoryStage } from '../DocsUtils'
-import { Heading } from '../Heading'
-import { Text } from '../Text'
-import { colorSchemeNames } from '../storybook/args'
+import { Discount } from 'pcln-icons'
+import React, { useState } from 'react'
+
+import { Box, Breadcrumbs, Button, Dialog, Grid, Text } from '..'
+import { argTypes, defaultArgs } from './Dialog.stories.args'
 
 type DialogStory = StoryObj<IDialogProps>
 
-const sizeOptions = ['sm', 'md', 'lg', 'xl', 'xxl']
+const exampleHeaderProps: Partial<IDialogProps> = {
+  headerColorScheme: 'neutralDarkOnLightest',
+  headerContent: 'Hello World',
+  headerIcon: <Discount />,
+  headerShowCloseButton: true,
+}
 
 export const Playground: DialogStory = {
-  render: (args) => <Dialog {...args} />,
+  render: (args) => <Dialog {...args} headerIcon={args.headerIcon && exampleHeaderProps.headerIcon} />,
 }
 
-export const HeaderString: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
-  args: {
-    headerContent: 'STRING HEADER',
-  },
-}
-export const HeaderTextNode: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
-  args: {
-    headerContent: <Text textStyle='title3'>Dialog Header</Text>,
-  },
-}
-
-export const Hug: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
+export const WithHug: DialogStory = {
+  ...Playground,
   args: {
     hugColor: 'primary.base',
   },
 }
 
-export const HeaderColorScheme: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
+export const WithHeaderText: DialogStory = {
+  ...Playground,
   args: {
-    headerColorScheme: 'primary',
-    headerContent: 'Primary Color Scheme',
+    showCloseButton: false,
+    ...exampleHeaderProps,
+  },
+}
+export const WithHeaderContent: DialogStory = {
+  ...Playground,
+  args: {
+    showCloseButton: false,
+    headerContent: (
+      <Text textStyle='paragraph'>
+        <Breadcrumbs>
+          <Breadcrumbs.Link href='javascript:void(0)' label='Home' />
+          <Breadcrumbs.Link href='javascript:void(0)' label='Flights' />
+          <Breadcrumbs.Link href='javascript:void(0)' label='Settings' />
+        </Breadcrumbs>
+      </Text>
+    ),
+    headerColorScheme: 'neutralDarkOnLightest',
+    headerShowCloseButton: true,
   },
 }
 
-export const HeaderColorSchemeIcon: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
-  args: {
-    headerColorScheme: 'primary',
-    headerContent: 'Primary Color Scheme',
-    headerIcon: <User />,
-  },
-}
-
-export const ContentPaddingWithHeader: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
-  args: {
-    headerColorScheme: 'primary',
-    headerContent: 'Primary Color Scheme',
-  },
-}
-
-export const ContentPaddingWithoutHeader: DialogStory = {
-  render: (args) => (
-    <StoryStage>
-      <Dialog {...args} />
-    </StoryStage>
-  ),
-}
-
-const DefaultContent = () => (
-  <Box>
-    <Heading.h3 textStyle='heading3'>Heading3</Heading.h3>
-    <Heading.h4 textStyle='heading3'>Heading4</Heading.h4>
-    <Text textStyle='paragraph'>
-      Paragraph. The quick brown fox jumps over the lazy dog to discover new deals every day. Lorem ipsum
-      dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      Cras id erat nec ante semper eleifend. In ex mi, eleifend non ultricies sed, ullamcorper a sem. Aenean
-      mollis mi eget libero commodo, non auctor dui fermentum. Aliquam ultrices nisi in odio sodales, vel
-      feugiat libero gravida.
-    </Text>
-    <Text textStyle='paragraph'>
-      Paragraph. The quick brown fox jumps over the lazy dog to discover new deals every day. Lorem ipsum
-      dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      Cras id erat nec ante semper eleifend. In ex mi, eleifend non ultricies sed, ullamcorper a sem. Aenean
-      mollis mi eget libero commodo, non auctor dui fermentum. Aliquam ultrices nisi in odio sodales, vel
-      feugiat libero gravida.
-    </Text>
-  </Box>
+const ExampleImage = () => (
+  <img
+    src='https://s1.pclncdn.com/design-assets/hero/beach.jpg?opto&optimize=medium&auto=jpg&width=600&height=450&fit=crop'
+    alt='an example'
+    style={{ width: '100%', display: 'block' }}
+  />
 )
-const defaultArgs = {
-  triggerNode: (
-    <Container>
-      <Button borderRadius='xl'>Open Modal</Button>
-    </Container>
-  ),
-  children: <DefaultContent />,
-}
-const argTypes = {
-  headerColorScheme: {
-    control: { type: 'select' },
-    options: colorSchemeNames,
-    defaultValue: 'primary',
-  },
-  size: {
-    control: { type: 'select' },
-    options: sizeOptions,
-    defaultValue: 'md',
-  },
-  triggerNode: {
-    control: { type: 'none' },
-  },
-  children: {
-    control: { type: 'none' },
+
+export const FullWidthImage: DialogStory = {
+  ...Playground,
+  args: {
+    children: (
+      <>
+        <ExampleImage />
+        <Grid p={24} gap={3}>
+          <Text textStyle='heading1'>Dialog Heading</Text>
+          <Text textStyle='paragraph'>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Totam possimus quia voluptatem minima
+            voluptatum dolor rem cumque odio ab accusantium deleniti vero voluptas odit numquam fugit non
+            eveniet, sunt natus!
+          </Text>
+        </Grid>
+      </>
+    ),
   },
 }
+
+const ExampleOverflowingContent = (props: IGridProps) => (
+  <Grid p={24} gap={5} {...props}>
+    {[...Array(5).keys()].map((i) => (
+      <>
+        <Text textStyle='heading4'>
+          {i + 1}. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ex quas voluptas, vel id
+          doloribus delectus deleniti minus eius ullam vero dolorum laboriosam dolor cupiditate sequi quia
+          itaque corrupti quaerat hic!
+        </Text>
+        <ExampleImage />
+      </>
+    ))}
+  </Grid>
+)
+
+export const OverflowModal: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingContent />,
+  },
+}
+
+export const OverflowContent: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingContent overflow='auto' maxHeight='calc(100vh - 2 * 96px)' />,
+  },
+}
+export const StickyHeader: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingContent overflow='auto' maxHeight={500} />,
+    ...exampleHeaderProps,
+    headerShowCloseButton: false,
+  },
+}
+
+export const ScrimColors: DialogStory = {
+  render: (args) => {
+    const [scrimColor, setScrimColor] = useState<IDialogProps['scrimColor']>('dark')
+
+    return (
+      <Dialog {...args} headerIcon={args.headerIcon && exampleHeaderProps.headerIcon} scrimColor={scrimColor}>
+        <Grid p={4} gap={4}>
+          <Text textStyle='heading3' textAlign='center'>
+            Set Scrim Color:
+          </Text>
+          <Grid gap={4} templateColumns='1fr 1fr'>
+            <Button onClick={() => setScrimColor('dark')}>Dark</Button>
+            <Button onClick={() => setScrimColor('medium')}>Medium</Button>
+            <Button onClick={() => setScrimColor('light')}>Light</Button>
+            <Button onClick={() => setScrimColor('rgba(0, 0, 0, 0.5)')}>rgba(0, 0, 0, 0.5)</Button>
+          </Grid>
+        </Grid>
+      </Dialog>
+    )
+  },
+}
+
+// export const WithShadowOnScroll: DialogStory = {
+//   ...Playground,
+//   args: {
+//     children: (
+//       <ExampleOverflowingContent
+//         overflow='auto'
+//         maxHeight={500}
+//         background={`
+//           linear-gradient(#ffffff 33%, rgba(255,255,255, 0)),
+//           linear-gradient(rgba(255,255,255, 0), #ffffff 66%) 0 100%,
+//           radial-gradient(farthest-side at 50% 0, rgba(40,40,40, 0.5), rgba(0,0,0,0)),
+//           radial-gradient(farthest-side at 50% 100%, rgba(40,40,40, 0.5), rgba(0,0,0,0)) 0 100%,
+//           linear-gradient(rgba(0,0,0,.15), rgba(0,0,0,.15))
+//         `}
+//         backgroundRepeat='no-repeat'
+//         backgroundSize='100% 40px, 100% 40px, 100% 16px, 100% 16px, 100% 1px'
+//         style={{ backgroundAttachment: 'local, local, scroll, scroll, scroll' }}
+//       />
+//     ),
+//     ...exampleHeaderProps,
+//     headerShowCloseButton: false,
+//   },
+// }
+
+export const SheetMode: DialogStory = {
+  ...Playground,
+  args: {
+    sheet: true,
+  },
+}
+
+export const Controlled: DialogStory = {
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <Dialog
+        {...args}
+        triggerNode={
+          <Button onClick={() => setOpen(true)}>Click to open. Modal is {open ? 'open' : 'closed'}</Button>
+        }
+        open={open}
+        onOpenChange={setOpen}
+        {...exampleHeaderProps}
+      >
+        <Grid p={3} gap={3}>
+          <Box>Dialog Content</Box>
+          <Grid placeItems='end' autoFlow='column'>
+            <Button onClick={() => setOpen(false)}>Close</Button>
+          </Grid>
+        </Grid>
+      </Dialog>
+    )
+  },
+}
+
 const meta: Meta<typeof Dialog> = {
   title: 'Overlays/Dialog',
   component: Dialog,
-  parameters: {
-    controls: {
-      exclude: ['triggerNode'],
-    },
-  },
-
   args: defaultArgs,
-  argTypes,
+  argTypes: argTypes,
 }
 
 export default meta

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { IDialogProps } from './Dialog'
+
+import { User } from 'pcln-icons'
+import React from 'react'
+import { Dialog } from '.'
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { Container } from '../Container'
+import { StoryStage } from '../DocsUtils'
+import { Heading } from '../Heading'
+import { Text } from '../Text'
+import { colorSchemeNames } from '../storybook/args'
+
+type DialogStory = StoryObj<IDialogProps>
+
+const sizeOptions = ['sm', 'md', 'lg', 'xl', 'xxl']
+
+export const Playground: DialogStory = {
+  render: (args) => <Dialog {...args} />,
+}
+
+export const HeaderString: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    headerContent: 'STRING HEADER',
+  },
+}
+export const HeaderTextNode: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    headerContent: <Text textStyle='title3'>Dialog Header</Text>,
+  },
+}
+
+export const Hug: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    hugColor: 'primary.base',
+  },
+}
+
+export const HeaderColorScheme: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    headerColorScheme: 'primary',
+    headerContent: 'Primary Color Scheme',
+  },
+}
+
+export const HeaderColorSchemeIcon: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    headerColorScheme: 'primary',
+    headerContent: 'Primary Color Scheme',
+    headerIcon: <User />,
+  },
+}
+
+export const ContentPaddingWithHeader: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+  args: {
+    headerColorScheme: 'primary',
+    headerContent: 'Primary Color Scheme',
+  },
+}
+
+export const ContentPaddingWithoutHeader: DialogStory = {
+  render: (args) => (
+    <StoryStage>
+      <Dialog {...args} />
+    </StoryStage>
+  ),
+}
+
+const DefaultContent = () => (
+  <Box>
+    <Heading.h3 textStyle='heading3'>Heading3</Heading.h3>
+    <Heading.h4 textStyle='heading3'>Heading4</Heading.h4>
+    <Text textStyle='paragraph'>
+      Paragraph. The quick brown fox jumps over the lazy dog to discover new deals every day. Lorem ipsum
+      dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Cras id erat nec ante semper eleifend. In ex mi, eleifend non ultricies sed, ullamcorper a sem. Aenean
+      mollis mi eget libero commodo, non auctor dui fermentum. Aliquam ultrices nisi in odio sodales, vel
+      feugiat libero gravida.
+    </Text>
+    <Text textStyle='paragraph'>
+      Paragraph. The quick brown fox jumps over the lazy dog to discover new deals every day. Lorem ipsum
+      dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Cras id erat nec ante semper eleifend. In ex mi, eleifend non ultricies sed, ullamcorper a sem. Aenean
+      mollis mi eget libero commodo, non auctor dui fermentum. Aliquam ultrices nisi in odio sodales, vel
+      feugiat libero gravida.
+    </Text>
+  </Box>
+)
+const defaultArgs = {
+  triggerNode: (
+    <Container>
+      <Button borderRadius='xl'>Open Modal</Button>
+    </Container>
+  ),
+  children: <DefaultContent />,
+}
+const argTypes = {
+  headerColorScheme: {
+    control: { type: 'select' },
+    options: colorSchemeNames,
+    defaultValue: 'primary',
+  },
+  size: {
+    control: { type: 'select' },
+    options: sizeOptions,
+    defaultValue: 'md',
+  },
+  triggerNode: {
+    control: { type: 'none' },
+  },
+  children: {
+    control: { type: 'none' },
+  },
+}
+const meta: Meta<typeof Dialog> = {
+  title: 'Overlays/Dialog',
+  component: Dialog,
+  parameters: {
+    controls: {
+      exclude: ['triggerNode'],
+    },
+  },
+
+  args: defaultArgs,
+  argTypes,
+}
+
+export default meta

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -1,0 +1,119 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import styled from 'styled-components'
+import { Box } from '../Box'
+import { getPaletteColor } from '../utils'
+
+const SCRIM_COLOR = 'rgba(0, 24, 51, 0.5)'
+
+export const DialogOverlay = styled(Dialog.Overlay)`
+  background-color: ${SCRIM_COLOR};
+  position: fixed;
+  inset: 0;
+
+  animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  @keyframes overlayShow {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`
+
+export const SIZES = {
+  sm: {
+    content: { p: 3 },
+    header: {
+      textStyle: 'heading4',
+    },
+  },
+  md: {
+    content: { p: 3 },
+    header: {
+      textStyle: 'heading3',
+    },
+  },
+  lg: {
+    content: { p: '24px' },
+    header: {
+      textStyle: 'heading3',
+    },
+  },
+  xl: {
+    content: { p: '24px' },
+    header: {
+      textStyle: 'heading3',
+    },
+  },
+  xxl: {
+    content: { p: '24px' },
+    header: {
+      textStyle: 'heading3',
+    },
+  },
+}
+
+export const DialogContentArea = styled(Box).attrs((props) => {
+  const { size, headerContent } = props
+  const contentSize = SIZES[size].content
+
+  if (contentSize) {
+    return {
+      px: contentSize.p,
+      pb: contentSize.p,
+      pt: headerContent ? 0 : contentSize.p,
+    }
+  }
+})``
+
+export const DialogContent = styled(Dialog.Content)`
+  background-color: white;
+  box-shadow: hsl(206 22% 7% / 35%) 0px 10px 38px -10px, hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  max-width: 750px;
+  max-height: 85vh;
+  animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  &:focus {
+    outline: none;
+  }
+
+  @keyframes contentShow {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -48%) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+
+  ${(props) =>
+    props?.hugColor &&
+    `
+    border-top: 4px solid ${getPaletteColor(props.hugColor)(props)};
+    `}
+`
+
+export const DialogTitle = styled(Box)`
+  ${(props) =>
+    props?.headerColorScheme === 'primary' &&
+    `
+    background-color: ${getPaletteColor('primary.base')(props)};
+    color: ${getPaletteColor('text.lightest')(props)};
+  `}
+`
+
+export const DialogDescription = styled(Dialog.Description)`
+  margin: 10px 0 20px;
+  color: red;
+  font-size: 15px;
+  line-height: 1.5;
+`

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,0 +1,103 @@
+import type { ColorSchemeName } from '../theme'
+
+import * as Dialog from '@radix-ui/react-dialog'
+import React from 'react'
+import { Close } from 'pcln-icons'
+
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { Grid } from '../Grid'
+import { Text } from '../Text'
+import { ThemeProvider } from '../ThemeProvider'
+import {
+  DialogContent,
+  DialogContentArea,
+  DialogDescription,
+  DialogOverlay,
+  DialogTitle,
+  SIZES,
+} from './Dialog.styled'
+
+export interface IDialogProps {
+  children?: React.ReactNode | JSX.Element[]
+  description: string
+  headerColorScheme?: ColorSchemeName
+  headerContent?: React.ReactNode
+  headerIcon?: React.ReactNode
+  hugColor?: string // TODO should be enum of palette
+  modal?: boolean
+  defaultOpen?: boolean
+  size: 'sm' | 'md' | 'lg' | 'xl'
+  triggerNode?: React.ReactNode | JSX.Element[]
+}
+
+const PclnDialog: React.FC = ({
+  children,
+  description,
+  defaultOpen = false,
+  headerColorScheme,
+  headerContent,
+  headerIcon,
+  hugColor,
+  modal = false,
+  size = 'md',
+  triggerNode,
+}: IDialogProps) => {
+  const showHeaderCloseButton = true
+
+  const headerTextStyle = SIZES[size].header.textStyle
+
+  return (
+    <Dialog.Root defaultOpen={defaultOpen} modal={modal}>
+      <Dialog.Trigger asChild>{triggerNode}</Dialog.Trigger>
+      <Dialog.Portal>
+        <ThemeProvider>
+          <DialogOverlay />
+          <DialogContent as={Box} borderRadius='2xl' hugColor={hugColor}>
+            <Dialog.Title asChild>
+              <DialogTitle
+                size={size}
+                headerColorScheme={headerColorScheme}
+                borderRadius='2xl'
+                rounded='top'
+                px={[3, null, 24]}
+                py={3}
+              >
+                <Grid templateColumns={['1fr auto']} gap={2} width={1}>
+                  <Grid templateColumns={['auto 1fr']} alignItems='center' gap={2} width={1}>
+                    <Grid>{headerIcon}</Grid>
+                    <Grid>
+                      <Text textStyle={headerTextStyle}>{headerContent}</Text>
+                    </Grid>
+                  </Grid>
+
+                  <Grid>
+                    {showHeaderCloseButton && (
+                      <Dialog.Close asChild>
+                        <Button size='extraLarge' color='primary' borderRadius='xl' IconLeft={Close} />
+                      </Dialog.Close>
+                    )}
+                  </Grid>
+                </Grid>
+              </DialogTitle>
+            </Dialog.Title>
+
+            <DialogContentArea size={size} headerContent={headerContent}>
+              <DialogDescription>{description}</DialogDescription>
+
+              {children}
+
+              <Dialog.Close asChild>
+                <Button size='extraLarge' color='primary' borderRadius='xl' IconLeft={Close} />
+              </Dialog.Close>
+            </DialogContentArea>
+          </DialogContent>
+        </ThemeProvider>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+PclnDialog.displayName = 'Dialog'
+
+export default PclnDialog

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,99 +1,85 @@
-import type { ColorSchemeName } from '../theme'
+import type { BorderRadius, ColorSchemes, PaletteColor } from '../theme'
+import type { DialogSize } from './Dialog.styled'
+import { DialogContent, DialogOverlay } from './Dialog.styled'
 
 import * as Dialog from '@radix-ui/react-dialog'
-import React from 'react'
-import { Close } from 'pcln-icons'
-
-import { Box } from '../Box'
-import { Button } from '../Button'
-import { Grid } from '../Grid'
-import { Text } from '../Text'
-import { ThemeProvider } from '../ThemeProvider'
-import {
-  DialogContent,
-  DialogContentArea,
-  DialogDescription,
-  DialogOverlay,
-  DialogTitle,
-  SIZES,
-} from './Dialog.styled'
+import React, { useEffect } from 'react'
 
 export interface IDialogProps {
-  children?: React.ReactNode | JSX.Element[]
-  description: string
-  headerColorScheme?: ColorSchemeName
-  headerContent?: React.ReactNode
-  headerIcon?: React.ReactNode
-  hugColor?: string // TODO should be enum of palette
-  modal?: boolean
+  ariaDescription: string
+  ariaTitle: string
+  borderRadius?: BorderRadius
+  children?: React.ReactNode
   defaultOpen?: boolean
-  size: 'sm' | 'md' | 'lg' | 'xl'
-  triggerNode?: React.ReactNode | JSX.Element[]
+  fullWidth?: boolean
+  headerColorScheme?: keyof ColorSchemes
+  headerContent?: string | React.ReactNode
+  headerIcon?: React.ReactNode
+  headerShowCloseButton?: boolean
+  hugColor?: PaletteColor
+  open?: boolean
+  scrimColor?: 'dark' | 'medium' | 'light' | (string & {})
+  scrimDismiss?: boolean
+  sheet?: boolean
+  showCloseButton?: boolean
+  size?: DialogSize
+  triggerNode?: React.ReactNode
+  onOpenChange?: (open: boolean) => void
 }
 
-const PclnDialog: React.FC = ({
+const PclnDialog = ({
+  ariaDescription,
+  ariaTitle,
+  borderRadius = '2xl',
   children,
-  description,
   defaultOpen = false,
-  headerColorScheme,
+  fullWidth = false,
+  headerColorScheme = 'neutralDarkOnLightest',
   headerContent,
   headerIcon,
+  headerShowCloseButton = false,
   hugColor,
-  modal = false,
+  open,
+  scrimColor = 'dark',
+  scrimDismiss = true,
+  sheet = false,
+  showCloseButton = true,
   size = 'md',
   triggerNode,
+  onOpenChange,
 }: IDialogProps) => {
-  const showHeaderCloseButton = true
+  const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
-  const headerTextStyle = SIZES[size].header.textStyle
+  useEffect(() => setOpen(open), [open])
+
+  const handleOpenChange = (newOpen: boolean) => {
+    onOpenChange?.(newOpen)
+    setOpen(newOpen)
+  }
 
   return (
-    <Dialog.Root defaultOpen={defaultOpen} modal={modal}>
+    <Dialog.Root open={_open} onOpenChange={handleOpenChange} defaultOpen={defaultOpen}>
       <Dialog.Trigger asChild>{triggerNode}</Dialog.Trigger>
-      <Dialog.Portal>
-        <ThemeProvider>
-          <DialogOverlay />
-          <DialogContent as={Box} borderRadius='2xl' hugColor={hugColor}>
-            <Dialog.Title asChild>
-              <DialogTitle
-                size={size}
-                headerColorScheme={headerColorScheme}
-                borderRadius='2xl'
-                rounded='top'
-                px={[3, null, 24]}
-                py={3}
-              >
-                <Grid templateColumns={['1fr auto']} gap={2} width={1}>
-                  <Grid templateColumns={['auto 1fr']} alignItems='center' gap={2} width={1}>
-                    <Grid>{headerIcon}</Grid>
-                    <Grid>
-                      <Text textStyle={headerTextStyle}>{headerContent}</Text>
-                    </Grid>
-                  </Grid>
-
-                  <Grid>
-                    {showHeaderCloseButton && (
-                      <Dialog.Close asChild>
-                        <Button size='extraLarge' color='primary' borderRadius='xl' IconLeft={Close} />
-                      </Dialog.Close>
-                    )}
-                  </Grid>
-                </Grid>
-              </DialogTitle>
-            </Dialog.Title>
-
-            <DialogContentArea size={size} headerContent={headerContent}>
-              <DialogDescription>{description}</DialogDescription>
-
-              {children}
-
-              <Dialog.Close asChild>
-                <Button size='extraLarge' color='primary' borderRadius='xl' IconLeft={Close} />
-              </Dialog.Close>
-            </DialogContentArea>
-          </DialogContent>
-        </ThemeProvider>
-      </Dialog.Portal>
+      <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet}>
+        <DialogContent
+          ariaDescription={ariaDescription}
+          ariaTitle={ariaTitle}
+          borderRadius={borderRadius}
+          fullWidth={fullWidth}
+          headerColorScheme={headerColorScheme}
+          headerContent={headerContent}
+          headerIcon={headerIcon}
+          headerShowCloseButton={headerShowCloseButton}
+          hugColor={hugColor}
+          onOpenChange={handleOpenChange}
+          scrimDismiss={scrimDismiss}
+          sheet={sheet}
+          showCloseButton={showCloseButton}
+          size={size}
+        >
+          {children}
+        </DialogContent>
+      </DialogOverlay>
     </Dialog.Root>
   )
 }

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence } from 'framer-motion'
 import type { BorderRadius, ColorSchemes, PaletteColor } from '../theme'
 import type { DialogSize } from './Dialog.styled'
 import { DialogContent, DialogOverlay } from './Dialog.styled'
@@ -60,26 +61,30 @@ const PclnDialog = ({
   return (
     <Dialog.Root open={_open} onOpenChange={handleOpenChange} defaultOpen={defaultOpen}>
       <Dialog.Trigger asChild>{triggerNode}</Dialog.Trigger>
-      <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet}>
-        <DialogContent
-          ariaDescription={ariaDescription}
-          ariaTitle={ariaTitle}
-          borderRadius={borderRadius}
-          fullWidth={fullWidth}
-          headerColorScheme={headerColorScheme}
-          headerContent={headerContent}
-          headerIcon={headerIcon}
-          headerShowCloseButton={headerShowCloseButton}
-          hugColor={hugColor}
-          onOpenChange={handleOpenChange}
-          scrimDismiss={scrimDismiss}
-          sheet={sheet}
-          showCloseButton={showCloseButton}
-          size={size}
-        >
-          {children}
-        </DialogContent>
-      </DialogOverlay>
+      <AnimatePresence>
+        {_open && (
+          <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet}>
+            <DialogContent
+              ariaDescription={ariaDescription}
+              ariaTitle={ariaTitle}
+              borderRadius={borderRadius}
+              fullWidth={fullWidth}
+              headerColorScheme={headerColorScheme}
+              headerContent={headerContent}
+              headerIcon={headerIcon}
+              headerShowCloseButton={headerShowCloseButton}
+              hugColor={hugColor}
+              onOpenChange={handleOpenChange}
+              scrimDismiss={scrimDismiss}
+              sheet={sheet}
+              showCloseButton={showCloseButton}
+              size={size}
+            >
+              {children}
+            </DialogContent>
+          </DialogOverlay>
+        )}
+      </AnimatePresence>
     </Dialog.Root>
   )
 }

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -1,0 +1,3 @@
+export type { IDialogProps } from './Dialog'
+
+export { default as Dialog } from './Dialog'

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -24,6 +24,8 @@ import {
   typography,
   TypographyProps,
 } from 'styled-system'
+import type { ColorSchemeName } from '..'
+import { colorScheme } from '..'
 
 export interface IStyledSystemProps
   extends BackgroundProps,
@@ -67,6 +69,7 @@ export interface IGridProps extends IStyledSystemProps {
   templateColumns?: GridProps['gridTemplateColumns']
   templateAreas?: GridProps['gridTemplateAreas']
   placeItems?: FlexboxProps['alignItems']
+  colorScheme?: ColorSchemeName
 }
 
 const GridStyleFns = system({
@@ -88,6 +91,7 @@ const GridStyleFns = system({
 const StyledGrid = styled.div<IGridProps>`
   ${ComposedStyleFns}
   ${GridStyleFns}
+  ${colorScheme}
   display: grid;
 `
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,8 @@
+import * as storybookArgs from './storybook/args'
+
 export type { IButtonProps } from './Button'
+export type { IDialogProps } from './Dialog'
+export type { IGridProps } from './Grid'
 
 export { Absolute } from './Absolute'
 export { Accordion } from './Accordion'
@@ -16,6 +20,7 @@ export { Checkbox } from './Checkbox'
 export { ButtonChip, FilterChip as Chip, ChoiceChip, FilterChip } from './Chip'
 export { CloseButton } from './CloseButton'
 export * from './Container'
+export { Dialog } from './Dialog'
 export { Divider } from './Divider'
 export { DotLoader } from './DotLoader'
 export { Flag } from './Flag'
@@ -80,8 +85,6 @@ export * from './DocsUtils/Section'
 export * from './DocsUtils/StoryHeading'
 export * from './DocsUtils/StoryStage'
 export * from './DocsUtils/TableOfContents'
-
-import * as storybookArgs from './storybook/args'
 export { storybookArgs }
 
 export * from './theme'

--- a/packages/core/src/storybook/args/index.ts
+++ b/packages/core/src/storybook/args/index.ts
@@ -11,8 +11,6 @@ import { zIndices, colorSchemeNames as colorSchemeNamesArr } from '../../theme'
 
 export const colorSchemeNames = colorSchemeNamesArr
 
-export { colorSchemeNames } from '../../utils/createColorScheme'
-
 export const colors = ['', ...paletteFamilies, 'NOTVALID']
 
 export const borderRadii = ['', ...borderRadiusValues, 'NOTVALID']

--- a/packages/core/src/storybook/args/index.ts
+++ b/packages/core/src/storybook/args/index.ts
@@ -11,6 +11,8 @@ import { zIndices, colorSchemeNames as colorSchemeNamesArr } from '../../theme'
 
 export const colorSchemeNames = colorSchemeNamesArr
 
+export { colorSchemeNames } from '../../utils/createColorScheme'
+
 export const colors = ['', ...paletteFamilies, 'NOTVALID']
 
 export const borderRadii = ['', ...borderRadiusValues, 'NOTVALID']

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -576,6 +576,44 @@ export type ColorSchemeName = typeof colorSchemeNames[number]
 export type ColorSchemes = Record<ColorSchemeName, ColorScheme>
 
 /** @public */
+export type ColorSchemeName =
+  | 'primary'
+  | 'primaryLight'
+  | 'primaryLightest'
+  | 'primaryDark'
+  | 'primaryShade'
+  | 'primaryDarkOnLight'
+  | 'secondary'
+  | 'secondaryLight'
+  | 'secondaryLightest'
+  | 'secondaryDark'
+  | 'secondaryDarkOnLight'
+  | 'neutral'
+  | 'neutralLight'
+  | 'neutralLightest'
+  | 'neutralDark'
+  | 'neutralDarkOnLight'
+  | 'success'
+  | 'successLight'
+  | 'successLightest'
+  | 'successDark'
+  | 'successDarkOnLight'
+  | 'warning'
+  | 'warningLight'
+  | 'warningLightest'
+  | 'cautionLight'
+  | 'highlightLight'
+  | 'promo'
+  | 'promoLight'
+  | 'promoLightest'
+  | 'promoDark'
+  | 'promoDarkOnLight'
+  | 'alert'
+  | 'alertLight'
+  | 'alertLightest'
+  | 'alertDarkOnLight'
+
+/** @public */
 export type DesignSystemTheme = {
   space: string[]
   colors: Record<string, string>

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -289,6 +289,8 @@ export const borderRadii = {
   ...actionBorderRadii,
 }
 
+export type BorderRadius = keyof typeof borderRadii
+
 export const maxContainerWidth = '1280px'
 
 export const shadows = {
@@ -439,6 +441,19 @@ export type TextStyle = {
 }
 
 /** @public */
+export const paletteFamilyVariations = [
+  'lightest',
+  'light',
+  'tint',
+  'base',
+  'heading',
+  'tone',
+  'dark',
+  'shade',
+  'darkest',
+] as const
+
+/** @public */
 export type PaletteFamily = {
   lightest?: string
   light?: string
@@ -483,6 +498,9 @@ type _PaletteFamilyOption = Array<keyof PaletteFamily>[number]
 
 /** @public */
 export type PaletteColor = `${_PaletteFamily}.${_PaletteFamilyOption}`
+export const paletteColors = paletteFamilyNames.flatMap((family) =>
+  paletteFamilyVariations.map((variation) => `${family}.${variation}`)
+)
 
 /** @public */
 export type ColorStyle = {
@@ -548,6 +566,7 @@ export const colorSchemeNames = [
   'neutralLightest',
   'neutralDark',
   'neutralDarkOnLight',
+  'neutralDarkOnLightest',
   'success',
   'successLight',
   'successLightest',
@@ -574,44 +593,6 @@ export type ColorSchemeName = typeof colorSchemeNames[number]
 
 /** @public */
 export type ColorSchemes = Record<ColorSchemeName, ColorScheme>
-
-/** @public */
-export type ColorSchemeName =
-  | 'primary'
-  | 'primaryLight'
-  | 'primaryLightest'
-  | 'primaryDark'
-  | 'primaryShade'
-  | 'primaryDarkOnLight'
-  | 'secondary'
-  | 'secondaryLight'
-  | 'secondaryLightest'
-  | 'secondaryDark'
-  | 'secondaryDarkOnLight'
-  | 'neutral'
-  | 'neutralLight'
-  | 'neutralLightest'
-  | 'neutralDark'
-  | 'neutralDarkOnLight'
-  | 'success'
-  | 'successLight'
-  | 'successLightest'
-  | 'successDark'
-  | 'successDarkOnLight'
-  | 'warning'
-  | 'warningLight'
-  | 'warningLightest'
-  | 'cautionLight'
-  | 'highlightLight'
-  | 'promo'
-  | 'promoLight'
-  | 'promoLightest'
-  | 'promoDark'
-  | 'promoDarkOnLight'
-  | 'alert'
-  | 'alertLight'
-  | 'alertLightest'
-  | 'alertDarkOnLight'
 
 /** @public */
 export type DesignSystemTheme = {

--- a/packages/core/src/utils/createColorScheme.ts
+++ b/packages/core/src/utils/createColorScheme.ts
@@ -103,6 +103,11 @@ export const createColorScheme = ({ palette }: { palette: PaletteFamilies }): Co
       backgroundName: 'background.light',
       foreground: background.darkest,
     },
+    neutralDarkOnLightest: {
+      background: background.lightest,
+      backgroundName: 'background.lightest',
+      foreground: background.darkest,
+    },
 
     // Success
     ///////////////////////////////////////////////

--- a/rigs/component/profiles/react/config/jest.config.json
+++ b/rigs/component/profiles/react/config/jest.config.json
@@ -8,7 +8,6 @@
 
   "collectCoverage": true,
   "collectCoverageFrom": [
-    "src/**/*.{js,ts}",
     "src/**/*.{js,ts}(x)",
     "!src/**/*.styled.*",
     "!src/storybook/**/*",


### PR DESCRIPTION
This PR adds the `Dialog` component to the Priceline Design System. This dialog is based off of the [Radix-UI dialog primitive](https://www.radix-ui.com/docs/primitives/components/dialog), and prescribes some logical defaults to make usability more convenient for the developer. Here is a video demo of the component in action:

https://github.com/priceline/design-system/assets/23641048/255b4ab2-3853-4e27-b946-31915eeaeaf3

Also, this adds the `neutralDarkOnLightest` color scheme to the overall design system