### PR TITLE
add text-transform support to Text

### DIFF
--- a/common/changes/pcln-design-system/add-text-transform-styles_2023-07-11-19-36.json
+++ b/common/changes/pcln-design-system/add-text-transform-styles_2023-07-11-19-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add text transform support to Text",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Text/Text.spec.tsx
+++ b/packages/core/src/Text/Text.spec.tsx
@@ -85,8 +85,13 @@ describe('Text', () => {
     expect(screen.getByText('Italic Text')).toHaveStyleRule('font-style', 'italic')
   })
 
-  test('textTransform', () => {
+  test('textDecoration', () => {
     render(<Text textDecoration='underline'>Underlined Text</Text>)
     expect(screen.getByText('Underlined Text')).toHaveStyleRule('text-decoration', 'underline')
+  })
+
+  test('textTransform', () => {
+    render(<Text textTransform='lowercase'>Lowercase Text</Text>)
+    expect(screen.getByText('Lowercase Text')).toHaveStyleRule('text-transform', 'lowercase')
   })
 })

--- a/packages/core/src/Text/Text.stories.tsx
+++ b/packages/core/src/Text/Text.stories.tsx
@@ -87,6 +87,18 @@ export const TextDecoration = () => (
   </div>
 )
 
+export const TextTransform = () => (
+  <div>
+    <Text textTransform='capitalize'>hello capitalize</Text>
+    <Text textTransform='uppercase'>hello uppercase</Text>
+    <Text textTransform='lowercase'>HELLO LOWERCASE</Text>
+    <Text textTransform='none'>Hello none</Text>
+    <Text textTransform='uppercase' textStyle='heading5'>
+      hello uppercase heading5
+    </Text>
+  </div>
+)
+
 export const Regular = () => <Text regular>Hello Regular</Text>
 
 export const Bold = () => <Text bold>Hello Bold</Text>

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -45,6 +45,7 @@ import {
   getPaletteColor,
   textAlignAttrs,
   textStylesValues,
+  textTransformValues,
   typographyAttrs,
 } from '../utils'
 
@@ -78,6 +79,8 @@ export const textShadow = (props) => {
   return props.enableTextShadow ? { textShadow: props.theme.textShadows[textShadowSize] } : null
 }
 
+export const textTransform = (props) => (props.textTransform ? { textTransform: props.textTransform } : null)
+
 const textPropTypes = {
   ...propTypes.display,
   ...propTypes.fontSize,
@@ -103,6 +106,7 @@ const textPropTypes = {
   textDecoration: PropTypes.string,
   textShadowSize: PropTypes.oneOf(['sm', 'md']),
   textStyle: PropTypes.oneOf(textStylesValues),
+  textTransform: PropTypes.oneOf(textTransformValues),
 }
 
 export interface ITextProps
@@ -131,12 +135,13 @@ const textProps: React.FC<ITextProps> = css`
   color: ${getPaletteColor('base')};
   ${(props) => (props.bg ? `background-color: ${getPaletteColor(props.bg, 'base')(props)};` : '')}
 
-  ${caps}
-  ${regular}
   ${bold}
+  ${caps}
+  ${colorScheme}
+  ${regular}
   ${textDecoration}
   ${textShadow}
-  ${colorScheme}
+  ${textTransform}
 
   ${(props) =>
     compose(

--- a/packages/core/src/utils/attrs/typographyAttrs.ts
+++ b/packages/core/src/utils/attrs/typographyAttrs.ts
@@ -32,6 +32,8 @@ export const textStylesValues = [
   'label',
 ]
 
+export const textTransformValues = ['capitalize', 'lowercase', 'none', 'uppercase']
+
 export function typographyAttrs(props) {
   const { textStyle, theme } = props
 


### PR DESCRIPTION
- Add support for text-transfom to Text Component
  -  kept existing support provided by `caps` prop until we ensure use of that is replaced by `textTransform` prop

<img width="565" alt="Screenshot 2023-07-11 at 3 32 20 PM" src="https://github.com/priceline/design-system/assets/65993822/f753df0f-1090-4e76-b97e-e4e3fc891833">

