### PR TITLE
Add chat action container component

### DIFF
--- a/common/changes/pcln-design-system/add-chat-action-container_2023-07-12-22-04.json
+++ b/common/changes/pcln-design-system/add-chat-action-container_2023-07-12-22-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Create chatActionContainer component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/ChatActionContainer/ChatActionContainer.stories.tsx
+++ b/packages/core/src/ChatActionContainer/ChatActionContainer.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import type { StoryObj } from '@storybook/react'
+import { expect, jest } from '@storybook/jest'
+import { within, userEvent } from '@storybook/testing-library'
+import ChatActionContainer, { IChatActionContainer } from './ChatActionContainer'
+
+export default {
+  title: 'Chat / ChatActionContainer',
+  component: ChatActionContainer,
+  tags: ['autodocs'],
+}
+
+type ChatActionContainerStory = StoryObj<IChatActionContainer>
+
+const twoChatActions = [
+  {
+    label: 'Yes',
+    onClick: jest.fn(),
+  },
+  {
+    label: 'No',
+    onClick: jest.fn(),
+  },
+]
+
+const threeChatActions = [
+  {
+    label: 'Send a copy of my itinerary',
+    onClick: jest.fn(),
+  },
+  {
+    label: 'Cancel my Trip',
+    onClick: jest.fn(),
+  },
+  {
+    label: 'Reset my Password',
+    onClick: jest.fn(),
+  },
+]
+
+export const _TwoChatActions: ChatActionContainerStory = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.getByText('Yes')).toBeInTheDocument()
+    expect(canvas.getByText('No')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getAllByRole('button')[0])
+    expect(twoChatActions[0].onClick).toHaveBeenCalled()
+
+    await userEvent.click(canvas.getAllByRole('button')[1])
+    expect(twoChatActions[1].onClick).toHaveBeenCalled()
+  },
+  render: (args) => <ChatActionContainer chatActions={twoChatActions} {...args} />,
+}
+
+export const _ThreeChatActions: ChatActionContainerStory = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.getByText('Send a copy of my itinerary')).toBeInTheDocument()
+    expect(canvas.getByText('Cancel my Trip')).toBeInTheDocument()
+    expect(canvas.getByText('Reset my Password')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getAllByRole('button')[0])
+    expect(threeChatActions[0].onClick).toHaveBeenCalled()
+
+    await userEvent.click(canvas.getAllByRole('button')[1])
+    expect(threeChatActions[1].onClick).toHaveBeenCalled()
+
+    await userEvent.click(canvas.getAllByRole('button')[2])
+    expect(threeChatActions[2].onClick).toHaveBeenCalled()
+  },
+  render: (args) => <ChatActionContainer chatActions={threeChatActions} {...args} />,
+}

--- a/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
+++ b/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
@@ -1,0 +1,46 @@
+/* istanbul ignore file */
+// todo: remove coverage ignore once storybook interaction test coverage counts
+
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import themeGet from '@styled-system/theme-get'
+import { Button, Flex, Grid } from '../'
+
+const GappedFlex = styled(Flex)`
+  gap: ${themeGet('space.2')};
+`
+
+export interface IChatActionContainer {
+  chatActions: IChatAction[]
+}
+
+export interface IChatAction {
+  label: string
+  onClick: () => void
+}
+
+function ChatActionContainer({ chatActions }: IChatActionContainer) {
+  const actions = useMemo(() => {
+    return chatActions.map((chatAction) => (
+      <Button key={chatAction.label} boxShadowSize='sm' variation='white' onClick={chatAction.onClick}>
+        {chatAction.label}
+      </Button>
+    ))
+  }, [chatActions])
+
+  if (chatActions?.length === 2) {
+    return (
+      <Grid templateColumns='1fr 1fr' gap={2}>
+        {actions}
+      </Grid>
+    )
+  } else {
+    return (
+      <GappedFlex flexDirection={['column', null, 'row']} flexWrap={['none', null, 'wrap']}>
+        {actions}
+      </GappedFlex>
+    )
+  }
+}
+
+export default ChatActionContainer

--- a/packages/core/src/ChatActionContainer/index.tsx
+++ b/packages/core/src/ChatActionContainer/index.tsx
@@ -1,0 +1,3 @@
+/* istanbul ignore file */
+// todo: remove coverage ignore once storybook interaction test coverage counts
+export { default as ChatActionContainer } from './ChatActionContainer'


### PR DESCRIPTION
- Create new ChatActionContainer component
- Using storybook interaction tests 

Two Chat Actions (same for desktop and mobile):

<img width="629" alt="Screenshot 2023-07-13 at 10 36 03 AM" src="https://github.com/priceline/design-system/assets/65993822/460cbd13-7a93-477a-96fb-8955452293b2">


More than two Chat Actions
Desktop:
<img width="752" alt="Screenshot 2023-07-12 at 5 06 48 PM" src="https://github.com/priceline/design-system/assets/65993822/7b06a562-f200-4f4c-8e0b-edaad1a33a6f">


Mobile: 
<img width="484" alt="Screenshot 2023-07-12 at 5 07 01 PM" src="https://github.com/priceline/design-system/assets/65993822/2057b952-a879-4846-8f39-27247365cc10">