### PR TITLE
fix(UXPT-4813): storybook to show how to make card focusbale

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -17,7 +17,7 @@ const storiesGlob = 'src/**/*.stories.@(js|jsx|ts|tsx)'
 const config: StorybookConfig = {
   framework,
   stories: packagesWithStories.map((packageFolder) => `../../../packages/${packageFolder}/${storiesGlob}`),
-  addons: storykitAddons,
+  addons: [...storykitAddons, 'storybook-addon-pseudo-states'],
   docs: {
     autodocs: true,
   },

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -38,6 +38,12 @@
     "storybook": "^7.0.20",
     "styled-components": "^5.3.11",
     "vite": "^4.3.9",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "storybook-addon-pseudo-states": "^2.1.0",
+    "@storybook/components": "^7.0.0",
+    "@storybook/core-events": "^7.0.0",
+    "@storybook/manager-api": "^7.0.0",
+    "@storybook/preview-api": "^7.0.0",
+    "@storybook/theming": "^7.0.0"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -76,8 +76,13 @@ importers:
       '@storybook/addon-a11y': ^7.0.20
       '@storybook/addon-actions': ^7.0.20
       '@storybook/addon-essentials': ^7.0.20
+      '@storybook/components': ^7.0.0
+      '@storybook/core-events': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
       '@storybook/react': ^7.0.20
       '@storybook/react-vite': ^7.0.20
+      '@storybook/theming': ^7.0.0
       babel-plugin-react-docgen: ^4.2.1
       chromatic: ^6.19.5
       eslint: ^8.42.0
@@ -88,6 +93,7 @@ importers:
       react-is: ^17.0.2
       require-from-string: 2.0.2
       storybook: ^7.0.20
+      storybook-addon-pseudo-states: ^2.1.0
       styled-components: ^5.3.11
       typescript: ^5.1.3
       vite: ^4.3.9
@@ -98,8 +104,13 @@ importers:
       '@storybook/addon-a11y': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-actions': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-essentials': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/components': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-events': 7.0.20
+      '@storybook/manager-api': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/preview-api': 7.0.20
       '@storybook/react': 7.0.20_s42qu5ohvsfrkcvstqvvqny6je
       '@storybook/react-vite': 7.0.20_cjzvl333x3grxndiyqlswp5gbu
+      '@storybook/theming': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
       babel-plugin-react-docgen: 4.2.1
       chromatic: 6.19.5
       eslint: 8.42.0
@@ -110,6 +121,7 @@ importers:
       react-is: 17.0.2
       require-from-string: 2.0.2
       storybook: 7.0.20
+      storybook-addon-pseudo-states: 2.1.0_2h4qia5rritxmzsjmgtbvcwo2e
       styled-components: 5.3.11_fane7jikarojcev26y27hpbhu4
       typescript: 5.1.3
       vite: 4.3.9
@@ -18424,6 +18436,31 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - '@xstate/fsm'
+    dev: true
+
+  /storybook-addon-pseudo-states/2.1.0_2h4qia5rritxmzsjmgtbvcwo2e:
+    resolution: {integrity: sha512-AwbCL1OiZ16aIeXSP/IOovkMwXy7NTZqmjkz+UM2guSGjvogHNA95NhuVyWoqieE+QWUpGO48+MrBGMeeJcHOQ==}
+    peerDependencies:
+      '@storybook/components': ^7.0.0
+      '@storybook/core-events': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
+      '@storybook/theming': ^7.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/components': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-events': 7.0.20
+      '@storybook/manager-api': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/preview-api': 7.0.20
+      '@storybook/theming': 7.0.20_sfoxds7t5ydpegc3knd667wn6m
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
     dev: true
 
   /storybook/7.0.20:

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -62,6 +62,9 @@ export const Playground: ButtonStory = {
     },
   },
 }
+Playground.parameters = {
+  pseudo: { rootSelector: "body" },
+}
 
 export const Size: ButtonStory = {
   render: () => (

--- a/packages/core/src/Card/Card.stories.tsx
+++ b/packages/core/src/Card/Card.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Box, Card } from '..'
+import styled from 'styled-components'
 
 export default {
   title: 'Card',
@@ -36,25 +37,38 @@ BoxShadowsWithDefaultBorder.story = {
   name: 'Box Shadows with default border',
 }
 
-export const BoxShadowsWithFocused2PxBorder = () => (
+const StyledCard = styled(Card)`
+  &:hover {
+    border-color: red;
+    box-shadow: rgba(0, 0, 0, 0.03) 0px -1px 0px 0px, rgba(0, 0, 0, 0.16) 0px 2px 8px 0px, rgba(0, 0, 0, 0.16) 0px 10px 8px -5px, rgba(0, 0, 0, 0.16) 0px 12px 32px -2px;
+  }
+  &:focus{
+    border-color: red;
+  }
+`
+
+export const CardAsButtonCanTabAndFocus = () => (
   <Box>
-    <Card boxShadowSize='sm' m={4} p={4} width={1 / 2} color='text' bg='white' borderWidth={2}>
+    <StyledCard tabIndex={0} boxShadowSize='sm' mx={4} my={3} p={4} width={1 / 2} color='text' bg='white'>
       Small Shadow
-    </Card>
-    <Card boxShadowSize='md' m={4} p={4} width={1 / 2} color='text' bg='white' borderWidth={2}>
+    </StyledCard>
+    <Card as='button' boxShadowSize='md' mx={4} my={3} p={4} width={1 / 2} color='text' bg='white'>
       Medium Shadow
     </Card>
-    <Card boxShadowSize='lg' m={4} p={4} width={1 / 2} color='text' bg='white' borderWidth={2}>
+    <Card as='button' boxShadowSize='lg' mx={4} my={3} p={4} width={1 / 2} color='text' bg='white'>
       Large Shadow
     </Card>
-    <Card boxShadowSize='xl' m={4} p={4} width={1 / 2} color='text' bg='white' borderWidth={2}>
+    <Card as='button' boxShadowSize='xl' mx={4} my={3} p={4} width={1 / 2} color='text' bg='white'>
       XLarge Shadow
     </Card>
   </Box>
 )
+CardAsButtonCanTabAndFocus.parameters = {
+  pseudo: { rootSelector: "body" },
+}
 
-BoxShadowsWithFocused2PxBorder.story = {
-  name: 'Box Shadows with focused 2px border',
+CardAsButtonCanTabAndFocus.story = {
+  name: 'Card As Button Can Tab and Focus',
 }
 
 export const BoxShadowsWithVaryingBorderRadii = () => (
@@ -73,6 +87,27 @@ export const BoxShadowsWithVaryingBorderRadii = () => (
     </Card>
   </Box>
 )
+
+export const Default = () => (
+  <a id='PABLO' href='www.priceline.com'>
+    Pablo
+  </a>
+)
+Default.parameters = {
+  pseudo: {rootSelector: "PABLO" },
+}
+
+export const Hover = () => (
+  <Box>
+  <StyledCard id='PABLO' boxShadowSize='sm'>
+    Card Text
+  </StyledCard>
+  </Box>
+)
+Hover.parameters = {
+  pseudo: { rootSelector: "body" },
+}
+
 
 BoxShadowsWithVaryingBorderRadii.story = {
   name: 'Box Shadows with varying border radii',


### PR DESCRIPTION
Small PR that changes one of the storybook stories to demonstrate how to make a card focusable and tab-able by adding `as = 'button'`