### PR TITLE
Add support for text-transform to badge

### DIFF
--- a/common/changes/pcln-design-system/badge-text-transform-support_2023-07-13-15-11.json
+++ b/common/changes/pcln-design-system/badge-text-transform-support_2023-07-13-15-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add text transform support to badge",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Badge/Badge.spec.tsx
+++ b/packages/core/src/Badge/Badge.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { render, screen } from '../__test__/testing-library'
 import { Badge, theme } from '..'
 
 describe('Badge', () => {
@@ -80,5 +81,11 @@ describe('Badge', () => {
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightBlue)
     expect(json).toHaveStyleRule('color', theme.colors.text)
+  })
+
+  test('textTransform', () => {
+    render(<Badge textTransform='lowercase'>Lowercase Text</Badge>)
+    expect(screen.getByText('Lowercase Text')).toHaveStyleRule('text-transform', 'lowercase')
+    expect(screen.getByText('Lowercase Text')).toHaveStyleRule('letter-spacing', 'normal')
   })
 })

--- a/packages/core/src/Badge/Badge.stories.args.ts
+++ b/packages/core/src/Badge/Badge.stories.args.ts
@@ -1,4 +1,5 @@
 import { borderRadii, colors } from '../storybook/args'
+import { textTransformValues } from '../utils'
 
 export const argTypes = {
   borderRadius: {
@@ -24,6 +25,15 @@ export const argTypes = {
     type: { name: 'string' },
     options: colors,
     description: 'Color of badge',
+    control: {
+      type: 'select',
+    },
+  },
+  textTransform: {
+    name: 'text transform',
+    type: { name: 'string' },
+    options: textTransformValues,
+    description: 'Text transform of Badge',
     control: {
       type: 'select',
     },

--- a/packages/core/src/Badge/Badge.stories.tsx
+++ b/packages/core/src/Badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Badge } from '..'
+import { Badge, textTransformValues } from '..'
 import type { ColorSchemeName } from '../theme'
 import { argTypes } from './Badge.stories.args'
 
@@ -40,6 +40,20 @@ LightBlueAndTextCustom.args = {
   bg: 'primary.light',
   color: 'text',
 }
+
+const TextTransformTemplate = () => {
+  return (
+    <React.Fragment>
+      {textTransformValues.map((textTransform) => (
+        <Badge m={3} p={3} textTransform={textTransform} key={textTransform}>
+          {textTransform}
+        </Badge>
+      ))}
+    </React.Fragment>
+  )
+}
+export const TextTransforms = TextTransformTemplate.bind({})
+TextTransformTemplate.args = {}
 
 const ColorSchemesTemplate = () => {
   return (

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -5,10 +5,12 @@ import styledSystemPropTypes from '@styled-system/prop-types'
 import {
   applySizes,
   applyVariations,
-  color,
-  deprecatedColorValue,
   borderRadiusAttrs,
+  color,
   colorScheme,
+  deprecatedColorValue,
+  textTransform,
+  textTransformValues,
 } from '../utils'
 import { space, borderRadius, SpaceProps, compose } from 'styled-system'
 import type { ColorSchemeName } from '../theme'
@@ -66,23 +68,30 @@ const sizes = {
   `,
 }
 
+const letterSpacing = (props) => {
+  return props.textTransform && props.textTransform !== 'uppercase'
+    ? { letterSpacing: themeGet('letterSpacings.normal')(props) }
+    : { letterSpacing: themeGet('letterSpacings.caps')(props) }
+}
+
 export interface IBadgeProps extends SpaceProps, React.HtmlHTMLAttributes<HTMLElement> {
   size?: 'small' | 'medium'
   color?: string
   bg?: string
   borderRadius?: string
   colorScheme?: ColorSchemeName
+  textTransform?: string
 }
 
 const Badge: React.FC<IBadgeProps> = styled.div.attrs(borderRadiusAttrs)`
   display: inline-block;
-  text-transform: uppercase;
-  letter-spacing: ${themeGet('letterSpacings.caps')};
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Badge')};
   ${type}
   ${color}
   ${colorScheme}
+  ${textTransform}
+  ${letterSpacing}
 
   ${(props) => compose(space, borderRadius)(props)}
 `
@@ -95,6 +104,7 @@ Badge.propTypes = {
   color: deprecatedColorValue(),
   bg: deprecatedColorValue(),
   borderRadius: PropTypes.string,
+  textTransform: PropTypes.oneOf(textTransformValues),
 }
 
 Badge.defaultProps = {
@@ -102,6 +112,7 @@ Badge.defaultProps = {
   px: 2,
   py: 1,
   borderRadius: 'full',
+  textTransform: 'uppercase',
 }
 
 export default Badge

--- a/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -3,11 +3,6 @@
 exports[`Badge bg blue sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -20,6 +15,11 @@ exports[`Badge bg blue sets background-color and color 1`] = `
   background-color: #0068ef;
   color: #fff;
   background-color: #0068ef;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -36,11 +36,6 @@ exports[`Badge bg blue sets background-color and color 1`] = `
 exports[`Badge bg green sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -53,6 +48,11 @@ exports[`Badge bg green sets background-color and color 1`] = `
   background-color: #0a0;
   color: #fff;
   background-color: #0a0;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -69,11 +69,6 @@ exports[`Badge bg green sets background-color and color 1`] = `
 exports[`Badge bg lightBlue sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -86,6 +81,11 @@ exports[`Badge bg lightBlue sets background-color and color 1`] = `
   background-color: #e8f2ff;
   color: #049;
   background-color: #e8f2ff;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -102,11 +102,6 @@ exports[`Badge bg lightBlue sets background-color and color 1`] = `
 exports[`Badge bg lightGreen sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -119,6 +114,11 @@ exports[`Badge bg lightGreen sets background-color and color 1`] = `
   background-color: #ecf7ec;
   color: #060;
   background-color: #ecf7ec;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -135,11 +135,6 @@ exports[`Badge bg lightGreen sets background-color and color 1`] = `
 exports[`Badge bg lightRed sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -152,6 +147,11 @@ exports[`Badge bg lightRed sets background-color and color 1`] = `
   background-color: #fbebeb;
   color: #800;
   background-color: #fbebeb;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -168,11 +168,6 @@ exports[`Badge bg lightRed sets background-color and color 1`] = `
 exports[`Badge bg orange sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -185,6 +180,11 @@ exports[`Badge bg orange sets background-color and color 1`] = `
   background-color: #f68013;
   color: #001833;
   background-color: #f68013;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -201,11 +201,6 @@ exports[`Badge bg orange sets background-color and color 1`] = `
 exports[`Badge bg red sets background-color and color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -218,6 +213,11 @@ exports[`Badge bg red sets background-color and color 1`] = `
   background-color: #c00;
   color: #fff;
   background-color: #c00;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -234,11 +234,6 @@ exports[`Badge bg red sets background-color and color 1`] = `
 exports[`Badge can escape preset: bg lightBlue sets background-color and color text sets color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -250,6 +245,11 @@ exports[`Badge can escape preset: bg lightBlue sets background-color and color t
   line-height: 1.4;
   background-color: #e8f2ff;
   color: #001833;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -267,11 +267,6 @@ exports[`Badge can escape preset: bg lightBlue sets background-color and color t
 exports[`Badge non-preset: bg text sets background-color and color white sets color 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -283,6 +278,11 @@ exports[`Badge non-preset: bg text sets background-color and color white sets co
   line-height: 1.4;
   background-color: #001833;
   color: #fff;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -300,11 +300,6 @@ exports[`Badge non-preset: bg text sets background-color and color white sets co
 exports[`Badge renders 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
@@ -316,6 +311,11 @@ exports[`Badge renders 1`] = `
   line-height: 1.4;
   background-color: #f4f6f8;
   color: #001833;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
@@ -332,17 +332,17 @@ exports[`Badge renders 1`] = `
 exports[`Badge renders small 1`] = `
 .c0 {
   display: inline-block;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.025em;
-  -moz-letter-spacing: 0.025em;
-  -ms-letter-spacing: 0.025em;
-  letter-spacing: 0.025em;
   font-size: 10px;
   font-weight: 700;
   line-height: 1.4;
   line-height: 1.25;
   background-color: #f4f6f8;
   color: #001833;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0.025em;
+  -moz-letter-spacing: 0.025em;
+  -ms-letter-spacing: 0.025em;
+  letter-spacing: 0.025em;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -45,6 +45,7 @@ import {
   getPaletteColor,
   textAlignAttrs,
   textStylesValues,
+  textTransform,
   textTransformValues,
   typographyAttrs,
 } from '../utils'
@@ -78,8 +79,6 @@ export const textShadow = (props) => {
   const textShadowSize = props.textShadowSize || 'md'
   return props.enableTextShadow ? { textShadow: props.theme.textShadows[textShadowSize] } : null
 }
-
-export const textTransform = (props) => (props.textTransform ? { textTransform: props.textTransform } : null)
 
 const textPropTypes = {
   ...propTypes.display,

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -416,3 +416,5 @@ export const colorSchemeCustomForeground = ({ colorScheme, color, ...props }) =>
     color: ${paletteColor ? paletteColor : getTextColorOn(backgroundName)(props)};
   `
 }
+
+export const textTransform = (props) => (props.textTransform ? { textTransform: props.textTransform } : null)


### PR DESCRIPTION

- Add support for text-transform to badge
- Set `uppercase` as the default textTransform prop
- Move `textTransform` from Text.tsx to the _very_ bottom of utils.ts (looks like the rest of the file was formatted here, let me know if I should undo that part 😬)

<img width="1034" alt="Screenshot 2023-07-13 at 3 18 57 PM" src="https://github.com/priceline/design-system/assets/65993822/b188e443-7875-4566-9df4-0245e8a1dde9">
