### PR TITLE
uxpt(pb-4814): Updated the list component with indentation and list s…

### DIFF
--- a/common/changes/pcln-design-system/uxpt-4814-update-lists_2023-07-17-14-39.json
+++ b/common/changes/pcln-design-system/uxpt-4814-update-lists_2023-07-17-14-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "List component enhancement with listStyle and indentSize props",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/List/List.spec.tsx
+++ b/packages/core/src/List/List.spec.tsx
@@ -37,4 +37,32 @@ describe('List', () => {
     screen.getByText('Example Text 2')
     screen.getByText('Example Text 3')
   })
+
+  it('renders list with listStyles and indentation which is passed in props ', () => {
+    render(
+      <List.ul color='text.light' fontSize={1} listStyle='upper-roman' indentSize='md' data-testid='list'>
+        <li>Example Text 1</li>
+        <li>Example Text 2</li>
+        <li>Example Text 3</li>
+      </List.ul>
+    )
+
+    const list = screen.getByTestId('list')
+    expect(list).toHaveStyleRule('list-style-type', 'upper-roman')
+    expect(list).toHaveStyleRule('margin-left', '32px')
+  })
+
+  it('should renders list with default listStyles and indentation if right props are not passed ', () => {
+    render(
+      <List.ul color='text.light' fontSize={1} listStyle='roman' data-testid='list'>
+        <li>Example Text 1</li>
+        <li>Example Text 2</li>
+        <li>Example Text 3</li>
+      </List.ul>
+    )
+
+    const list = screen.getByTestId('list')
+    expect(list).toHaveStyleRule('list-style-type', 'auto')
+    expect(list).toHaveStyleRule('margin-left', '40px')
+  })
 })

--- a/packages/core/src/List/List.stories.args.ts
+++ b/packages/core/src/List/List.stories.args.ts
@@ -4,7 +4,21 @@ export const defaultArgs = {
   color: 'text.light',
   fontSize: 2,
   type: 'ol',
+  listStyle: '',
+  indentSize: 'lg',
 }
+
+const listStyles = [
+  '',
+  'disc',
+  'upper-roman',
+  'lower-roman',
+  'upper-alpha',
+  'lower-alpha',
+  'decimal',
+  'square',
+  'circle',
+]
 
 export const argTypes = {
   color: {
@@ -40,10 +54,30 @@ export const argTypes = {
   type: {
     name: 'List Type',
     type: { name: 'Type', details: 'Ordered vs Unordered' },
-    description: 'List Type',
+    description: 'List type',
     control: {
       type: 'select',
       options: ['ol', 'ul'],
+    },
+  },
+
+  listStyle: {
+    name: 'List Style',
+    type: { name: 'string', required: false },
+    description: 'List style to use',
+    options: listStyles,
+    control: {
+      type: 'select',
+    },
+  },
+
+  indentSize: {
+    name: 'Spacing tab indent',
+    type: { name: 'string', required: false },
+    description: 'Indent space size to use',
+    options: ['', 'xsm', 'sm', 'md', 'lg', 'xl'],
+    control: {
+      type: 'select',
     },
   },
 }

--- a/packages/core/src/List/List.stories.tsx
+++ b/packages/core/src/List/List.stories.tsx
@@ -10,9 +10,8 @@ export default {
   argTypes,
 }
 
-const Template = (args) => {
+const BasicTemplate = (args) => {
   const ListType = args.type === 'ol' ? List.ol : List.ul
-
   return (
     <ListType {...args}>
       <li>
@@ -31,10 +30,163 @@ const Template = (args) => {
   )
 }
 
-export const _List = Template.bind({})
+const StructuredRomanTemplate = (args) => {
+  const ListType = args.type === 'ol' ? List.ol : List.ul
+  return (
+    <div style={{ border: '1px solid lightgray' }}>
+      <ListType {...{ ...args, ...{ listStyle: 'upper-roman' } }}>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <ListType {...{ ...args, ...{ listStyle: 'upper-alpha' } }}>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <ListType {...{ ...args, ...{ listStyle: 'decimal' } }}>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <ListType {...{ ...args, ...{ listStyle: 'lower-alpha' } }}>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <ListType {...{ ...args, ...{ listStyle: 'decimal' } }}>
+                <li>
+                  <Text>An example line of text</Text>
+                </li>
+              </ListType>
+            </ListType>
+          </ListType>
+        </ListType>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+      </ListType>
+    </div>
+  )
+}
 
-export const OrderedList = Template.bind({})
+const StructuredDecimalTemplate = (args) => {
+  const ListType = args.type === 'ol' ? List.ol : List.ul
+  return (
+    <div style={{ border: '1px solid lightgray' }}>
+      <ListType {...{ ...args, ...{ listStyle: 'decimal' } }}>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <ListType {...{ ...args, ...{ listStyle: 'lower-alpha' } }}>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <ListType {...{ ...args, ...{ listStyle: 'lower-roman' } }}>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <ListType {...{ ...args, ...{ listStyle: 'decimal' } }}>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <ListType {...{ ...args, ...{ listStyle: 'lower-alpha' } }}>
+                <li>
+                  <Text>An example line of text</Text>
+                </li>
+              </ListType>
+            </ListType>
+          </ListType>
+        </ListType>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+      </ListType>
+    </div>
+  )
+}
+
+const StructuredBulletTemplate = (args) => {
+  const ListType = args.type === 'ol' ? List.ol : List.ul
+  return (
+    <div style={{ border: '1px solid lightgray' }}>
+      <ListType {...{ ...args, ...{ listStyle: 'disc' } }}>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+        <ListType {...{ ...args, ...{ listStyle: 'circle' } }}>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <li>
+            <Text>An example line of text</Text>
+          </li>
+          <ListType {...{ ...args, ...{ listStyle: 'square' } }}>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <li>
+              <Text>An example line of text</Text>
+            </li>
+            <ListType {...{ ...args, ...{ listStyle: 'disc' } }}>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <li>
+                <Text>An example line of text</Text>
+              </li>
+              <ListType {...{ ...args, ...{ listStyle: 'circle' } }}>
+                <li>
+                  <Text>An example line of text</Text>
+                </li>
+              </ListType>
+            </ListType>
+          </ListType>
+        </ListType>
+        <li>
+          <Text>An example line of text</Text>
+        </li>
+      </ListType>
+    </div>
+  )
+}
+
+export const _List = BasicTemplate.bind({})
+
+export const OrderedList = BasicTemplate.bind({})
 OrderedList.args = { color: 'text.light', fontSize: 1 }
 
-export const UnorderedList = Template.bind({})
-UnorderedList.args = { color: 'text.light', fontSize: 1, type: 'ul' }
+export const UnorderedList = BasicTemplate.bind({})
+UnorderedList.args = { color: 'primary.dark', fontSize: 1, type: 'ul' }
+
+export const StructuredRomanList = StructuredRomanTemplate.bind({})
+StructuredRomanList.args = { color: 'text.light', fontSize: 1 }
+
+export const StructuredDecimalList = StructuredDecimalTemplate.bind({})
+StructuredDecimalList.args = { color: 'text.light', fontSize: 1 }
+
+export const StructuredBulletList = StructuredBulletTemplate.bind({})
+StructuredBulletList.args = { color: 'text.light', fontSize: 1, type: 'ul' }

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -3,6 +3,25 @@ import { fontSize, space, width, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 import { getPaletteColor } from '../utils'
 
+const tabSpacingSize = {
+  xsm: '16px',
+  sm: '24px',
+  md: '32px',
+  lg: '40px',
+  xl: '48px',
+}
+
+const listStyles = [
+  'disc',
+  'upper-roman',
+  'lower-roman',
+  'upper-alpha',
+  'lower-alpha',
+  'decimal',
+  'square',
+  'circle',
+]
+
 const BaseCSS = css`
   margin: ${themeGet('space.1')} 0;
   color: ${getPaletteColor('base')};
@@ -12,23 +31,23 @@ const BaseCSS = css`
   }
 
   ${(props) => compose(fontSize, space, width)(props)}
+  padding: 0;
+  list-style-type: ${(props) =>
+    props.listStyle ? (listStyles.includes(props.listStyle) ? props.listStyle : 'auto') : ''};
+  margin-left: ${(props) => tabSpacingSize[props.indentSize ? props.indentSize : 'lg']};
 `
 
 const Ordered = styled('ol')`
-  ${BaseCSS};
-
   & > li > * {
     margin-left: ${themeGet('space.2')};
   }
-`
 
-Ordered.defaultProps = { my: 1 }
+  ${BaseCSS};
+`
 
 const Unordered = styled('ul')`
   ${BaseCSS};
 `
-
-Unordered.defaultProps = { my: 1 }
 
 const List = Unordered
 


### PR DESCRIPTION
**Normal List**
<img width="313" alt="image" src="https://github.com/priceline/design-system/assets/110497266/ef1ed166-804b-47b7-b208-259a71815eda">

**Ordered List**
<img width="229" alt="image" src="https://github.com/priceline/design-system/assets/110497266/210cd2ae-e021-4ef5-8dff-7c8b1917d14f">

**Unordered List**
<img width="240" alt="image" src="https://github.com/priceline/design-system/assets/110497266/7a6682a1-7f55-4ab1-9a6a-49e7f38e582e">

**Structured Roman List**
<img width="682" alt="image" src="https://github.com/priceline/design-system/assets/110497266/9cee60f2-bbfb-4abc-922a-1637ee874af1">

**Structured Decimal List**
<img width="679" alt="image" src="https://github.com/priceline/design-system/assets/110497266/dba73eda-c6ce-4d25-b1ad-ac81242ce1f5">

**Structured Bullet List**
<img width="669" alt="image" src="https://github.com/priceline/design-system/assets/110497266/c14e8377-15e3-4746-a101-62fca390350a">
