### PR TITLE
feat(UXPT-4812): style when card as button

### DIFF
--- a/common/changes/pcln-design-system/UXPT-4812-add-styling-card-as-button_2023-07-17-18-35.json
+++ b/common/changes/pcln-design-system/UXPT-4812-add-styling-card-as-button_2023-07-17-18-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add styling for when card is as button",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Card/Card.spec.tsx
+++ b/packages/core/src/Card/Card.spec.tsx
@@ -57,6 +57,14 @@ describe('Card', () => {
     expect(json).toHaveStyleRule('box-shadow', theme.shadows.md)
   })
 
+  test('renders with as button', () => {
+    const json = rendererCreateWithTheme(<Card as='button' />).toJSON()
+    expect(json).toMatchSnapshot()
+    assertBorderGray(json)
+    expect(json).toHaveStyleRule('border-radius', theme.radius)
+    expect(json).toHaveStyleRule('box-shadow', undefined)
+  })
+
   test('renders border 0 without warning', () => {
     console.error = jest.fn()
     const json = rendererCreateWithTheme(<Card borderWidth={0} />).toJSON()

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -11,6 +11,16 @@ const boxBorder = ({ borderWidth, borderColor, ...props }) => ({
   borderColor: borderWidth === 0 ? '0' : getPaletteColor(borderColor, 'base')(props),
 })
 
+const styleAsButton = ({ as, ...props }) =>
+  as === 'button'
+    ? `
+      font-family : inherit;
+      &:hover {
+        cursor: pointer;
+        box-shadow: ${props.theme.shadows.xl};
+      }`
+    : ''
+
 const cardPropTypes = {
   borderColor: deprecatedColorValue(),
   color: deprecatedColorValue(),
@@ -25,6 +35,7 @@ export interface ICardProps extends IBoxProps {
 const Card: React.FC<ICardProps> = styled(Box)`
   ${applyVariations('Card')}
   ${boxBorder}
+  ${styleAsButton}
 `
 
 Card.propTypes = cardPropTypes

--- a/packages/core/src/Card/__snapshots__/Card.spec.tsx.snap
+++ b/packages/core/src/Card/__snapshots__/Card.spec.tsx.snap
@@ -100,6 +100,28 @@ exports[`Card renders small box shadow with default border 1`] = `
 />
 `;
 
+exports[`Card renders with as button 1`] = `
+.c0 {
+  border-radius: 2px;
+}
+
+.c1 {
+  border-width: 1px;
+  border-style: solid;
+  border-color: #c0cad5;
+  font-family: inherit;
+}
+
+.c1:hover {
+  cursor: pointer;
+  box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 2px 8px 0 rgba(0,0,0,0.16),0 10px 8px -5px rgba(0,0,0,0.16),0 12px 32px -2px rgba(0,0,0,0.16);
+}
+
+<button
+  className="c0 c1"
+/>
+`;
+
 exports[`Card renders xlarge box shadow with default border 1`] = `
 .c0 {
   border-radius: 2px;


### PR DESCRIPTION
Small PR to style the `Card` when given the prop `as='button'`

<img width="581" alt="Screenshot 2023-07-17 at 2 44 59 PM" src="https://github.com/priceline/design-system/assets/67336461/b285f410-79c8-4056-8a11-585b2996681f">

When `hovered`
<img width="602" alt="Screenshot 2023-07-17 at 2 45 03 PM" src="https://github.com/priceline/design-system/assets/67336461/a896e55e-fcc6-4d4e-9006-8872e3fd1214">