### PR TITLE
add variations and sizes to link

### DIFF
--- a/common/changes/pcln-design-system/add-link-variations_2023-07-19-13-34.json
+++ b/common/changes/pcln-design-system/add-link-variations_2023-07-19-13-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add variations to Link",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -144,10 +144,14 @@ const variations = {
   lightFill: css`
     background-color: ${getPaletteColor('light')};
     color: ${getPaletteColor('base')};
-    &:hover {
-      background-color: ${getPaletteColor('light')};
-      color: ${getPaletteColor('dark')};
-    }
+    ${(props) =>
+      props.disabled
+        ? ''
+        : `
+      &:hover {
+        background-color: ${getPaletteColor('light')(props)};
+        color: ${getPaletteColor('dark')(props)};
+      }`}
     &:focus {
       outline: ${(props) => `0px solid ${getPaletteColor(props.disabled ? '' : 'dark')(props)}`};
       box-shadow: ${(props) => ` 0 0 0 2px  ${getPaletteColor(props.disabled ? '' : 'dark')(props)}`};
@@ -174,6 +178,8 @@ const variations = {
 }
 
 export type Sizes = 'small' | 'medium' | 'large' | 'extraLarge'
+export type Variations = 'fill' | 'link' | 'outline' | 'plain' | 'subtle' | 'white' | 'lightFill' | 'input'
+
 export type StyledButtonProps = IButtonProps & { hasChildren: boolean }
 export interface IButtonProps
   extends WidthProps,
@@ -182,7 +188,7 @@ export interface IButtonProps
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     React.RefAttributes<unknown> {
   color?: string
-  variation?: 'fill' | 'link' | 'outline' | 'plain' | 'subtle' | 'white' | 'lightFill' | 'input'
+  variation?: Variations
   size?: Sizes | Sizes[]
   borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | ''
   boxShadowSize?: '' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'overlay-lg' | 'overlay-xl'

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -1,3 +1,3 @@
-export type { IButtonProps } from './Button'
+export type { IButtonProps, Sizes, Variations } from './Button'
 
 export { default as Button, buttonStyles } from './Button'

--- a/packages/core/src/Link/Link.stories.args.ts
+++ b/packages/core/src/Link/Link.stories.args.ts
@@ -1,6 +1,9 @@
 import { action } from '@storybook/addon-actions'
 import { colors } from '../__test__/mocks/colors'
 
+export const sizeOptions = ['small', 'medium', 'large', 'extraLarge']
+export const variationOptions = ['fill', 'link', 'outline', 'plain', 'subtle', 'white', 'lightFill', 'input']
+
 export const defaultArgs = {
   children: 'Hello There',
   color: 'primary',
@@ -21,12 +24,17 @@ export const argTypes = {
   },
   size: {
     name: 'size',
-    options: ['small', 'medium', 'large'],
-    control: 'radio',
+    options: sizeOptions,
+    control: 'select',
   },
   target: {
     name: 'target',
     options: ['_blank', '_self'],
     control: 'radio',
+  },
+  variation: {
+    name: 'variation',
+    options: variationOptions,
+    control: 'select',
   },
 }

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -3,13 +3,12 @@ import type { IButtonProps } from '../Button'
 import React from 'react'
 import styled from 'styled-components'
 import { StoryObj } from '@storybook/react'
-import { Box, Button, getLinkStylesOn, Layout, Link, Text } from '..'
+import { Box, Button, getLinkStylesOn, Container, Grid, Link, Text } from '..'
 import { ILinkProps } from './Link'
 import { argTypes, defaultArgs } from './Link.stories.args'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
 import { colors } from '../storybook/args'
-
-const sizeOptions = ['small', 'medium', 'large', 'extraLarge']
+import { sizeOptions, variationOptions } from './Link.stories.args'
 
 export default {
   title: 'Link',
@@ -44,32 +43,36 @@ export const Playground: ButtonStory = {
   },
 }
 
-export function AllLinkExamples(args) {
+export function Variations(args) {
   return (
     <>
       <Text textStyle='heading3' mb={2}>
         Link Variations
       </Text>
-      <Layout variation='100' gap={1} rowGap={2} bg='background.tone' p={4}>
-        <Link {...args} variation='fill' mb={4}>
-          fill
-        </Link>
-        <Link {...args} variation='subtle' mb={4}>
-          subtle
-        </Link>
-        <Link {...args} variation='link'>
-          link
-        </Link>
-        <Link {...args} variation='outline' my={4}>
-          outline
-        </Link>
-        <Link {...args} variation='plain' mb={4}>
-          plain
-        </Link>
-        <Link {...args} variation='white'>
-          white
-        </Link>
-      </Layout>
+      <Grid gap={4} templateColumns={['1fr']} background='primary'>
+        {variationOptions.map((variation) => (
+          <Link {...args} key={variation} variation={variation} m={1}>
+            {variation} link
+          </Link>
+        ))}
+      </Grid>
+    </>
+  )
+}
+
+export function Sizes(args) {
+  return (
+    <>
+      <Text textStyle='heading3' mb={2}>
+        Link Sizes
+      </Text>
+      <Container>
+        {sizeOptions.map((size) => (
+          <Link {...args} key={size} size={size} variation='fill' m={3}>
+            {size}
+          </Link>
+        ))}
+      </Container>
     </>
   )
 }

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { width, space, WidthProps, SpaceProps, compose } from 'styled-system'
 
+import type { Sizes, Variations } from '../Button'
 import { buttonStyles } from '../Button'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
 
@@ -55,6 +56,27 @@ const variations = {
       background-color: ${getPaletteColor('background.base')};
     }
   `,
+  lightFill: css`
+    ${buttonStyles}
+    ${(props) => {
+      return props.disabled
+        ? `
+        background-color: ${getPaletteColor('background.base')(props)};
+        color: ${getPaletteColor('text.light')(props)};`
+        : ''
+    }}
+  `,
+  input: css`
+    ${buttonStyles}
+    text-align: center;
+    ${(props) => {
+      return props.disabled
+        ? `
+        background-color: ${getPaletteColor('background.base')(props)};
+        color: ${getPaletteColor('text.light')(props)};`
+        : ''
+    }}
+  `,
 }
 
 const propTypes = {
@@ -72,9 +94,9 @@ export interface ILinkProps
   color?: string
   disabled?: boolean
   href?: string
-  size?: 'small' | 'medium' | 'large'
+  size?: Sizes | Sizes[]
   target?: string
-  variation?: 'fill' | 'link' | 'outline' | 'subtle' | 'plain' | 'white'
+  variation?: Variations
   onClick?: (unknown) => unknown
   onFocus?: (unknown) => unknown
 }


### PR DESCRIPTION
- Updating variations and sizes on Link component to be consistent with Button
  - adding variations `lightFill` and `input` 
  - adding size `extraLarge` 

Variations (enabled): 
<img width="616" alt="Screenshot 2023-07-18 at 5 16 07 PM" src="https://github.com/priceline/design-system/assets/65993822/bfc9a48a-0fe5-47bf-a303-ebb6840fc65b">

Variations (disabled):
<img width="618" alt="Screenshot 2023-07-18 at 5 16 21 PM" src="https://github.com/priceline/design-system/assets/65993822/004a2fd5-61b1-4f1f-ae98-8a40104920c6">

Sizes: 
<img width="550" alt="Screenshot 2023-07-18 at 5 15 33 PM" src="https://github.com/priceline/design-system/assets/65993822/59d412da-08c6-4e1f-ba9b-3979d6bb3e9b">
