### PR TITLE
ChoiceChip: Add a topLabel prop and ability to set borderRadius and w…

### DIFF
--- a/common/changes/pcln-design-system/feat-choichchip-toplabel_2023-08-02-13-29.json
+++ b/common/changes/pcln-design-system/feat-choichchip-toplabel_2023-08-02-13-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "ChoiceChip: add topLabel prop along with width and borderRadius",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Chip/ChipContent/ChipContent.spec.tsx
+++ b/packages/core/src/Chip/ChipContent/ChipContent.spec.tsx
@@ -64,11 +64,27 @@ describe('ChipContent', () => {
     expect(getByTestId('chipContentWrapper')).toHaveStyleRule('height', '40px')
   })
 
+  test('md, with topLabel', () => {
+    const { getByTestId, getByText } = render(
+      <ChipContent {...{ ...props, size: 'md', topLabel: 'I love chips' }} />
+    )
+    expect(getByTestId('chipContentWrapper')).toHaveStyleRule('height', '58px')
+    expect(getByText('I love chips'))
+  })
+
   test('Custom contents', () => {
     const { getByText } = render(<ChipContent>HELLO</ChipContent>)
 
     //Child element
     expect(getByText('HELLO'))
+  })
+
+  test('No Icon and No image', () => {
+    const { queryByAltText, queryByTitle } = render(
+      <ChipContent {...{ ...props, BridgeIcon: Broom, Icon: undefined, image: undefined }} />
+    )
+    expect(queryByAltText('Delta')).not.toBeInTheDocument()
+    expect(queryByTitle('Departure')).not.toBeInTheDocument()
   })
 
   test('disabled and selected', () => {

--- a/packages/core/src/Chip/ChipContent/ChipContent.tsx
+++ b/packages/core/src/Chip/ChipContent/ChipContent.tsx
@@ -54,6 +54,7 @@ const ChipContent: React.FC<InferProps<typeof propTypes>> = ({
   BridgeIcon = undefined,
   topLabel = undefined,
   borderRadius = undefined,
+  justifyContent = 'center',
   ...props
 }) => (
   <ChipContentWrapper
@@ -64,6 +65,7 @@ const ChipContent: React.FC<InferProps<typeof propTypes>> = ({
     disabled={disabled}
     selected={selected}
     size={size}
+    justifyContent={justifyContent}
     {...props}
   >
     {children}

--- a/packages/core/src/Chip/ChipContent/ChipContent.tsx
+++ b/packages/core/src/Chip/ChipContent/ChipContent.tsx
@@ -89,7 +89,7 @@ const ChipContent: React.FC<InferProps<typeof propTypes>> = ({
               {facet}
             </Text>
           )}
-          {Boolean(bridgeLabel) && <BridgeIcon title='to' size='16px' ml={2} />}
+          {Boolean(bridgeLabel) && <BridgeIcon title='to' size='16px' ml={2} mt='1px' />}
           {Boolean(bridgeLabel) && (
             <Text regular ml={2}>
               {bridgeLabel}

--- a/packages/core/src/Chip/ChipContent/ChipContent.tsx
+++ b/packages/core/src/Chip/ChipContent/ChipContent.tsx
@@ -7,6 +7,7 @@ import { ChipContentWrapper } from '../ChipContentWrapper'
 import { getPaletteColor } from '../../utils'
 import { Flex } from '../../Flex'
 import { Text } from '../../Text'
+import { Box } from '../../Box'
 
 const ImageWrapper = styled(Flex)`
   background-color: ${getPaletteColor('background.lightest')};
@@ -31,6 +32,8 @@ const propTypes = {
     title: PropTypes.string,
   }),
   Image: PropTypes.object,
+  topLabel: PropTypes.string,
+  borderRadius: PropTypes.string,
 }
 
 const ChipContent: React.FC<InferProps<typeof propTypes>> = ({
@@ -49,36 +52,51 @@ const ChipContent: React.FC<InferProps<typeof propTypes>> = ({
   bridgeLabel = undefined,
   /* eslint-disable @typescript-eslint/naming-convention */
   BridgeIcon = undefined,
+  topLabel = undefined,
+  borderRadius = undefined,
   ...props
 }) => (
   <ChipContentWrapper
     data-testid='chipContentWrapper'
     hasChildren={Boolean(children)}
+    hasTopLabel={Boolean(topLabel)}
+    borderRadiusOverride={borderRadius}
     disabled={disabled}
     selected={selected}
     size={size}
     {...props}
   >
     {children}
-    {Boolean(image) && <ImageWrapper disabled={disabled}>{image}</ImageWrapper>}
-    {Boolean(Icon) && <Icon title={IconTitle} size='20px' />}
-    {Boolean(label) && (
-      <Text regular ml={Boolean(Icon) || Boolean(image) ? 2 : 0}>
-        {label}
-      </Text>
-    )}
-    {Boolean(facet) && (
-      <Text regular ml={1}>
-        {facet}
-      </Text>
-    )}
-    {Boolean(bridgeLabel) && <BridgeIcon title='to' size='16px' ml={2} />}
-    {Boolean(bridgeLabel) && (
-      <Text regular ml={2}>
-        {bridgeLabel}
-      </Text>
-    )}
-    {Boolean(action?.Icon) && action.title && <action.Icon title={action.title} size='16px' ml={2} />}
+    <Flex alignItems='center' height='100%'>
+      {Boolean(image) && <ImageWrapper disabled={disabled}>{image}</ImageWrapper>}
+      {Boolean(Icon) && <Icon title={IconTitle} size='20px' />}
+      <Box>
+        {Boolean(topLabel) && (
+          <Text regular ml={2} mb={1} fontWeight='bold'>
+            {topLabel}
+          </Text>
+        )}
+        <Flex>
+          {Boolean(label) && (
+            <Text regular ml={Boolean(Icon) || Boolean(image) ? 2 : 0}>
+              {label}
+            </Text>
+          )}
+          {Boolean(facet) && (
+            <Text regular ml={1}>
+              {facet}
+            </Text>
+          )}
+          {Boolean(bridgeLabel) && <BridgeIcon title='to' size='16px' ml={2} />}
+          {Boolean(bridgeLabel) && (
+            <Text regular ml={2}>
+              {bridgeLabel}
+            </Text>
+          )}
+        </Flex>
+      </Box>
+      {Boolean(action?.Icon) && action.title && <action.Icon title={action.title} size='16px' ml={2} />}
+    </Flex>
   </ChipContentWrapper>
 )
 

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -4,19 +4,19 @@ import themeGet from '@styled-system/theme-get'
 import { getPaletteColor, applySizes } from '../utils'
 import { Box, IBoxProps } from '../Box'
 
-const getSizes = ({ hasChildren }) => ({
+const getSizes = ({ hasChildren, hasTopLabel, borderRadiusOverride }) => ({
   sm: css`
-    border-radius: ${themeGet('borderRadii.action-sm')};
+    border-radius: ${themeGet(`borderRadii.${borderRadiusOverride || 'action-sm'}`)};
     padding-left: 8px;
     padding-right: 8px;
-    ${hasChildren ? '' : 'height: 32px;'}
+    ${hasChildren ? '' : hasTopLabel ? 'height: 50px;' : 'height: 32px;'}
     font-size: ${themeGet('fontSizes.0')}px;
   `,
   md: css`
-    border-radius: ${themeGet('borderRadii.action-md')};
+    border-radius: ${themeGet(`borderRadii.${borderRadiusOverride || 'action-md'}`)};
     padding-left: 16px;
     padding-right: 16px;
-    ${hasChildren ? '' : 'height: 40px;'}
+    ${hasChildren ? '' : hasTopLabel ? 'height: 58px;' : 'height: 40px;'}
     font-size: ${themeGet('fontSizes.1')}px;
   `,
 })
@@ -35,6 +35,8 @@ interface IChipContentWrapper extends IBoxProps {
   disabled: boolean
   hasChildren: boolean
   selected: boolean
+  hasTopLabel: boolean
+  borderRadiusOverride?: string
 }
 
 const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
@@ -70,13 +72,11 @@ const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
   `}
   width: 100%;
   max-width: 100%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   position: relative;
   border-radius: 2px;
   white-space: nowrap;
-  ${({ theme, hasChildren }) => applySizes(getSizes({ hasChildren }), undefined, theme.mediaQueries)};
+  ${({ theme, hasChildren, hasTopLabel, borderRadiusOverride }) =>
+    applySizes(getSizes({ hasChildren, hasTopLabel, borderRadiusOverride }), undefined, theme.mediaQueries)};
 
   ${(props) => compose(space, fontSize)(props)}
 `

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -72,6 +72,9 @@ const ChipContentWrapper: React.FC<IChipContentWrapper> = styled(Box)`
   `}
   width: 100%;
   max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: ${({ justifyContent }) => justifyContent};
   position: relative;
   border-radius: 2px;
   white-space: nowrap;

--- a/packages/core/src/Chip/ChipLabel/index.tsx
+++ b/packages/core/src/Chip/ChipLabel/index.tsx
@@ -5,7 +5,6 @@ import { Label } from '../../Label'
 
 const ChipLabel = styled(Label)`
   display: inline-flex;
-  width: auto;
   user-select: none;
   padding: 0;
   margin: 0;

--- a/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
+++ b/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
@@ -138,6 +138,44 @@ const withImageAndBridgeLabel = [
 ]
 export const WithImageAndBridgeLabel = () => getExamples(withImageAndBridgeLabel, [medium])
 
+//With Image And Bridge Label
+const withImageBridgeLabelAndTopLabel = [
+  {
+    label: 'Enabled',
+    image: image,
+    bridgeLabel: 'Bridge',
+    topLabel: 'Departure Flight',
+    borderRadius: 'lg',
+    width: '300px',
+  },
+  {
+    label: 'Active',
+    selected: true,
+    image: image,
+    bridgeLabel: 'Bridge',
+    topLabel: 'Departure Flight',
+    borderRadius: 'lg',
+  },
+  {
+    label: 'Disabled',
+    disabled: true,
+    image: image,
+    bridgeLabel: 'Bridge',
+    topLabel: 'Departure Flight',
+    borderRadius: 'lg',
+  },
+  {
+    label: 'Active and Disabled',
+    selected: true,
+    disabled: true,
+    image: image,
+    bridgeLabel: 'Bridge',
+    topLabel: 'Departure Flight',
+    borderRadius: 'lg',
+  },
+]
+export const WithImageBridgeLabelAndTopLabel = () => getExamples(withImageBridgeLabelAndTopLabel, [medium])
+
 //Image Only
 const imageOnly = [
   { image: image },

--- a/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
+++ b/packages/core/src/Chip/ChoiceChip/ChoiceChip.stories.tsx
@@ -147,6 +147,7 @@ const withImageBridgeLabelAndTopLabel = [
     topLabel: 'Departure Flight',
     borderRadius: 'lg',
     width: '300px',
+    justifyContent: 'flex-start',
   },
   {
     label: 'Active',

--- a/packages/core/src/Chip/ChoiceChip/ChoiceChip.tsx
+++ b/packages/core/src/Chip/ChoiceChip/ChoiceChip.tsx
@@ -26,6 +26,7 @@ const choiceChipProps = {
   topLabel: PropTypes.string,
   borderRadius: PropTypes.string,
   width: PropTypes.string,
+  justifyContent: PropTypes.string,
 }
 
 export interface IChoiceChipProps extends SpaceProps, FontSizeProps, React.HTMLAttributes<HTMLElement> {
@@ -37,6 +38,7 @@ export interface IChoiceChipProps extends SpaceProps, FontSizeProps, React.HTMLA
   topLabel?: string
   borderRadius?: string
   width?: string
+  justifyContent?: string
 }
 
 const ChoiceChip: React.FC<IChoiceChipProps> = ({

--- a/packages/core/src/Chip/ChoiceChip/ChoiceChip.tsx
+++ b/packages/core/src/Chip/ChoiceChip/ChoiceChip.tsx
@@ -23,6 +23,9 @@ const choiceChipProps = {
     title: PropTypes.string,
   }),
   Image: PropTypes.object,
+  topLabel: PropTypes.string,
+  borderRadius: PropTypes.string,
+  width: PropTypes.string,
 }
 
 export interface IChoiceChipProps extends SpaceProps, FontSizeProps, React.HTMLAttributes<HTMLElement> {
@@ -31,6 +34,9 @@ export interface IChoiceChipProps extends SpaceProps, FontSizeProps, React.HTMLA
   selected?: boolean
   label?: string
   value?: string | number
+  topLabel?: string
+  borderRadius?: string
+  width?: string
 }
 
 const ChoiceChip: React.FC<IChoiceChipProps> = ({
@@ -41,9 +47,10 @@ const ChoiceChip: React.FC<IChoiceChipProps> = ({
   children,
   onClick,
   label,
+  width = 'auto',
   ...props
 }) => (
-  <ChipLabel htmlFor={id} {...props}>
+  <ChipLabel htmlFor={id} width={width} {...props}>
     <ChipInput
       data-testid={id}
       name={name}

--- a/packages/core/src/Chip/FilterChip/FilterChip.tsx
+++ b/packages/core/src/Chip/FilterChip/FilterChip.tsx
@@ -55,7 +55,7 @@ const FilterChip: React.FC<IFilterChipProps> = ({
   value,
   ...props
 }) => (
-  <ChipLabel htmlFor={id} {...props}>
+  <ChipLabel htmlFor={id} width='auto' {...props}>
     <ChipInput
       type='checkbox'
       role='checkbox'


### PR DESCRIPTION
Add new props to `ChoiceChp`
  **topLabel**:  label that will display above the **label** prop
  **borderRadius**: allow user to override borderRadius
  **width**: allow user to set the width
  **justifyContent**: allow user to override the justifyContent (Default "center")