### PR TITLE
SlideBox: set arrowPosition default to hide

### DIFF
--- a/common/changes/pcln-design-system/main_2023-08-03-21-57.json
+++ b/common/changes/pcln-design-system/main_2023-08-03-21-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "SlideBox: set default arrowPosition to hide",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/SlideBox/BottomArrows.tsx
+++ b/packages/core/src/SlideBox/BottomArrows.tsx
@@ -15,7 +15,12 @@ const BottomArrows: React.FC<ITBottomArrowProps> = ({ arrowPosition, arrowProps 
   const isSide = arrowPosition === 'side'
   const Wrapper = isSide ? AbsoluteTransformRight : Flex
   return ['bottom', 'side'].includes(arrowPosition) ? (
-    <Wrapper justifyContent='center' pt={isSide ? 0 : 2} right={0}>
+    <Wrapper
+      justifyContent='center'
+      pt={isSide ? 0 : 2}
+      right={0}
+      data-testid={isSide ? 'side-right-arrow' : 'bottom-arrows'}
+    >
       {isSide ? null : <Arrow mr={3} isLeft {...arrowProps} />}
       <Arrow {...arrowProps} />
     </Wrapper>

--- a/packages/core/src/SlideBox/SlideBox.spec.tsx
+++ b/packages/core/src/SlideBox/SlideBox.spec.tsx
@@ -38,7 +38,7 @@ describe('SlideBox', () => {
     const slideChange = jest.fn()
 
     const { getByTestId } = render(
-      <SlideBox visibleSlides={1} onSlideChange={slideChange} slideSpacing={2} arrowPosition='side'>
+      <SlideBox visibleSlides={1} onSlideChange={slideChange} slideSpacing={2} arrowPosition='bottom'>
         <Box>1</Box>
         <Box>2</Box>
         <Box>3</Box>

--- a/packages/core/src/SlideBox/SlideBox.spec.tsx
+++ b/packages/core/src/SlideBox/SlideBox.spec.tsx
@@ -6,7 +6,7 @@ import { SlideBox, Box } from '..'
 describe('SlideBox', () => {
   it('renders with layout', () => {
     const { getByTestId } = render(
-      <SlideBox layout='60-40' onSlideChange={() => {}} slideSpacing={2} stretchHeight>
+      <SlideBox layout='60-40' onSlideChange={() => {}} slideSpacing={2} stretchHeight arrowPosition='side'>
         <Box>1</Box>
         <Box>2</Box>
         <Box>3</Box>
@@ -18,7 +18,13 @@ describe('SlideBox', () => {
 
   it('renders with array visible slides', () => {
     const { getByTestId } = render(
-      <SlideBox visibleSlides={[2, 3, 4]} onSlideChange={() => {}} slideSpacing={2} currentSlideOverride={2}>
+      <SlideBox
+        visibleSlides={[2, 3, 4]}
+        onSlideChange={() => {}}
+        slideSpacing={2}
+        currentSlideOverride={2}
+        arrowPosition='side'
+      >
         <Box key='testkey'>1</Box>
         <Box>2</Box>
         <Box>3</Box>
@@ -32,7 +38,7 @@ describe('SlideBox', () => {
     const slideChange = jest.fn()
 
     const { getByTestId } = render(
-      <SlideBox visibleSlides={1} onSlideChange={slideChange} slideSpacing={2}>
+      <SlideBox visibleSlides={1} onSlideChange={slideChange} slideSpacing={2} arrowPosition='side'>
         <Box>1</Box>
         <Box>2</Box>
         <Box>3</Box>
@@ -54,5 +60,19 @@ describe('SlideBox', () => {
     )
 
     getByTestId('top-arrows')
+  })
+
+  it('renders with no arrows default', () => {
+    const { queryByTestId } = render(
+      <SlideBox visibleSlides={1}>
+        <Box>1</Box>
+        <Box>2</Box>
+        <Box>3</Box>
+      </SlideBox>
+    )
+    expect(queryByTestId('top-arrows')).not.toBeInTheDocument()
+    expect(queryByTestId('bottom-arrows')).not.toBeInTheDocument()
+    expect(queryByTestId('side-left-arrow')).not.toBeInTheDocument()
+    expect(queryByTestId('side-right-arrow')).not.toBeInTheDocument()
   })
 })

--- a/packages/core/src/SlideBox/SlideBox.stories.tsx
+++ b/packages/core/src/SlideBox/SlideBox.stories.tsx
@@ -55,6 +55,7 @@ export const Default = () => (
       onSlideChange={action('Slide Change')}
       slideSpacing={2}
       stretchHeight
+      arrowPosition='side'
     >
       {Array.from(Array(20)).map((_, idx) => (
         <ToutCard
@@ -73,7 +74,12 @@ export const Default = () => (
 
 export const NoStrechHeight = () => (
   <Box m={3}>
-    <SlideBox visibleSlides={[1.2, 2.2, 3, 3, 4]} onSlideChange={action('Slide Change')} slideSpacing={2}>
+    <SlideBox
+      visibleSlides={[1.2, 2.2, 3, 3, 4]}
+      onSlideChange={action('Slide Change')}
+      slideSpacing={2}
+      arrowPosition='side'
+    >
       {Array.from(Array(6)).map((_, idx) => (
         <ToutCard
           height={idx === 1 ? '300px' : '320px'}
@@ -97,6 +103,7 @@ export const CustomLayout = () => (
       slideSpacing={2}
       stretchHeight
       layout='30-70'
+      arrowPosition='side'
     >
       {Array.from(Array(6)).map((_, idx) => (
         <ToutCard

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -33,7 +33,7 @@ const SlideBox: React.FC<ISlideBoxProps> = ({
   currentSlideOverride,
   arrowSizeOverride,
   arrowButtonVariation = 'white',
-  arrowPosition = 'side',
+  arrowPosition = 'hide',
   slideScrollNum = 2,
   mobileSlideScrollNum = 1,
 }) => {


### PR DESCRIPTION
Update the `arrowPosition` prop default value to "hide" to fix downstream issue with mobile carousel displaying arrows when they were not before