### PR TITLE
Add borderStyles to Card component

### DIFF
--- a/common/changes/pcln-design-system/border-styles-on-card_2023-08-03-22-11.json
+++ b/common/changes/pcln-design-system/border-styles-on-card_2023-08-03-22-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add borderStyles to Card component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Card/Card.stories.args.ts
+++ b/packages/core/src/Card/Card.stories.args.ts
@@ -1,4 +1,4 @@
-import { colors, inputArgs, shadows } from '../storybook/args'
+import { borderStyles, colors, inputArgs, shadows } from '../storybook/args'
 import { Card } from '..'
 
 export const argTypes = {
@@ -21,6 +21,11 @@ export const argTypes = {
     control: 'select',
     options: inputArgs,
     defaultValue: Card.defaultProps.borderRadius,
+  },
+  borderStyle: {
+    control: 'select',
+    options: borderStyles,
+    defaultValue: Card.defaultProps.borderStyle,
   },
   borderWidth: {
     control: { type: 'number', min: 0, max: 5, step: 1 },

--- a/packages/core/src/Card/Card.stories.args.ts
+++ b/packages/core/src/Card/Card.stories.args.ts
@@ -1,7 +1,7 @@
 import { borderStyles, colors, inputArgs, shadows } from '../storybook/args'
 import { Card } from '..'
 
-export const argTypes = {
+export const argTypes: unknown = {
   as: {
     control: 'select',
     description:

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -1,15 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import { border, BorderProps } from 'styled-system'
 import PropTypes from 'prop-types'
 
 import { Box, IBoxProps } from '../Box'
 import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
-
-const boxBorder = ({ borderWidth, borderColor, ...props }) => ({
-  borderWidth: borderWidth === 0 ? '0' : `${borderWidth}px`,
-  borderStyle: borderWidth === 0 ? undefined : 'solid',
-  borderColor: borderWidth === 0 ? '0' : getPaletteColor(borderColor, 'base')(props),
-})
 
 const styleAsButton = ({ as, ...props }) =>
   as === 'button'
@@ -27,15 +22,17 @@ const cardPropTypes = {
   borderWidth: PropTypes.oneOf([0, 1, 2]),
 }
 
-export interface ICardProps extends IBoxProps {
-  borderWidth?: 0 | 1 | 2 | string
+export interface ICardProps extends IBoxProps, BorderProps {
   borderColor?: string
 }
 
 const Card: React.FC<ICardProps> = styled(Box)`
   ${applyVariations('Card')}
-  ${boxBorder}
   ${styleAsButton}
+
+  border-color: ${(props) =>
+    props.borderWidth === 0 ? '0' : getPaletteColor(props.borderColor, 'base')(props)};
+  ${border};
 `
 
 Card.propTypes = cardPropTypes
@@ -43,6 +40,7 @@ Card.propTypes = cardPropTypes
 Card.defaultProps = {
   borderColor: 'border',
   borderRadius: 'xsm',
+  borderStyle: 'solid',
   borderWidth: 1,
 }
 

--- a/packages/core/src/Card/__snapshots__/Card.spec.tsx.snap
+++ b/packages/core/src/Card/__snapshots__/Card.spec.tsx.snap
@@ -6,8 +6,11 @@ exports[`Card renders border 0 without warning 1`] = `
 }
 
 .c1 {
-  border-width: 0;
   border-color: 0;
+  border-width: 0;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
 }
 
 <div
@@ -22,9 +25,11 @@ exports[`Card renders large box shadow with default border 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 <div
@@ -39,9 +44,11 @@ exports[`Card renders medium box shadow with default border 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 <div
@@ -56,9 +63,11 @@ exports[`Card renders medium box shadow with specified borderRadius 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-radius: 0;
+  border-color: #c0cad5;
+  border-style: solid;
+  border-width: 1px;
 }
 
 <div
@@ -73,9 +82,11 @@ exports[`Card renders medium box shadow with specified borderWidth 1`] = `
 }
 
 .c1 {
-  border-width: 2px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-width: 2px;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
 }
 
 <div
@@ -90,9 +101,11 @@ exports[`Card renders small box shadow with default border 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 <div
@@ -106,10 +119,12 @@ exports[`Card renders with as button 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
-  border-color: #c0cad5;
   font-family: inherit;
+  border-color: #c0cad5;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 .c1:hover {
@@ -129,9 +144,11 @@ exports[`Card renders xlarge box shadow with default border 1`] = `
 }
 
 .c1 {
-  border-width: 1px;
-  border-style: solid;
   border-color: #c0cad5;
+  border-color: #c0cad5;
+  border-radius: 2px;
+  border-style: solid;
+  border-width: 1px;
 }
 
 <div

--- a/packages/core/src/storybook/args/index.ts
+++ b/packages/core/src/storybook/args/index.ts
@@ -15,6 +15,21 @@ export const colors = ['', ...paletteFamilies, 'NOTVALID']
 
 export const borderRadii = ['', ...borderRadiusValues, 'NOTVALID']
 
+export const borderStyles = [
+  'none',
+  'hidden',
+  'dotted',
+  'dashed',
+  'solid',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
+  'initial',
+  'inherit',
+]
+
 export const rounded = ['', ...roundedValues, 'NOTVALID']
 
 export const shadows = ['', ...boxShadowSizeValues, 'NOTVALID']


### PR DESCRIPTION
Adding the `borderStyle` prop to the Card component because I need to use it for a component I'm working on and assumed others might be able to benefit from this too.

https://styled-system.com/api/#border

I was torn between adding this to Card or to Box and therefore everything would get the benefit of it too. I can go back and make this change if people prefer that approach.