### PR TITLE
Make styled component peers consistent

### DIFF
--- a/common/changes/pcln-autocomplete/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-autocomplete/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-autocomplete",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-autocomplete"
+}

--- a/common/changes/pcln-carousel/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-carousel/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/common/changes/pcln-design-system/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-design-system/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-menu/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-menu/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/common/changes/pcln-modal/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-modal/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-modal"
+}

--- a/common/changes/pcln-popover/make-styled-component-peers-consistent_2023-08-10-18-33.json
+++ b/common/changes/pcln-popover/make-styled-component-peers-consistent_2023-08-10-18-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Make styled-component peer dep versions consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -60,6 +60,6 @@
     "pcln-design-system": "^5.20.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6"
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6"
   }
 }

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6",
     "pcln-design-system": "^5.20.0",
     "pcln-icons": "^5.11.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -133,7 +133,7 @@
   "peerDependencies": {
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6",
     "framer-motion": ">=6.5.1"
   }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -57,7 +57,7 @@
     "pcln-popover": "^5.5.7",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6",
     "styled-system": "^5.0.0"
   }
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -57,7 +57,7 @@
     "pcln-design-system": "^5.20.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6",
     "styled-system": "^5.0.0"
   }
 }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -64,7 +64,7 @@
     "pcln-design-system": "^5.20.0",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
-    "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6",
+    "styled-components": ">=5 <5.3.4 || >5.3.7 <6",
     "styled-system": "^5.0.0"
   }
 }


### PR DESCRIPTION
Making the peer dependencies constant across packages as to not cause doppelgangers in rush monorepos.

https://rushjs.io/pages/advanced/npm_doppelgangers/#:~:text=How%20Rush%20helps%3A%20Rush's%20symlinking,possible%20for%20any%20indirect%20dependencies.