### PR TITLE
Resolve avatar prop type issue

### DIFF
--- a/common/changes/pcln-design-system/resolve-avatar-prop-type-issue_2023-08-22-17-15.json
+++ b/common/changes/pcln-design-system/resolve-avatar-prop-type-issue_2023-08-22-17-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "resolve Avatar propType issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -28,7 +28,7 @@ const propTypes = {
   initials: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   color: PropTypes.string,
-  colorScheme: PropTypes.oneOfType(colorSchemeNames),
+  colorScheme: PropTypes.oneOf(colorSchemeNames),
 }
 
 /** @public */


### PR DESCRIPTION
I noticed I was getting a prop type issue using the latest version of the DS and I tracked the issue down to the Avatar component.

`oneOfType` should be `oneOf` as `colorSchemeNames` is a list of strings such as `['primary', 'secondary', ...]`