### PR TITLE
Accordion types use typescript

### DIFF
--- a/common/changes/pcln-design-system/accordion-types-use-typescript_2023-08-23-16-54.json
+++ b/common/changes/pcln-design-system/accordion-types-use-typescript_2023-08-23-16-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Use typescript for Accordion types and remove prop types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -97,7 +97,7 @@ export const TrackStateMultiple = {
           items={items}
           itemsState={itemsState}
           onToggle={(newItemsState) => {
-            setItemsState(newItemsState)
+            setItemsState(newItemsState as string[])
             console.log('previousState:', itemsState, 'newState:', newItemsState)
           }}
         />
@@ -132,7 +132,7 @@ export const TrackStateSingular = {
           items={items}
           itemsState={itemsState}
           onToggle={(newItemsState) => {
-            setItemsState(newItemsState)
+            setItemsState(newItemsState as string)
             console.log('previousState:', itemsState, 'newState:', newItemsState)
           }}
           type='single'

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -8,7 +8,7 @@ import { Box, Flex } from '..'
 export interface IAccordion {
   items: IAccordionItem[]
   itemsState?: string | string[]
-  onToggle?: () => void
+  onToggle?: (value: string | string[]) => void
   type?: string
   variation?: string
 }

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -4,21 +4,20 @@ import React from 'react'
 import * as RadixAccordion from '@radix-ui/react-accordion'
 import { IconContainer, StyledChevron, StyledContent, StyledItem, StyledTrigger } from './Accordion.styled'
 import { Box, Flex } from '..'
-import PropTypes from 'prop-types'
 
 export interface IAccordion {
   items: IAccordionItem[]
-  itemsState?: PropTypes.string | PropTypes.string[]
-  onToggle?: PropTypes.func
-  type?: PropTypes.string
-  variation?: PropTypes.string
+  itemsState?: string | string[]
+  onToggle?: () => void
+  type?: string
+  variation?: string
 }
 
 export interface IAccordionItem {
   content: React.ReactNode
   headerActions?: React.ReactNode
   headerLabel?: React.ReactNode
-  value: PropTypes.string
+  value: string
 }
 
 export const Accordion = ({
@@ -30,6 +29,7 @@ export const Accordion = ({
 }: IAccordion) => {
   return items ? (
     <RadixAccordion.Root
+      // @ts-ignore
       type={type}
       defaultValue={itemsState ?? items.map((child) => child.value)}
       collapsible


### PR DESCRIPTION
Found an issue with Accordion types while trying to use the latest version of the design system. Not sure if this is due to my typescript config in my app or if this would never work but I decided to fix it this way.