### PR TITLE
Feat(htl-94282): Add Gradient and StrokeWidth to Spinner

### DIFF
--- a/common/changes/pcln-design-system/feat-HTL-94282_2023-09-18-13-17.json
+++ b/common/changes/pcln-design-system/feat-HTL-94282_2023-09-18-13-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Added gradient and strokeWidth property to Spinner",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Spinner/Spinner.spec.tsx
+++ b/packages/core/src/Spinner/Spinner.spec.tsx
@@ -10,6 +10,11 @@ describe('Spinner', () => {
     expect(screen.getByTestId('spinner')).toHaveStyle('color: primary')
   })
 
+  it('renders a lonely spinner with gradient', () => {
+    render(<Spinner data-testid='spinner' useGradient={true} />)
+    expect(screen.getByTestId('spinner')).toHaveStyle('color: primary')
+  })
+
   it('renders with an icon', () => {
     render(
       <Spinner data-testid='spinner'>
@@ -24,6 +29,16 @@ describe('Spinner', () => {
   it('renders with multiple colors', () => {
     render(
       <Spinner color='secondary' data-testid='spinner'>
+        <Hotels color='error' data-testid='icon' />
+      </Spinner>
+    )
+
+    expect(screen.getByTestId('spinner')).toHaveStyle('color: secondary')
+    expect(screen.getByTestId('icon')).toHaveStyle('color: rgb(204, 0, 0)')
+  })
+  it('renders with multiple colors and gradient', () => {
+    render(
+      <Spinner color='secondary' data-testid='spinner' useGradient={true}>
         <Hotels color='error' data-testid='icon' />
       </Spinner>
     )

--- a/packages/core/src/Spinner/Spinner.stories.args.tsx
+++ b/packages/core/src/Spinner/Spinner.stories.args.tsx
@@ -67,4 +67,14 @@ export const argTypes = {
       options: icons,
     },
   },
+  useGradient: {
+    name: 'useGradient',
+    type: { name: 'boolean', required: false },
+    description: 'Control to have a gradient on the ring or not',
+  },
+  strokeWidth: {
+    name: 'strokeWidth',
+    type: { name: 'string', required: false },
+    description: 'Defines the width of the spinner ring(needs to useGradient to work)',
+  },
 }

--- a/packages/core/src/Spinner/Spinner.stories.tsx
+++ b/packages/core/src/Spinner/Spinner.stories.tsx
@@ -55,13 +55,13 @@ Responsive.args = {
 Responsive.parameters = {
   viewport: { defaultViewport: 'designSystem_sm' },
 }
-export const withGradient = Template.bind({})
-withGradient.args = {
+export const WithGradient = Template.bind({})
+WithGradient.args = {
   size: 'large',
   useGradient: true,
 }
-export const withGradientCustomWidth = Template.bind({})
-withGradientCustomWidth.args = {
+export const WithGradientCustomWidth = Template.bind({})
+WithGradientCustomWidth.args = {
   size: 'large',
   useGradient: true,
   strokeWidth: '10px',

--- a/packages/core/src/Spinner/Spinner.stories.tsx
+++ b/packages/core/src/Spinner/Spinner.stories.tsx
@@ -55,3 +55,14 @@ Responsive.args = {
 Responsive.parameters = {
   viewport: { defaultViewport: 'designSystem_sm' },
 }
+export const withGradient = Template.bind({})
+withGradient.args = {
+  size: 'large',
+  useGradient: true,
+}
+export const withGradientCustomWidth = Template.bind({})
+withGradientCustomWidth.args = {
+  size: 'large',
+  useGradient: true,
+  strokeWidth: '10px',
+}

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -79,7 +79,7 @@ const propTypes = {
 }
 
 const GradientRing: React.FC<InferProps<typeof propTypes>> = ({ strokeWidth = '6px', ...props }) => {
-  const strokeColor = getPaletteColor(props?.color, 'base')(props)
+  const strokeColor = getPaletteColor(props.color, 'base')(props)
   return (
     <GradientRingWrapper>
       <svg

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes, { InferProps } from 'prop-types'
-import styled, { css, keyframes } from 'styled-components'
-import { Flex } from '..'
+import styled, { css, keyframes, useTheme } from 'styled-components'
+import { Flex, Absolute } from '..'
 import { applySizes, getPaletteColor } from '../utils'
 
 const sizes = {
@@ -57,6 +57,14 @@ const Ring = styled.div`
   animation: ${rotate} 1s linear infinite;
 `
 
+const GradientRingWrapper = styled(Absolute)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
 const propTypes = {
   children: PropTypes.node,
   color: PropTypes.string,
@@ -70,14 +78,61 @@ const propTypes = {
   ]),
 }
 
-const Spinner: React.FC<InferProps<typeof propTypes>> = ({ children, color, ...props }) => {
+const GradientRing: React.FC<InferProps<typeof propTypes>> = ({ strokeWidth = '6px', ...props }) => {
+  const strokeColor = getPaletteColor(props?.color, 'base')(props)
+  return (
+    <GradientRingWrapper>
+      <svg
+        width='100%'
+        height='100%'
+        viewBox='0 0 200 200'
+        color={strokeColor}
+        fill='none'
+        overflow='visible'
+      >
+        <defs>
+          <linearGradient id='spinner-secondHalf'>
+            <stop offset='0%' stop-opacity='0' stop-color='currentColor' />
+            <stop offset='100%' stop-opacity='0.5' stop-color='currentColor' />
+          </linearGradient>
+          <linearGradient id='spinner-firstHalf'>
+            <stop offset='0%' stop-opacity='1' stop-color='currentColor' />
+            <stop offset='100%' stop-opacity='0.5' stop-color='currentColor' />
+          </linearGradient>
+        </defs>
+
+        <g stroke-width={strokeWidth}>
+          <path stroke='url(#spinner-secondHalf)' d='M 4 100 A 96 96 0 0 1 196 100' />
+          <path stroke='url(#spinner-firstHalf)' d='M 196 100 A 96 96 0 0 1 4 100' />
+          <path stroke='currentColor' stroke-linecap='round' d='M 4 100 A 96 96 0 0 1 4 98' />
+        </g>
+        <animateTransform
+          from='0 0 0'
+          to='360 0 0'
+          attributeName='transform'
+          type='rotate'
+          repeatCount='indefinite'
+          dur='1000ms'
+        />
+      </svg>
+    </GradientRingWrapper>
+  )
+}
+
+const Spinner: React.FC<InferProps<typeof propTypes>> = ({
+  children,
+  color,
+  useGradient = false,
+  ...props
+}) => {
   if (children) {
     React.Children.only(children)
   }
+  const theme = useTheme()
 
   return (
     <RelativeFlex justifyContent='center' alignItems='center' {...props}>
-      <Ring color={color} />
+      {useGradient ? <GradientRing color={color} theme={theme} {...props} /> : <Ring color={color} />}
       {children &&
         React.cloneElement(children, {
           color: children?.props?.color || color,


### PR DESCRIPTION
<img width="495" alt="image" src="https://github.com/priceline/design-system/assets/94923201/e281d6d9-0020-4141-824f-846f855e5257">


useGradient and strokeWidth property was added to the component.

An svg was created to handle smooth gradient and stroke line cap property
