### PR TITLE
fix(): Remove readonly styles from Select

### DIFF
--- a/common/changes/pcln-design-system/fix-select-readonly-disabled_2023-09-20-18-08.json
+++ b/common/changes/pcln-design-system/fix-select-readonly-disabled_2023-09-20-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Remove readonly prop from Select",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -302,28 +302,27 @@ exports[`FormField disabled state renders select with icon - disabled 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: inherit;
   background-color: transparent;
   border-radius: 12px;
-  border-width: 1px;
   border-style: solid;
+  border-width: 1px;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
   padding-left: 40px;
+  border-radius: 12px;
   font-size: 16px;
   margin: 0px;
-  border-radius: 12px;
 }
 
 .c10::-ms-expand {
   display: none;
 }
 
-.c10:disabled,
-.c10[readOnly] {
+.c10:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -1052,27 +1051,26 @@ exports[`FormField renders with Select  1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: inherit;
   background-color: transparent;
   border-radius: 12px;
-  border-width: 1px;
   border-style: solid;
+  border-width: 1px;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
+  border-radius: 12px;
   font-size: 16px;
   margin: 0px;
-  border-radius: 12px;
 }
 
 .c4::-ms-expand {
   display: none;
 }
 
-.c4:disabled,
-.c4[readOnly] {
+.c4:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -1250,28 +1248,27 @@ exports[`FormField renders with Select and Icon 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: inherit;
   background-color: transparent;
   border-radius: 12px;
-  border-width: 1px;
   border-style: solid;
+  border-width: 1px;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
   padding-left: 40px;
+  border-radius: 12px;
   font-size: 16px;
   margin: 0px;
-  border-radius: 12px;
 }
 
 .c8::-ms-expand {
   display: none;
 }
 
-.c8:disabled,
-.c8[readOnly] {
+.c8:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;

--- a/packages/core/src/Select/Select.spec.tsx
+++ b/packages/core/src/Select/Select.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { render, screen } from '../__test__/testing-library'
-
 import { Select, theme, createTheme, getPaletteColor } from '..'
 
 describe('Select', () => {
@@ -12,12 +11,12 @@ describe('Select', () => {
   test('it renders disabled', () => {
     const paletteTheme = createTheme(theme)
     render(
-      <Select defaultValue='Premium Economy' disabled>
+      <Select data-testId='disabled-select' defaultValue='Premium Economy' disabled>
         <option>Premium Economy</option>
       </Select>
     )
 
-    const select = screen.getByText('Premium Economy').closest('select')
+    const select = screen.getByTestId('disabled-select')
     expect(select).toBeDisabled()
     expect(select).toHaveStyleRule(
       'background-color',
@@ -29,29 +28,5 @@ describe('Select', () => {
     })
     expect(select).toHaveStyleRule('cursor', 'not-allowed', { modifier: ':disabled' })
     expect(select).toHaveStyleRule('opacity', '1', { modifier: ':disabled' })
-  })
-
-  test('it renders read-only', () => {
-    const paletteTheme = createTheme(theme)
-    render(
-      <Select defaultValue='Premium Economy' readOnly>
-        <option>Premium Economy</option>
-      </Select>
-    )
-
-    const select = screen.getByText('Premium Economy').closest('select')
-
-    expect(screen.getByText('Premium Economy')).toBeDisabled()
-    expect(select).toHaveAttribute('readonly')
-    expect(select).toHaveStyleRule(
-      'background-color',
-      getPaletteColor('background.light')({ theme: paletteTheme }),
-      { modifier: '[readOnly]' }
-    )
-    expect(select).toHaveStyleRule('color', getPaletteColor('text.light')({ theme: paletteTheme }), {
-      modifier: '[readOnly]',
-    })
-    expect(select).toHaveStyleRule('cursor', 'not-allowed', { modifier: '[readOnly]' })
-    expect(select).toHaveStyleRule('opacity', '1', { modifier: '[readOnly]' })
   })
 })

--- a/packages/core/src/Select/Select.stories.args.ts
+++ b/packages/core/src/Select/Select.stories.args.ts
@@ -19,11 +19,6 @@ export const argTypes = {
     type: { name: 'boolean' },
     defaultValue: false,
   },
-  readOnly: {
-    name: 'readOnly',
-    type: { name: 'boolean' },
-    defaultValue: false,
-  },
   size: {
     name: 'size',
     type: { name: 'string' },

--- a/packages/core/src/Select/Select.stories.tsx
+++ b/packages/core/src/Select/Select.stories.tsx
@@ -16,6 +16,7 @@ const Template = (args) => (
     <Label htmlFor='cabinClass'>Cabin Class</Label>
     <Select id='cabinClass' name='cabinClass' defaultValue='Premium Economy' {...args}>
       <option>Economy</option>
+      <option disabled>-------------</option>
       <option>Premium Economy</option>
       <option>Business</option>
       <option>First Class</option>
@@ -28,9 +29,6 @@ export const _Select = Template.bind({})
 
 export const Disabled = Template.bind({})
 Disabled.args = { disabled: true }
-
-export const ReadOnly = Template.bind({})
-ReadOnly.args = { readOnly: true }
 
 export const LongOptionString = () => (
   <Box width={[1, 320]}>

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { InferProps } from 'prop-types'
 import styled, { css } from 'styled-components'
-import { space, fontSize, borderRadius, SpaceProps, FontSizeProps, compose } from 'styled-system'
+import { borderRadius, compose, fontSize, space, FontSizeProps, SpaceProps } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
 import styledSystemPropTypes from '@styled-system/prop-types'
 import { ChevronDown } from 'pcln-icons'
-import { applySizes, borderRadiusAttrs, borders, deprecatedColorValue, getPaletteColor } from '../utils'
 import { Flex } from '../Flex'
+import { applySizes, borderRadiusAttrs, borders, deprecatedColorValue, getPaletteColor } from '../utils'
 
 const sizes = {
   sm: css`
@@ -34,21 +34,20 @@ const propTypes = {
 }
 const SelectBase: React.FC<InferProps<typeof propTypes>> = styled.select.attrs(borderRadiusAttrs)`
   appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: inherit;
   background-color: transparent;
   border-radius: ${themeGet('borderRadii.lg')};
-  border-width: 1px;
   border-style: solid;
+  border-width: 1px;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  width: 100%;
 
   ::-ms-expand {
     display: none;
   }
 
-  &:disabled,
-  &[readOnly] {
+  &:disabled {
     background-color: ${getPaletteColor('background.light')};
     color: ${getPaletteColor('text.light')};
     cursor: not-allowed;
@@ -63,10 +62,10 @@ const SelectBase: React.FC<InferProps<typeof propTypes>> = styled.select.attrs(b
 `
 
 SelectBase.defaultProps = {
+  borderRadius: 'lg',
   fontSize: [2, null, 1],
   m: 0,
   size: 'lg',
-  borderRadius: 'lg',
 }
 
 SelectBase.propTypes = propTypes
@@ -76,15 +75,9 @@ export interface ISelectProps extends SpaceProps, FontSizeProps {}
 const Select: React.FC<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Pick<any, string | number | symbol> & React.RefAttributes<unknown>
-> & { isField?: boolean } = React.forwardRef(({ children, readOnly, ...props }, ref) => (
+> & { isField?: boolean } = React.forwardRef((props, ref) => (
   <Flex width={1} alignItems='center'>
-    <SelectBase {...props} readOnly={readOnly} ref={ref}>
-      {React.Children.map(children, (child) => {
-        return React.cloneElement(child as React.ReactElement, {
-          disabled: readOnly,
-        })
-      })}
-    </SelectBase>
+    <SelectBase {...props} ref={ref} />
     <ClickableIcon ml={-32} color='text.light' />
   </Flex>
 ))

--- a/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
@@ -38,27 +38,26 @@ exports[`Select renders 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: inherit;
   background-color: transparent;
   border-radius: 12px;
-  border-width: 1px;
   border-style: solid;
+  border-width: 1px;
+  color: inherit;
+  display: block;
+  font-family: inherit;
+  width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
+  border-radius: 12px;
   font-size: 16px;
   margin: 0px;
-  border-radius: 12px;
 }
 
 .c2::-ms-expand {
   display: none;
 }
 
-.c2:disabled,
-.c2[readOnly] {
+.c2:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;


### PR DESCRIPTION
- Remove `readonly` styles/prop from Select as it is not supported or relevant to `select`
  - https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly
- It also created a bug where individual `option`s' ability to set `disabled` were overwritten by the `readOnly` prop functionality in this component even if it wasn't set
  - Add to storybook to show this so that we can catch this in the future
 
Disabled option among non-disabled options example: 
![Screenshot 2023-09-20 at 1 24 16 PM](https://github.com/priceline/design-system/assets/62613356/53d4bb28-a79c-4797-a898-9f0cd0c8a2e6)
