### PR TITLE
Fix regressions related to readonly in Input and Toggle

### DIFF
--- a/common/changes/pcln-design-system/fix-readonly-regressions_2023-09-21-16-37.json
+++ b/common/changes/pcln-design-system/fix-readonly-regressions_2023-09-21-16-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix regressions related to readonly in Input and Toggle",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Button/Button.stories.tsx
+++ b/packages/core/src/Button/Button.stories.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable react/no-unescaped-entities */
+// @ts-nocheck
 
 import type { Meta, StoryObj } from '@storybook/react'
 import type { IButtonProps, Sizes } from './Button'
 
 import { ArgsTable, Primary, PRIMARY_STORY } from '@storybook/addon-docs'
 import { linkTo } from '@storybook/addon-links'
-import { Calendar, Check, ChevronLeft, ChevronRight, Search, User } from 'pcln-icons'
+import { Calendar, Check, ChevronLeft, ChevronRight, ChevronDown, Search, User, Guests } from 'pcln-icons'
 import React from 'react'
 
-import { Box, Button, ButtonChip, CloseButton, Flex, Image, Link, Text, ThemeProvider } from '..'
+import { Box, Button, ButtonChip, CloseButton, Flex, Image, Link, Text, ThemeProvider, Label } from '..'
 import {
   DocTable,
   DoDont,
@@ -177,14 +178,50 @@ export const IconButtons: ButtonStory = {
   ),
 }
 
+export const InputVariation: ButtonStory = {
+  render: () => (
+    <StoryStage>
+      <Button size='lg' variation='input' borderRadius='lg' py={0}>
+        <Flex width='100%' justifyContent='flex-start' height='100%' alignItems='center' height='54px'>
+          <Calendar mr={2} color='primary.base' />
+          <Flex flexDirection='column'>
+            <Label as='div'>Check-in - Check-out</Label>
+            <Text>09/21/2023 – 09/22/2023</Text>
+          </Flex>
+        </Flex>
+      </Button>
+
+      <Button size='lg' variation='input' borderRadius='lg'>
+        <Flex width='100%' justifyContent='flex-start' height='100%' alignItems='center'>
+          <Calendar mr={2} color='primary.base' />
+          <Flex flexDirection='column'>
+            <Text color='text.light'>mm/dd/yyyy - mm/dd/yyyy</Text>
+          </Flex>
+        </Flex>
+      </Button>
+
+      <Button size='lg' variation='input' borderRadius='lg'>
+        <Flex width='100%' justifyContent='space-between' height='100%' alignItems='center'>
+          <Flex alignItems='center'>
+            <Guests mr={2} color='primary.base' />
+            <Flex flexDirection='column'>
+              <Text color='text.light'>Select travelers</Text>
+            </Flex>
+          </Flex>
+          <ChevronDown color='primary.base' />
+        </Flex>
+      </Button>
+    </StoryStage>
+  ),
+}
+
 const meta: Meta<typeof Button> = {
   title: 'Actions/Button',
   component: Button,
   parameters: {
     design: {
       type: 'figma',
-      url:
-        'https://www.figma.com/file/1lLCo0ZnO1RyMDEbnnS0by/Web-Design-System?type=design&node-id=131-21304&t=wTmhDg2MwlPA9PGf-4',
+      url: 'https://www.figma.com/file/1lLCo0ZnO1RyMDEbnnS0by/Web-Design-System?type=design&node-id=131-21304&t=wTmhDg2MwlPA9PGf-4',
     },
 
     docs: {

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -109,15 +109,7 @@ exports[`FormField disabled state renders input with icon - disabled 1`] = `
   display: none;
 }
 
-.c9:disabled,
-.c9:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c9:disabled,
-.c9:read-only {
+.c9:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -509,15 +501,7 @@ exports[`FormField renders 1`] = `
   display: none;
 }
 
-.c3:disabled,
-.c3:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c3:disabled,
-.c3:read-only {
+.c3:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -689,15 +673,7 @@ exports[`FormField renders with Icon 1`] = `
   display: none;
 }
 
-.c7:disabled,
-.c7:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c7:disabled,
-.c7:read-only {
+.c7:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -890,15 +866,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   display: none;
 }
 
-.c7:disabled,
-.c7:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c7:disabled,
-.c7:read-only {
+.c7:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -57,8 +57,7 @@ const StyledInput = styled.input.attrs(borderRadiusAttrs)`
     display: none;
   }
 
-  &:disabled,
-  &:read-only {
+  &:disabled {
     background-color: ${getPaletteColor('background.light')};
     color: ${getPaletteColor('text.light')};
     cursor: not-allowed;

--- a/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
@@ -40,15 +40,7 @@ exports[`Input it renders 1`] = `
   display: none;
 }
 
-.c0:disabled,
-.c0:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c0:disabled,
-.c0:read-only {
+.c0:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -126,15 +118,7 @@ exports[`Input it renders an input element with a really large padding and margi
   display: none;
 }
 
-.c0:disabled,
-.c0:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c0:disabled,
-.c0:read-only {
+.c0:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -210,15 +194,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   display: none;
 }
 
-.c0:disabled,
-.c0:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c0:disabled,
-.c0:read-only {
+.c0:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;
@@ -295,15 +271,7 @@ exports[`Input it renders an input element with large text 1`] = `
   display: none;
 }
 
-.c0:disabled,
-.c0:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c0:disabled,
-.c0:read-only {
+.c0:disabled {
   background-color: #f4f6f8;
   color: #4f6f8f;
   cursor: not-allowed;

--- a/packages/core/src/RadioCheckToggleCard/__snapshots__/RadioCheckToggleCard.spec.tsx.snap
+++ b/packages/core/src/RadioCheckToggleCard/__snapshots__/RadioCheckToggleCard.spec.tsx.snap
@@ -800,7 +800,7 @@ exports[`RadioCheckToggleCard Radio Card should render unchecked state UI correc
 
 exports[`RadioCheckToggleCard Toggle Card should render checked state UI correctly 1`] = `
 <DocumentFragment>
-  .c22 {
+  .c21 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -808,7 +808,7 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   width: 16;
 }
 
-.c23 {
+.c22 {
   outline: none;
 }
 
@@ -825,12 +825,12 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   width: 45px;
 }
 
-.c16 {
+.c15 {
   border-radius: 9999px;
   width: calc(100% + 8px);
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #001833;
   border-radius: 9999px;
@@ -838,13 +838,13 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 1px 0 rgba(0,0,0,0.24),0 2px 1px -1px rgba(0,0,0,0.16),0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.c17 {
+.c16 {
   position: absolute;
   left: -4px;
   top: -4px;
 }
 
-.c20 {
+.c19 {
   position: absolute;
   left: 23px;
   top: 2px;
@@ -874,67 +874,7 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   flex-direction: row;
 }
 
-.c12 {
-  position: relative;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: #001833;
-  background-color: transparent;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 14px 12px 14px 12px;
-  border-color: #c0cad5;
-  padding: 0px;
-  font-size: 16px;
-  border-radius: 12px;
-}
-
-.c12::-webkit-input-placeholder {
-  color: #4f6f8f;
-}
-
-.c12::-moz-placeholder {
-  color: #4f6f8f;
-}
-
-.c12:-ms-input-placeholder {
-  color: #4f6f8f;
-}
-
-.c12::placeholder {
-  color: #4f6f8f;
-}
-
-.c12::-ms-clear {
-  display: none;
-}
-
-.c12:disabled,
-.c12:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c12:disabled,
-.c12:read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c12:focus {
-  outline: 0;
-  border-color: #0068ef;
-  box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c14 {
+.c13 {
   position: absolute;
   z-index: 1;
   opacity: 0;
@@ -946,13 +886,13 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   cursor: pointer;
 }
 
-.c18 {
+.c17 {
   height: calc(100% + 8px);
   opacity: 0;
   background-color: #0068ef4C;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -980,7 +920,7 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   min-width: 45px;
 }
 
-.c11 .c13:focus-visible + .c15 {
+.c11 .c12:focus-visible + .c14 {
   opacity: 1;
 }
 
@@ -1093,16 +1033,6 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
   box-sizing: border-box;
 }
 
-@media screen and (min-width:32em) {
-
-}
-
-@media screen and (min-width:40em) {
-  .c12 {
-    font-size: 14px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -1153,18 +1083,17 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
                 <input
                   aria-checked="true"
                   checked=""
-                  class="c12 c13 c14"
-                  font-size="2,,1"
+                  class="c12 c13"
                   role="switch"
                   tabindex="0"
                   type="checkbox"
                 />
                 <div
-                  class="c15 c16 c17 c18"
+                  class="c14 c15 c16 c17"
                   width="calc(100% + 8px)"
                 />
                 <div
-                  class="c19 c20 c21"
+                  class="c18 c19 c20"
                   color="background.lightest"
                   data-testid="handle-div"
                   id="circle-handle"
@@ -1172,7 +1101,7 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
                 >
                   <svg
                     aria-hidden="true"
-                    class="c22 c23"
+                    class="c21 c22"
                     fill="currentcolor"
                     focusable="false"
                     height="16"
@@ -1199,7 +1128,7 @@ exports[`RadioCheckToggleCard Toggle Card should render checked state UI correct
 
 exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI correctly 1`] = `
 <DocumentFragment>
-  .c22 {
+  .c21 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -1207,7 +1136,7 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   width: 16;
 }
 
-.c23 {
+.c22 {
   outline: none;
 }
 
@@ -1224,12 +1153,12 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   width: 45px;
 }
 
-.c16 {
+.c15 {
   border-radius: 9999px;
   width: calc(100% + 8px);
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #001833;
   border-radius: 9999px;
@@ -1237,13 +1166,13 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   box-shadow: 0 -1px 0 0 rgba(0,0,0,0.03),0 0 1px 0 rgba(0,0,0,0.24),0 2px 1px -1px rgba(0,0,0,0.16),0 2px 4px 0 rgba(0,0,0,0.12);
 }
 
-.c17 {
+.c16 {
   position: absolute;
   left: -4px;
   top: -4px;
 }
 
-.c20 {
+.c19 {
   position: absolute;
   left: 2px;
   top: 2px;
@@ -1273,67 +1202,7 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   flex-direction: row;
 }
 
-.c12 {
-  position: relative;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 100%;
-  font-family: inherit;
-  color: #001833;
-  background-color: transparent;
-  border-width: 1px;
-  border-style: solid;
-  margin: 0;
-  padding: 14px 12px 14px 12px;
-  border-color: #c0cad5;
-  padding: 0px;
-  font-size: 16px;
-  border-radius: 12px;
-}
-
-.c12::-webkit-input-placeholder {
-  color: #4f6f8f;
-}
-
-.c12::-moz-placeholder {
-  color: #4f6f8f;
-}
-
-.c12:-ms-input-placeholder {
-  color: #4f6f8f;
-}
-
-.c12::placeholder {
-  color: #4f6f8f;
-}
-
-.c12::-ms-clear {
-  display: none;
-}
-
-.c12:disabled,
-.c12:-moz-read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c12:disabled,
-.c12:read-only {
-  background-color: #f4f6f8;
-  color: #4f6f8f;
-  cursor: not-allowed;
-}
-
-.c12:focus {
-  outline: 0;
-  border-color: #0068ef;
-  box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c14 {
+.c13 {
   position: absolute;
   z-index: 1;
   opacity: 0;
@@ -1345,13 +1214,13 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   cursor: pointer;
 }
 
-.c18 {
+.c17 {
   height: calc(100% + 8px);
   opacity: 0;
   background-color: #4f6f8f4C;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1379,7 +1248,7 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   min-width: 45px;
 }
 
-.c11 .c13:focus-visible + .c15 {
+.c11 .c12:focus-visible + .c14 {
   opacity: 1;
 }
 
@@ -1492,16 +1361,6 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
   box-sizing: border-box;
 }
 
-@media screen and (min-width:32em) {
-
-}
-
-@media screen and (min-width:40em) {
-  .c12 {
-    font-size: 14px;
-  }
-}
-
 <div
     class="c0"
   >
@@ -1550,18 +1409,17 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
               >
                 <input
                   aria-checked="false"
-                  class="c12 c13 c14"
-                  font-size="2,,1"
+                  class="c12 c13"
                   role="switch"
                   tabindex="0"
                   type="checkbox"
                 />
                 <div
-                  class="c15 c16 c17 c18"
+                  class="c14 c15 c16 c17"
                   width="calc(100% + 8px)"
                 />
                 <div
-                  class="c19 c20 c21"
+                  class="c18 c19 c20"
                   color="background.lightest"
                   data-testid="handle-div"
                   id="circle-handle"
@@ -1569,7 +1427,7 @@ exports[`RadioCheckToggleCard Toggle Card should render unchecked state UI corre
                 >
                   <svg
                     aria-hidden="true"
-                    class="c22 c23"
+                    class="c21 c22"
                     fill="currentcolor"
                     focusable="false"
                     height="16"

--- a/packages/core/src/Toggle/Toggle.tsx
+++ b/packages/core/src/Toggle/Toggle.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Box, Absolute, Input, getPaletteColor } from '..'
+import { Box, Absolute, getPaletteColor } from '..'
 
 const alphaColor = (color: string, props) => `${getPaletteColor(color)(props)}4C`
 
-const AbsoluteInput = styled(Input)`
+const AbsoluteInput = styled.input`
   position: absolute;
   z-index: 1;
   opacity: 0;


### PR DESCRIPTION
Bonus examples of properly styling a `Button` like an `Input` without being semantically incorrect and violating a11y rules.

![CleanShot 2023-09-21 at 12 48 35](https://github.com/priceline/design-system/assets/3260642/6eee9d6b-245a-4416-82c5-d244f7e97515)
