### PR TITLE
bugfix: Allows elements inside the Modal to overflow on the y axis

### DIFF
--- a/common/changes/pcln-modal/bugfix-fix-modal-overflow_2023-09-25-16-21.json
+++ b/common/changes/pcln-modal/bugfix-fix-modal-overflow_2023-09-25-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "remove explicit setting of overflow-y:auto on Modal component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-modal"
+}

--- a/packages/modal/src/Modal.jsx
+++ b/packages/modal/src/Modal.jsx
@@ -54,7 +54,6 @@ const Dialog = styled(DialogContent)`
   margin-right: auto;
   box-shadow: ${(props) => props.theme.shadows['overlay-xl']};
   border-radius: ${({ borderRadius }) => themeGet(`borderRadii.${borderRadius}`)};
-  overflow-y: auto;
   &:focus {
     outline: none;
   }

--- a/packages/modal/src/Modal.stories.jsx
+++ b/packages/modal/src/Modal.stories.jsx
@@ -1,8 +1,7 @@
 import { action } from '@storybook/addon-actions'
-import { Box, Button, Text } from 'pcln-design-system'
+import { Box, Button, Accordion, Text } from 'pcln-design-system'
 import { Menu, MenuItem } from 'pcln-menu'
-import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState, useRef } from 'react'
 import styled from 'styled-components'
 import { Modal, ModalHeader, ScrollLock, SmallModalHeader } from '../src'
 import { currencies } from './mockData'
@@ -15,50 +14,32 @@ const CUSTOM_ANIMATION = (transitionState) => `
   transition: transform 0.3s linear;
   ${transitionState === 'entered' ? `transform: translateY(0%);` : ''}
 `
-
-class ModalStory extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isOpen: props.isOpen,
+function ModalStory(props) {
+  const [isOpen, setIsOpen] = useState(props.isOpen)
+  const scrollLock = useRef(new ScrollLock())
+  function onClose() {
+    setIsOpen(false)
+    if (props.lock) {
+      scrollLock.current.off()
     }
-    this.scrollLock = new ScrollLock()
   }
-
-  static propTypes = {
-    isOpen: PropTypes.bool,
-    lock: PropTypes.bool,
-  }
-
-  render() {
-    return (
-      <div style={{ height: '1500px' }}>
-        <Button
-          onClick={() => {
-            if (this.props.lock) {
-              this.scrollLock.on()
-            }
-            this.setState({ isOpen: true })
-          }}
-        >
-          Open
-        </Button>
-        <StyledModal
-          ariaLabel='Storybook modal.'
-          isOpen={this.state.isOpen}
-          onClose={() => {
-            this.setState({ isOpen: false })
-            if (this.props.lock) {
-              this.scrollLock.off()
-            }
-          }}
-          {...this.props}
-        >
-          <div style={{ height: '1000px' }}>Content with 1000px height</div>
-        </StyledModal>
-      </div>
-    )
-  }
+  return (
+    <div style={{ height: '1500px' }}>
+      <Button
+        onClick={() => {
+          if (props.lock) {
+            scrollLock.current.on()
+          }
+          setIsOpen(true)
+        }}
+      >
+        Open
+      </Button>
+      <StyledModal ariaLabel='Storybook modal.' isOpen={isOpen} onClose={onClose} {...props}>
+        <div style={{ height: '1000px' }}>Content with 1000px height</div>
+      </StyledModal>
+    </div>
+  )
 }
 
 export default {
@@ -115,6 +96,29 @@ export const WithSmallModalHeaderAndWhiteBackgroundModalHeaderWithSetTextStyle =
 
 export const WithOverflow = () => (
   <ModalStory header={<SmallModalHeader />} width={['80vw', '400px', '500px']} enableOverflow />
+)
+
+const accordionItems = [
+  {
+    headerLabel: (
+      <>
+        <Text>Header Label First Item</Text>
+      </>
+    ),
+    content: (
+      <>
+        <Text>I am some content</Text>
+        <Text>I am some content</Text>
+        <Text>I am some content</Text>
+      </>
+    ),
+    value: 'item-1',
+  },
+]
+export const WithOverflowForElementsRenderedInsideTheModal = () => (
+  <StyledModal ariaLabel='Storybook modal.' isOpen={true} height='100px' enableOverflow>
+    <Accordion items={accordionItems} />
+  </StyledModal>
 )
 
 export const WithOverflowAndDropdown = () => (


### PR DESCRIPTION
### Description/Summary of changes

- Revert the `overflow-y: auto` change that was introduced in this [PR](https://github.com/priceline/design-system/pull/1319/files#diff-5b5f252abb56263bc4b86a7916c35586d4e9c96da30f35e18e66d1e9ed013eb2R57)
- The change was breaking the modals where form elements are hosted that naturally overflow the modal (when the elements are in an active state)

### Screenshots

Broken state
<img width="1134" alt="Modal Overflow missing" src="https://github.com/priceline/design-system/assets/5671981/6f991408-0635-4913-b1bd-2c7a28a8d2e3">


Current Production state 
<img width="1049" alt="image" src="https://github.com/priceline/design-system/assets/5671981/bd280ae0-4cd7-4398-bd7a-2f3c8ab6533f">

