### PR TITLE
Expand allowed peerDeps versions for framer-motion in core package

### DIFF
--- a/common/changes/pcln-design-system/expand-framer-motion-peerdep_2023-10-24-19-52.json
+++ b/common/changes/pcln-design-system/expand-framer-motion-peerdep_2023-10-24-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Expand allowed peerDeps versions for framer-motion to fix issue with Webpack builds",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^8.48.0
         version: 8.48.0
       framer-motion:
-        specifier: ^6.5.1
-        version: 6.5.1(react-dom@17.0.2)(react@17.0.2)
+        specifier: ^3.10.6
+        version: 3.10.6(react-dom@17.0.2)(react@17.0.2)
       jest:
         specifier: ^29.6.4
         version: 29.6.4(@types/node@18.17.14)
@@ -3553,53 +3553,6 @@ packages:
 
   /@microsoft/tsdoc@0.14.2:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
-
-  /@motionone/animation@10.15.1:
-    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
-    dependencies:
-      '@motionone/easing': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: true
-
-  /@motionone/dom@10.12.0:
-    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
-    dependencies:
-      '@motionone/animation': 10.15.1
-      '@motionone/generators': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.2
-    dev: true
-
-  /@motionone/easing@10.15.1:
-    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
-    dependencies:
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: true
-
-  /@motionone/generators@10.15.1:
-    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: true
-
-  /@motionone/types@10.15.1:
-    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
-    dev: true
-
-  /@motionone/utils@10.15.1:
-    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.2
-    dev: true
 
   /@ndelangen/get-tarball@3.0.9:
     resolution: {integrity: sha512-9JKTEik4vq+yGosHYhZ1tiH/3WpUS0Nh0kej4Agndhox8pAdWhEx5knFVRcb/ya9knCRCs1rPxNrSXTDdfVqpA==}
@@ -9926,28 +9879,25 @@ packages:
       map-cache: 0.2.2
     dev: false
 
-  /framer-motion@6.5.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
+  /framer-motion@3.10.6(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-OxOtKgQS4km9a8dm0IMBtNNp4f0DiHfQ/IzxKs818+Kg9V/Ve/pRUJ2dtWBb6+W4lIPNLgRSpbOwOACVj15XcQ==}
     peerDependencies:
-      react: '>=16.8 || ^17.0.0 || ^18.0.0'
-      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
+      react: '>=16.8 || ^17.0.0'
+      react-dom: '>=16.8 || ^17.0.0'
     dependencies:
-      '@motionone/dom': 10.12.0
-      framesync: 6.0.1
+      framesync: 5.2.0
       hey-listen: 1.0.8
-      popmotion: 11.0.3
+      popmotion: 9.3.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      style-value-types: 5.0.0
-      tslib: 2.6.2
+      style-value-types: 4.1.1
+      tslib: 1.14.1
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
     dev: true
 
-  /framesync@6.0.1:
-    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
-    dependencies:
-      tslib: 2.6.2
+  /framesync@5.2.0:
+    resolution: {integrity: sha512-dcl92w5SHc0o6pRK3//VBVNvu6WkYkiXmHG6ZIXrVzmgh0aDYMDAaoA3p3LH71JIdN5qmhDcfONFA4Lmq22tNA==}
     dev: true
 
   /fresh@0.5.2:
@@ -13195,13 +13145,13 @@ packages:
       '@babel/runtime': 7.22.15
     dev: true
 
-  /popmotion@11.0.3:
-    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
+  /popmotion@9.3.1:
+    resolution: {integrity: sha512-Qozvg8rz2OGeZwWuIjqlSXqqgWto/+QL24ll8sAAc0n71KY/wvN1W4sAASxTuHv8YWdDnk9u9IdadyPo2DGvDA==}
     dependencies:
-      framesync: 6.0.1
+      framesync: 5.2.0
       hey-listen: 1.0.8
-      style-value-types: 5.0.0
-      tslib: 2.6.2
+      style-value-types: 4.1.1
+      tslib: 1.14.1
     dev: true
 
   /posix-character-classes@0.1.1:
@@ -15352,11 +15302,11 @@ packages:
       webpack: 5.80.0
     dev: false
 
-  /style-value-types@5.0.0:
-    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
+  /style-value-types@4.1.1:
+    resolution: {integrity: sha512-cNLrl6jk+I1T18ZI2KIp/fcqKVuykcNELDrOz7y+TYZR97xmNdN0ewupURvVFnQxVrRJv98TMBq92VMsggq3kw==}
     dependencies:
       hey-listen: 1.0.8
-      tslib: 2.6.2
+      tslib: 1.14.1
     dev: true
 
   /styled-components@5.3.11(@babel/core@7.22.15)(react-dom@17.0.2)(react-is@17.0.2)(react@17.0.2):

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "camelcase": "^6.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.48.0",
-    "framer-motion": "^6.5.1",
+    "framer-motion": "^3.10.6",
     "jest-styled-components": "^7.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
@@ -127,7 +127,7 @@
     "jest": "^29.6.4"
   },
   "peerDependencies": {
-    "framer-motion": ">=6.5.1",
+    "framer-motion": ">=3.10.6",
     "react": ">=16.10.0",
     "react-dom": ">=16.10.0",
     "styled-components": ">=4 <5 || >=5 <5.3.4 || >=5.3.7 <6"


### PR DESCRIPTION
Allowing older versions of `framer-motion` enables apps built with Webpack to avoid an issue when bundling some `.mjs` files exported from later versions of Framer.

![image](https://github.com/priceline/design-system/assets/3260642/ae8b8fac-ea85-4b90-b779-de8b4d30b20f)
