### PR TITLE
Feat accordion header divider color

### DIFF
--- a/common/changes/pcln-design-system/feat-accordion-headerDividerColor_2023-10-31-17-59.json
+++ b/common/changes/pcln-design-system/feat-accordion-headerDividerColor_2023-10-31-17-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Accordion: add headerDividerColor prop to allow divider between steps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -85,6 +85,7 @@ export const Ladder = {
   render: (args) => (
     <Accordion
       {...args}
+      headerDividerColor='border.base'
       items={[
         {
           ...items[0],

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -119,7 +119,13 @@ export const IconContainer = styled(Box)`
   }
 `
 
-export const StyledItem = styled(Box)`
+export interface IStyledItem {
+  variation: string
+  headerBg?: string
+  headerDividerColor?: string
+}
+
+export const StyledItem = styled(Box)<IStyledItem>`
   box-shadow: ${(props) => (props.variation === 'card' ? themeGet('shadows.sm') : '')};
   ${(props) =>
     props.variation === 'default' ? `background-color: ${getPaletteColor('background.light')(props)};` : ''}
@@ -131,6 +137,11 @@ export const StyledItem = styled(Box)`
   ${(props) =>
     props.variation === 'ladder'
       ? `background-color: ${getPaletteColor(props.headerBg || 'background.light')(props)};
+        ${
+          props.headerDividerColor
+            ? `border-top: solid ${getPaletteColor(props.headerDividerColor)(props)} 1px;`
+            : ''
+        }
         border-radius: 0px; margin-bottom: 0px;
         `
       : ''}

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -20,6 +20,7 @@ export interface IAccordion extends SpaceProps {
   type?: string
   variation?: string
   isExternallyControlled?: boolean
+  headerDividerColor?: string
 }
 
 export interface IAccordionItem {
@@ -38,6 +39,7 @@ export const Accordion = ({
   type = 'multiple',
   variation = 'default',
   p = '12px',
+  headerDividerColor,
   ...props
 }: IAccordion) => {
   return items ? (
@@ -54,7 +56,7 @@ export const Accordion = ({
         isolation: 'isolate',
       }}
     >
-      {items.map((child: IAccordionItem) => (
+      {items.map((child: IAccordionItem, index) => (
         <RadixAccordion.Item key={child.value} asChild value={child.value}>
           <StyledItem
             variation={variation}
@@ -63,6 +65,7 @@ export const Accordion = ({
             marginBottom='12px'
             headerBg={child.headerBg}
             data-testid={`styled-item-${child.value}`}
+            headerDividerColor={index > 0 && headerDividerColor}
           >
             <StyledTrigger {...props} p={p} variation={variation}>
               <Flex width='100%' justifyContent='space-between' alignItems='center'>


### PR DESCRIPTION
Add `headerDividerColor` prop to the `Accordion` component. This will take in a DS color that will add a border-top to each step in the `ladder` variation (except for index === 0)

`headerDividerColor === undefined`:
<img width="1304" alt="no-divider" src="https://github.com/priceline/design-system/assets/62948290/42123b3a-225c-43b8-9357-db257820ed54">

`headerDividerColor === 'border.base'`:
<img width="1298" alt="with-divider" src="https://github.com/priceline/design-system/assets/62948290/d94bab10-ba7c-45b2-ade8-8ad50dc0a48c">
