### PR TITLE
Make ChatMessage accept react node as children

### DIFF
--- a/common/changes/pcln-design-system/feature-update-chat-message-component_2023-11-11-16-40.json
+++ b/common/changes/pcln-design-system/feature-update-chat-message-component_2023-11-11-16-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "update ChatMessage accepts react node as child",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/ChatMessage/ChatMessage.stories.tsx
+++ b/packages/core/src/ChatMessage/ChatMessage.stories.tsx
@@ -43,6 +43,10 @@ export const InitialMessage: ChatMessageStory = {
   render: (args) => <ChatMessage {...args} variation='initial' />,
 }
 
+export const WithReactNodeMessage: ChatMessageStory = {
+  render: (args) => <ChatMessage {...args} variation='initial' message={<div>How can I help you?</div>} />,
+}
+
 export const IncomingMessage: ChatMessageStory = {
   render: (args) => <ChatMessage {...args} variation='incoming' />,
 }

--- a/packages/core/src/ChatMessage/ChatMessage.tsx
+++ b/packages/core/src/ChatMessage/ChatMessage.tsx
@@ -41,7 +41,7 @@ export interface IChatMessage extends IFlexProps {
   footer?: React.ReactNode
   header?: React.ReactNode
   Icon?: React.FC<{ color?: string; size?: string }>
-  message: string
+  message: React.ReactNode
   variation: (typeof variationNames)[number]
 }
 


### PR DESCRIPTION
Allow `ChatMessage` accepts React Node as children.