### PR TITLE
Checkbox and Label component improvements

### DIFF
--- a/common/changes/pcln-design-system/UXPT-3813-checkbox-and-label-improvements_2023-11-17-20-53.json
+++ b/common/changes/pcln-design-system/UXPT-3813-checkbox-and-label-improvements_2023-11-17-20-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Checkbox and Label component improvements",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/core/src/Checkbox/Checkbox.stories.tsx
@@ -86,7 +86,7 @@ const FilterExample: React.FC = () => {
   return (
     <>
       <Wrapper>
-        <StyledLabel htmlFor='all'>
+        <StyledLabel htmlFor='all' isCentered>
           <Checkbox
             id='all'
             onChange={handleFilterSelection}
@@ -96,15 +96,15 @@ const FilterExample: React.FC = () => {
           Cars
         </StyledLabel>
         <Box ml={2}>
-          <StyledLabel htmlFor='small'>
+          <StyledLabel htmlFor='small' isCentered>
             <Checkbox id='small' onChange={handleFilterSelection} checked={filterState.small} />
             Small
           </StyledLabel>
-          <StyledLabel htmlFor='medium'>
+          <StyledLabel htmlFor='medium' isCentered>
             <Checkbox id='medium' onChange={handleFilterSelection} checked={filterState.medium} />
             Medium
           </StyledLabel>
-          <StyledLabel htmlFor='large'>
+          <StyledLabel htmlFor='large' isCentered>
             <Checkbox id='large' onChange={handleFilterSelection} checked={filterState.large} />
             Large
           </StyledLabel>
@@ -118,42 +118,42 @@ export const CheckboxStates = () => {
   return (
     <div>
       <Wrapper>
-        <StyledLabel htmlFor='unchecked_box'>
+        <StyledLabel htmlFor='unchecked_box' isCentered>
           <Checkbox id='unchecked_box' onChange={checkAction} unselectedColor='text.light' />
           Unchecked by default
         </StyledLabel>
       </Wrapper>
 
       <Wrapper>
-        <StyledLabel htmlFor='checked_box'>
+        <StyledLabel htmlFor='checked_box' isCentered>
           <Checkbox id='checked_box' defaultChecked onChange={checkAction} />
           Checked by default
         </StyledLabel>
       </Wrapper>
 
       <Wrapper>
-        <StyledLabel htmlFor='disabled_box'>
+        <StyledLabel htmlFor='disabled_box' isCentered>
           <Checkbox id='disabled_box' disabled onChange={checkAction} />
           <Text.span color='border.base'>Disabled</Text.span>
         </StyledLabel>
       </Wrapper>
 
       <Wrapper>
-        <StyledLabel htmlFor='disabled_checked_box'>
+        <StyledLabel htmlFor='disabled_checked_box' isCentered>
           <Checkbox id='disabled_checked_box' disabled defaultChecked onChange={checkAction} />
           <Text.span color='border.base'>Disabled &amp; Checked</Text.span>
         </StyledLabel>
       </Wrapper>
 
       <Wrapper>
-        <StyledLabel htmlFor='indeterminate_box'>
+        <StyledLabel htmlFor='indeterminate_box' isCentered>
           <Checkbox id='indeterminate_box' indeterminate onChange={checkAction} />
           Initially indeterminate check box (clicking will checkmark it)
         </StyledLabel>
       </Wrapper>
 
       <Wrapper>
-        <StyledLabel htmlFor='indeterminate_checked_box'>
+        <StyledLabel htmlFor='indeterminate_checked_box' isCentered>
           <Checkbox id='indeterminate_checked_box' defaultChecked indeterminate onChange={checkAction} />
           Initially indeterminate check box (clicking will uncheck it)
         </StyledLabel>
@@ -169,7 +169,7 @@ export const CheckboxStates = () => {
             <legend>Fancy Form</legend>
 
             <Wrapper>
-              <StyledLabel fontSize='14px' htmlFor='form_checkbox'>
+              <StyledLabel fontSize='14px' htmlFor='form_checkbox' isCentered>
                 <Checkbox id='form_checkbox' size={30} onChange={checkAction} />
                 &nbsp;In This Form
               </StyledLabel>
@@ -191,29 +191,29 @@ export const CheckboxStates = () => {
 export const Color = () => (
   <div>
     <Wrapper>
-      <StyledLabel htmlFor='secondary_unchecked_box'>
+      <StyledLabel htmlFor='secondary_unchecked_box' isCentered>
         <Checkbox id='secondary_unchecked_box' onChange={checkAction} color='secondary' />
         Secondary color unchecked by default
       </StyledLabel>
-      <StyledLabel htmlFor='secondary_checked_box'>
+      <StyledLabel htmlFor='secondary_checked_box' isCentered>
         <Checkbox id='secondary_checked_box' defaultChecked onChange={checkAction} color='secondary' />
         Secondary color checked by default
       </StyledLabel>
-      <StyledLabel htmlFor='secondary_disabled_box'>
+      <StyledLabel htmlFor='secondary_disabled_box' isCentered>
         <Checkbox id='secondary_disabled_box' disabled onChange={checkAction} color='secondary' />
         Secondary color disabled
       </StyledLabel>
     </Wrapper>
     <Wrapper>
-      <StyledLabel htmlFor='error_unchecked_box'>
+      <StyledLabel htmlFor='error_unchecked_box' isCentered>
         <Checkbox id='error_unchecked_box' onChange={checkAction} color='error' />
         Error color unchecked by default
       </StyledLabel>
-      <StyledLabel htmlFor='error_checked_box'>
+      <StyledLabel htmlFor='error_checked_box' isCentered>
         <Checkbox id='error_checked_box' defaultChecked onChange={checkAction} color='error' />
         Error color checked by default
       </StyledLabel>
-      <StyledLabel htmlFor='error_disabled_box'>
+      <StyledLabel htmlFor='error_disabled_box' isCentered>
         <Checkbox id='error_disabled_box' disabled onChange={checkAction} color='error' />
         Error color disabled
       </StyledLabel>
@@ -232,7 +232,7 @@ export function ForwardRefs() {
           This example is for SC3
             <Button dsRef={e => this.btnRef = e}>Click me</Button>
         */}
-        <StyledLabel htmlFor='check'>
+        <StyledLabel htmlFor='check' isCentered>
           <Checkbox id='check' ref={dsRef} />
           Checkbox with ref
         </StyledLabel>

--- a/packages/core/src/Checkbox/Checkbox.tsx
+++ b/packages/core/src/Checkbox/Checkbox.tsx
@@ -19,10 +19,19 @@ const CheckBoxWrapper = styled.div`
   position: relative;
   vertical-align: middle;
   padding: 2px;
-  cursor: ${(props) => (props.disabled ? `default` : `pointer`)};
+  cursor: ${(props) => (props.disabled ? `not-allowed` : `pointer`)};
   background-color: inherit;
   color: ${(props) =>
     props.disabled ? getPaletteColor('border.base')(props) : getPaletteColor('border.dark')(props)};
+
+  ${(props) =>
+    props.disabled
+      ? `
+    & ~ * {
+      cursor: not-allowed;
+    }
+  `
+      : ''}
 
   svg {
     border: 1px solid transparent;
@@ -54,9 +63,12 @@ const CheckBoxWrapper = styled.div`
       display: none;
     }
   }
-  > input:hover ~ svg[data-name='empty'] {
-    color: ${(props) =>
-      props.disabled ? getPaletteColor('border.base')(props) : getPaletteColor('base')(props)};
+
+  > input:not([data-indeterminate='true']):hover {
+    & ~ svg[data-name='empty'] {
+      color: ${(props) =>
+        props.disabled ? getPaletteColor('border.base')(props) : getPaletteColor('base')(props)};
+    }
   }
 
   > input:not([data-indeterminate='true']) {

--- a/packages/core/src/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/core/src/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -34,9 +34,13 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
   position: relative;
   vertical-align: middle;
   padding: 2px;
-  cursor: default;
+  cursor: not-allowed;
   background-color: inherit;
   color: #c0cad5;
+}
+
+.c1 ~ * {
+  cursor: not-allowed;
 }
 
 .c1 svg {
@@ -70,7 +74,7 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
   display: none;
 }
 
-.c1 > input:hover ~ svg[data-name='empty'] {
+.c1 > input:not([data-indeterminate='true']):hover ~ svg[data-name='empty'] {
   color: #c0cad5;
 }
 
@@ -229,9 +233,13 @@ exports[`Checkbox renders disabled with disabled prop 1`] = `
   position: relative;
   vertical-align: middle;
   padding: 2px;
-  cursor: default;
+  cursor: not-allowed;
   background-color: inherit;
   color: #c0cad5;
+}
+
+.c1 ~ * {
+  cursor: not-allowed;
 }
 
 .c1 svg {
@@ -265,7 +273,7 @@ exports[`Checkbox renders disabled with disabled prop 1`] = `
   display: none;
 }
 
-.c1 > input:hover ~ svg[data-name='empty'] {
+.c1 > input:not([data-indeterminate='true']):hover ~ svg[data-name='empty'] {
   color: #c0cad5;
 }
 
@@ -459,7 +467,7 @@ exports[`Checkbox renders without the theme passed specifically 1`] = `
   display: none;
 }
 
-.c1 > input:hover ~ svg[data-name='empty'] {
+.c1 > input:not([data-indeterminate='true']):hover ~ svg[data-name='empty'] {
   color: #0068ef;
 }
 

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -62,9 +62,10 @@ export interface ILabelProps
     TextStyleProps,
     WidthProps,
     Partial<Omit<HTMLLabelElement, 'children'>> {
+  autoHide?: boolean
   children?: React.ReactNode | string
   color?: string
-  autoHide?: boolean
+  isCentered?: boolean
   nowrap?: boolean
   for?: string
   onClick?: (evt: unknown) => void
@@ -80,6 +81,13 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(
   color: ${getPaletteColor('base')};
   ${(props) => (props.bg ? `background-color: ${getPaletteColor(props.bg, 'base')(props)};` : '')}
   ${(props) => (props.onClick ? 'cursor: pointer;' : '')}
+  ${(props) =>
+    props.isCentered
+      ? `
+    display: flex;
+    align-items: center;
+  `
+      : ''}
 
   ${applyVariations('Label')}
 


### PR DESCRIPTION
- unchecked hover state for when over the checkbox and/or label should render svg with primary.base
- when disabled show the not-allowed curser
- fix center alignment with label