### PR TITLE
Export palette family variation

### DIFF
--- a/common/changes/pcln-design-system/export-palette-family-variation_2023-11-27-19-15.json
+++ b/common/changes/pcln-design-system/export-palette-family-variation_2023-11-27-19-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Export PaletteFamilyVariation type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -509,6 +509,9 @@ export const paletteFamilyNames = [
 ] as const
 
 /** @public */
+export type PaletteFamilyVariation = (typeof paletteFamilyVariations)[number]
+
+/** @public */
 export type PaletteFamilyName = (typeof paletteFamilyNames)[number]
 
 /** @public */


### PR DESCRIPTION
Exporting a new type for the possible palette shades:
```
[
  'lightest',
  'light',
  'tint',
  'base',
  'heading',
  'tone',
  'dark',
  'shade',
  'darkest',
]
```