### PR TITLE
feat(SITE-21794): fix the outgoing ChatMessage footer position issue

### DIFF
--- a/common/changes/pcln-design-system/feature-SITE-21794_2023-12-06-14-54.json
+++ b/common/changes/pcln-design-system/feature-SITE-21794_2023-12-06-14-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix outgoing ChatMessage Footer position",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/ChatMessage/ChatMessage.stories.tsx
+++ b/packages/core/src/ChatMessage/ChatMessage.stories.tsx
@@ -69,6 +69,27 @@ export const WithFooter: ChatMessageStory = {
   render: (args) => <ChatMessage {...args} footer={HeaderFooter} variation='incoming' />,
 }
 
+export const OutgoingWithFooter: ChatMessageStory = {
+  render: (args) => (
+    <ChatMessage
+      {...args}
+      ml='60px'
+      variation='outgoing'
+      message='hello!!'
+      footer={
+        <Flex alignItems='center' justifyContent='flex-end'>
+          <Text color='text.light' textStyle='subheading6' mr={2}>
+            READ
+          </Text>
+          <Text color='text.light' textStyle='subheading6'>
+            12:55 pm
+          </Text>
+        </Flex>
+      }
+    />
+  ),
+}
+
 export const MessageList: ChatMessageStory = {
   render: (args) => (
     <>

--- a/packages/core/src/ChatMessage/ChatMessage.tsx
+++ b/packages/core/src/ChatMessage/ChatMessage.tsx
@@ -55,6 +55,12 @@ function ChatMessage({
 }: IChatMessage) {
   const marginTop = header ? 3 : 0
   const marginBottom = footer ? 3 : 0
+  const footerPosition = variation === 'outgoing'
+    ? {
+      right: 0
+    }: {
+      left: 0
+    }
 
   return (
     <Message borderRadius='18px' variation={variation} mt={marginTop} mb={marginBottom} p='12px' {...props}>
@@ -79,7 +85,13 @@ function ChatMessage({
       )}
       <Text textStyle='paragraph2'>{message}</Text>
       {footer && (
-        <Absolute bottom='-20px' left='0px' minWidth='300px' width='100%' px={3}>
+        <Absolute
+          bottom='-20px'
+          minWidth='300px'
+          width='100%'
+          px={3}
+          {...footerPosition}
+        >
           {footer}
         </Absolute>
       )}


### PR DESCRIPTION
![image](https://github.com/priceline/design-system/assets/15325954/4f278e10-a7af-4e8e-8588-18bb4c4f2ff3)

<img width="919" alt="image" src="https://github.com/priceline/design-system/assets/15325954/ee0f34fa-11b6-4192-8869-adab30a68f16">


