### PR TITLE
(AIR-59161):fix for loosing focus of menu after selecting menuitem

### DIFF
--- a/common/changes/pcln-menu/chore-AIR-59161-FixAccessibilityMenu_2023-12-14-16-45.json
+++ b/common/changes/pcln-menu/chore-AIR-59161-FixAccessibilityMenu_2023-12-14-16-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Adding querySelectorPortal prop to menu item to fix the focus issue.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/common/changes/pcln-menu/chore-AIR-59161-FixAccessibilityMenu_2023-12-14-16-45.json
+++ b/common/changes/pcln-menu/chore-AIR-59161-FixAccessibilityMenu_2023-12-14-16-45.json
@@ -3,7 +3,7 @@
     {
       "packageName": "pcln-menu",
       "comment": "Adding querySelectorPortal prop to menu item to fix the focus issue.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "pcln-menu"

--- a/packages/menu/src/Menu/Menu.jsx
+++ b/packages/menu/src/Menu/Menu.jsx
@@ -17,6 +17,7 @@ function Menu({
   trapFocus,
   placement,
   children,
+  querySelectorPortal,
   ...props
 }) {
   const MenuContent = ({ handleClose }) => (
@@ -57,19 +58,25 @@ function Menu({
   )
 
   return (
-    <Popover
-      aria-controls={id}
-      hideArrow
-      idx={id}
-      placement={placement ?? 'bottom-start'}
-      renderContent={MenuContent}
-      trapFocus={trapFocus}
-      width={width}
-      zIndex={1600}
-      {...props}
-    >
-      <ClickableNode />
-    </Popover>
+    <>
+      <Popover
+        aria-controls={id}
+        hideArrow
+        idx={id}
+        placement={placement ?? 'bottom-start'}
+        renderContent={MenuContent}
+        trapFocus={trapFocus}
+        width={width}
+        zIndex={1600}
+        querySelectorPortal={`.${querySelectorPortal}`}
+        {...props}
+      >
+        <ClickableNode />
+      </Popover>
+      {querySelectorPortal ? (
+        <div style={{ width: 0, display: 'inline-block' }} className={querySelectorPortal} />
+      ) : null}
+    </>
   )
 }
 
@@ -87,6 +94,7 @@ Menu.propTypes = {
   trapFocus: PropTypes.bool,
   placement: PropTypes.string,
   children: PropTypes.node,
+  querySelectorPortal: PropTypes.string,
 }
 
 Menu.defaultProps = {


### PR DESCRIPTION
This Pr is to fix the accessibility issue, user lose the focus on Menu after selecting a menu item. The focus goes to top of the body after selecting any menu item. This issues is caused because of the popover position. In order to fix it we are passing the `querySelectorPortal` prop from menu.