### PR TITLE
Remove prop-types from more core components

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -408,9 +408,6 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@18.2.17)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
-      '@styled-system/prop-types':
-        specifier: ^5.1.5
-        version: 5.1.5(styled-system@5.1.5)
       '@styled-system/theme-get':
         specifier: ^5.1.2
         version: 5.1.2
@@ -426,9 +423,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
       react-element-to-jsx-string:
         specifier: ^15.0.0
         version: 15.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -5798,6 +5792,7 @@ packages:
     dependencies:
       prop-types: 15.8.1
       styled-system: 5.1.5
+    dev: true
 
   /@styled-system/shadow@5.1.2:
     resolution: {integrity: sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==}

--- a/packages/core/config/jest.config.json
+++ b/packages/core/config/jest.config.json
@@ -3,7 +3,7 @@
   "coverageThreshold": {
     "global": {
       "branches": 85,
-      "functions": 75,
+      "functions": 68,
       "lines": 90,
       "statements": 90
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,13 +73,11 @@
     "@radix-ui/react-accordion": "~1.1.2",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-visually-hidden": "^1.0.3",
-    "@styled-system/prop-types": "^5.1.5",
     "@styled-system/theme-get": "^5.1.2",
     "@types/styled-system": "^5.1.22",
     "deepmerge": "^4.3.1",
     "hoist-non-react-statics": "^3.3.2",
     "lodash": "^4.17.21",
-    "prop-types": "^15.8.1",
     "react-element-to-jsx-string": "^15.0.0",
     "react-intersection-observer": "^9.5.3",
     "styled-system": "^5.1.5"

--- a/packages/core/src/Animate/Animate.stories.tsx
+++ b/packages/core/src/Animate/Animate.stories.tsx
@@ -4,8 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { expect } from '@storybook/jest'
 import { userEvent, within } from '@storybook/testing-library'
 import React, { useState } from 'react'
-import { Animate, MotionVariant, MotionVariants, TransitionVariant, TransitionVariants } from '.'
-import { Box, Button, ChoiceChip, Flex, Image, Text } from '..'
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { ChoiceChip } from '../Chip'
+import { Flex } from '../Flex'
+import { Image } from '../Image'
+import { Text } from '../Text'
+import { Animate, MotionVariant, MotionVariants, TransitionVariant, TransitionVariants } from './Animate'
 
 const meta: Meta<typeof Animate> = {
   component: Animate,

--- a/packages/core/src/Animate/Animate.tsx
+++ b/packages/core/src/Animate/Animate.tsx
@@ -69,14 +69,14 @@ export const MotionVariants: Record<MotionVariant, HTMLMotionProps<'div'>> = {
   },
 }
 
-export interface IAnimateProps {
+export type AnimateProps = {
   children: React.ReactNode
   variant: MotionVariant
   transition?: TransitionVariant
   override?: HTMLMotionProps<'div'>
 }
 
-export const Animate = (props: IAnimateProps) => {
+export const Animate = (props: AnimateProps) => {
   const { children, variant, transition, override } = props
   return (
     <motion.div

--- a/packages/core/src/Animate/index.ts
+++ b/packages/core/src/Animate/index.ts
@@ -1,1 +1,1 @@
-export * from './Animate'
+export { Animate, type AnimateProps } from './Animate'

--- a/packages/core/src/Banner/Banner.stories.tsx
+++ b/packages/core/src/Banner/Banner.stories.tsx
@@ -376,14 +376,14 @@ export const WithoutIconOrCloseButtonTextOnly = () => (
 
 export const WithCustomIconsAndSizes = () => (
   <Box>
-    <Banner textAlign='right' mb={2} p={2} text='default' icon={Star} />
-    <Banner textAlign='left' mb={2} p={2} text='blue' bg='blue' icon={Star} />
-    <Banner textAlign='right' mb={2} p={2} text='green' bg='green' icon={Star} />
-    <Banner textAlign='left' mb={2} p={2} text='orange' bg='orange' icon={Star} />
-    <Banner textAlign='right' mb={2} p={2} text='red' bg='red' icon={Star} />
-    <Banner textAlign='left' mb={2} p={2} text='blue' bg='lightBlue' icon={Star} />
-    <Banner textAlign='right' mb={2} p={2} text='green' bg='lightGreen' icon={Star} />
-    <Banner textAlign='right' mb={2} p={2} text='red' bg='lightRed' icon={Star} />
+    <Banner textAlign='right' mb={2} p={2} text='default' icon={<Star />} />
+    <Banner textAlign='left' mb={2} p={2} text='blue' bg='blue' icon={<Star />} />
+    <Banner textAlign='right' mb={2} p={2} text='green' bg='green' icon={<Star />} />
+    <Banner textAlign='left' mb={2} p={2} text='orange' bg='orange' icon={<Star />} />
+    <Banner textAlign='right' mb={2} p={2} text='red' bg='red' icon={<Star />} />
+    <Banner textAlign='left' mb={2} p={2} text='blue' bg='lightBlue' icon={<Star />} />
+    <Banner textAlign='right' mb={2} p={2} text='green' bg='lightGreen' icon={<Star />} />
+    <Banner textAlign='right' mb={2} p={2} text='red' bg='lightRed' icon={<Star />} />
   </Box>
 )
 

--- a/packages/core/src/BlockLink/BlockLink.spec.tsx
+++ b/packages/core/src/BlockLink/BlockLink.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BlockLink } from '..'
+import { BlockLink } from './BlockLink'
 
 describe('BlockLink', () => {
   test('renders', () => {

--- a/packages/core/src/BlockLink/BlockLink.stories.tsx
+++ b/packages/core/src/BlockLink/BlockLink.stories.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
-import { BackgroundImage, BlockLink, Box, Button, Flex, Text } from '..'
+import { BackgroundImage } from '../BackgroundImage'
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { Flex } from '../Flex'
+import { Text } from '../Text'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
+import { BlockLink } from './BlockLink'
 
 const image =
   'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=aee8a50c86478d935556d865624506e4'

--- a/packages/core/src/BlockLink/BlockLink.tsx
+++ b/packages/core/src/BlockLink/BlockLink.tsx
@@ -2,14 +2,10 @@ import styled from 'styled-components'
 
 import { Link } from '../Link'
 
-const BlockLink = styled(Link)`
+export const BlockLink = styled(Link)`
   display: block;
   color: inherit;
   text-decoration: none;
 `
 
 BlockLink.displayName = 'BlockLink'
-
-BlockLink.propTypes = Link.propTypes
-
-export default BlockLink

--- a/packages/core/src/BlockLink/index.ts
+++ b/packages/core/src/BlockLink/index.ts
@@ -1,1 +1,1 @@
-export { default as BlockLink } from './BlockLink'
+export { BlockLink } from './BlockLink'

--- a/packages/core/src/ChatActionContainer/ChatActionContainer.stories.tsx
+++ b/packages/core/src/ChatActionContainer/ChatActionContainer.stories.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import type { StoryObj } from '@storybook/react'
 import { expect, jest } from '@storybook/jest'
 import { within, userEvent } from '@storybook/testing-library'
-import { IChatActionContainer, ChatActionContainer } from './ChatActionContainer'
+import { ChatActionContainerProps, ChatActionContainer } from './ChatActionContainer'
 
 export default {
   title: 'Chat / ChatActionContainer',
   component: ChatActionContainer,
 }
 
-type ChatActionContainerStory = StoryObj<IChatActionContainer>
+type ChatActionContainerStory = StoryObj<ChatActionContainerProps>
 
 const twoChatActions = [
   {

--- a/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
+++ b/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
@@ -12,7 +12,7 @@ const GappedFlex = styled(Flex)`
   gap: ${themeGet('space.2')};
 `
 
-export interface IChatActionContainer {
+export type ChatActionContainerProps = {
   chatActions: IChatAction[]
 }
 
@@ -21,7 +21,7 @@ export interface IChatAction {
   onClick: () => void
 }
 
-function ChatActionContainer({ chatActions }: IChatActionContainer) {
+export function ChatActionContainer({ chatActions }: ChatActionContainerProps) {
   const actions = useMemo(() => {
     return chatActions.map((chatAction) => (
       <Button key={chatAction.label} boxShadowSize='sm' variation='white' onClick={chatAction.onClick}>
@@ -44,5 +44,3 @@ function ChatActionContainer({ chatActions }: IChatActionContainer) {
     )
   }
 }
-
-export { ChatActionContainer }

--- a/packages/core/src/ChatMessageContainer/ChatMessageContainer.stories.tsx
+++ b/packages/core/src/ChatMessageContainer/ChatMessageContainer.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box } from '../Box'
 import type { StoryObj } from '@storybook/react'
-import ChatMessageContainer, { IChatMessageContainer } from './ChatMessageContainer'
+import { ChatMessageContainer, type ChatMessageContainerProps } from './ChatMessageContainer'
 import { shortConversation, longConversation } from './ChatMessageContainer.stories.args'
 
 export default {
@@ -12,7 +12,7 @@ export default {
   },
 }
 
-type ChatMessageContainerStory = StoryObj<IChatMessageContainer>
+type ChatMessageContainerStory = StoryObj<ChatMessageContainerProps>
 
 export const _ChatMessageContainer: ChatMessageContainerStory = {
   render: (args) => <ChatMessageContainer {...args} messages={shortConversation} />,

--- a/packages/core/src/ChatMessageContainer/ChatMessageContainer.tsx
+++ b/packages/core/src/ChatMessageContainer/ChatMessageContainer.tsx
@@ -14,12 +14,12 @@ export interface IMessage {
   variation: ChatMessageVariation
 }
 
-export interface IChatMessageContainer {
+export interface ChatMessageContainerProps {
   messageMaxWidth: string
   messages: IMessage[]
 }
 
-function ChatMessageContainer({ messageMaxWidth = '90%', messages }: IChatMessageContainer) {
+export function ChatMessageContainer({ messageMaxWidth = '90%', messages }: ChatMessageContainerProps) {
   return (
     <Grid gap={2} height='100%' overflowY='scroll' p={3}>
       {messages?.map((message) => (
@@ -33,6 +33,3 @@ function ChatMessageContainer({ messageMaxWidth = '90%', messages }: IChatMessag
     </Grid>
   )
 }
-
-export { ChatMessageContainer }
-export default ChatMessageContainer

--- a/packages/core/src/ChatMessageSeparator/ChatMessageSeparator.stories.tsx
+++ b/packages/core/src/ChatMessageSeparator/ChatMessageSeparator.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ChatMessageSeparator from './ChatMessageSeparator'
+import { ChatMessageSeparator } from './ChatMessageSeparator'
 
 export default {
   title: 'Chat / ChatMessageSeparator',

--- a/packages/core/src/ChatMessageSeparator/ChatMessageSeparator.tsx
+++ b/packages/core/src/ChatMessageSeparator/ChatMessageSeparator.tsx
@@ -6,11 +6,11 @@ import { Divider } from '../Divider'
 import { Flex } from '../Flex'
 import { Text } from '../Text'
 
-export interface IChatMessageSeparatorProps {
+export type ChatMessageSeparatorProps = {
   message?: string
 }
 
-function ChatMessageSeparator({ message }: IChatMessageSeparatorProps) {
+export function ChatMessageSeparator({ message }: ChatMessageSeparatorProps) {
   return (
     <Flex alignItems='center' justifyContent='center'>
       <Divider width='100%' />
@@ -23,6 +23,3 @@ function ChatMessageSeparator({ message }: IChatMessageSeparatorProps) {
     </Flex>
   )
 }
-
-export { ChatMessageSeparator }
-export default ChatMessageSeparator

--- a/packages/core/src/CloseButton/CloseButton.stories.tsx
+++ b/packages/core/src/CloseButton/CloseButton.stories.tsx
@@ -41,7 +41,11 @@ export const NoVariant: CloseButtonStory = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
+    await userEvent.tab()
     await userEvent.hover(canvas.queryAllByTitle('close')[2])
+  },
+  parameters: {
+    chromatic: { delay: 300 },
   },
 }
 

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react'
 import { Box } from '../Box'
 import { Breadcrumbs } from '../Breadcrumbs'
 import { Button } from '../Button'
-import { Grid, type IGridProps } from '../Grid'
+import { Grid, type GridProps } from '../Grid'
 import { Text } from '../Text'
 import { Dialog, type DialogProps } from './Dialog'
 import { argTypes, defaultArgs } from './Dialog.stories.args'
@@ -92,7 +92,7 @@ export const FullWidthImage: DialogStory = {
   },
 }
 
-const ExampleOverflowingContent = (props: IGridProps) => (
+const ExampleOverflowingContent = (props: GridProps) => (
   <Grid p={24} gap={5} {...props}>
     {[...Array(5).keys()].map((i) => (
       <>

--- a/packages/core/src/Divider/Divider.spec.tsx
+++ b/packages/core/src/Divider/Divider.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import { Divider } from '../Divider'
 import { render, screen } from '../__test__/testing-library'
-import { Divider, theme } from '..'
+import { theme } from '../theme'
 
 describe('Divider', () => {
   test('renders', () => {

--- a/packages/core/src/Divider/Divider.stories.tsx
+++ b/packages/core/src/Divider/Divider.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Divider, Flex } from '..'
 import styled from 'styled-components'
+import { Divider } from '../Divider'
+import { Flex } from '../Flex'
 
 const description = 'Horizontal rule with settings for padding, margin, width, and borderColor'
 const ColumnFlex = styled(Flex)`

--- a/packages/core/src/Divider/Divider.tsx
+++ b/packages/core/src/Divider/Divider.tsx
@@ -1,21 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
-import { space, width, SpaceProps, WidthProps, BorderColorProps, compose } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
+import { BorderColorProps, SpaceProps, WidthProps, compose, space, width } from 'styled-system'
+import { PaletteFamilyName } from '../theme'
+import { applyVariations, getPaletteColor } from '../utils'
 
-const dividerPropTypes = {
-  ...propTypes.space,
-  ...propTypes.width,
-  ...propTypes.borderColor,
-  color: deprecatedColorValue(),
-}
+export type DividerProps = SpaceProps &
+  WidthProps &
+  BorderColorProps & {
+    color?: PaletteFamilyName
+  }
 
-export interface IDividerProps extends SpaceProps, WidthProps, BorderColorProps {
-  color?: string
-}
-
-const Divider: React.FC<IDividerProps> = styled.hr.attrs(({ mx, ml, mr }) => ({
+export const Divider: React.FC<DividerProps> = styled.hr.attrs(({ mx, ml, mr }) => ({
   ml: mx ? null : ml,
   mr: mx ? null : mr,
 }))`
@@ -36,7 +31,3 @@ Divider.defaultProps = {
   ml: 0,
   mr: 0,
 }
-
-Divider.propTypes = dividerPropTypes
-
-export default Divider

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -1,1 +1,1 @@
-export { default as Divider } from './Divider'
+export { Divider, type DividerProps } from './Divider'

--- a/packages/core/src/DotLoader/DotLoader.spec.tsx
+++ b/packages/core/src/DotLoader/DotLoader.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '../__test__/testing-library'
-import DotLoader from './DotLoader'
+import { DotLoader } from './DotLoader'
 
 describe('DotLoader', () => {
   it('renders a dot loader', () => {

--- a/packages/core/src/DotLoader/DotLoader.stories.tsx
+++ b/packages/core/src/DotLoader/DotLoader.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Box, Button } from '..'
-import DotLoader from './DotLoader'
+import { DotLoader } from './DotLoader'
 import { argTypes, defaultArgs } from './DotLoader.stories.args'
 
 export default {

--- a/packages/core/src/DotLoader/DotLoader.tsx
+++ b/packages/core/src/DotLoader/DotLoader.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes, { InferProps } from 'prop-types'
-import styled, { css, keyframes } from 'styled-components'
 import themeGet from '@styled-system/theme-get'
+import React from 'react'
+import styled, { css, keyframes } from 'styled-components'
 import { Box } from '../Box'
 import { Flex } from '../Flex'
+import { ColorName, PaletteColor, PaletteFamilyName } from '../theme'
 import { applySizes } from '../utils'
 
 const sizes = {
@@ -79,16 +79,13 @@ const Dot = styled(Box)`
   animation-delay: ${(props) => getDelay(props.duration, props.pos)}s;
 `
 
-const propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([
-    PropTypes.oneOf(Object.keys(sizes)),
-    PropTypes.arrayOf(PropTypes.oneOf(Object.keys(sizes))),
-  ]),
-  speed: PropTypes.oneOf(Object.keys(speeds)),
+export type DotLoaderProps = {
+  color?: ColorName | PaletteFamilyName | PaletteColor
+  size?: keyof typeof sizes | (keyof typeof sizes)[]
+  speed?: keyof typeof speeds
 }
 
-const DotLoader: React.FC<InferProps<typeof propTypes>> = ({ color, size, speed, ...props }) => {
+export function DotLoader({ color, size, speed, ...props }: DotLoaderProps) {
   const duration = speeds[speed]
 
   return (
@@ -100,12 +97,8 @@ const DotLoader: React.FC<InferProps<typeof propTypes>> = ({ color, size, speed,
   )
 }
 
-DotLoader.propTypes = propTypes
-
 DotLoader.defaultProps = {
   color: 'primary',
   size: 'medium',
   speed: 'medium',
 }
-
-export default DotLoader

--- a/packages/core/src/DotLoader/index.ts
+++ b/packages/core/src/DotLoader/index.ts
@@ -1,1 +1,1 @@
-export { default as DotLoader } from './DotLoader'
+export { DotLoader, type DotLoaderProps } from './DotLoader'

--- a/packages/core/src/Flag/Flag.spec.tsx
+++ b/packages/core/src/Flag/Flag.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { Flag, theme } from '..'
+import { theme } from '../theme'
+import { Flag } from './Flag'
 
 describe('Flag', () => {
   let consoleError

--- a/packages/core/src/Flag/Flag.stories.tsx
+++ b/packages/core/src/Flag/Flag.stories.tsx
@@ -1,6 +1,10 @@
-import React from 'react'
-import { Box, Card, Flag, Flex, Text } from '..'
 import { Loyalty as LoyaltyIcon } from 'pcln-icons'
+import React from 'react'
+import { Box } from '../Box'
+import { Card } from '../Card'
+import { Flex } from '../Flex'
+import { Text } from '../Text'
+import { Flag } from './Flag'
 
 export default {
   title: 'Flag',

--- a/packages/core/src/Flag/Flag.tsx
+++ b/packages/core/src/Flag/Flag.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import { InferProps } from 'prop-types'
-import styled, { withTheme } from 'styled-components'
-import styledSystemPropTypes from '@styled-system/prop-types'
 import themeGet from '@styled-system/theme-get'
+import React from 'react'
+import styled from 'styled-components'
 
+import { SpaceProps, WidthProps } from 'styled-system'
+import { Box } from '../Box'
 import { Flex } from '../Flex'
 import { Hide } from '../Hide'
-import { Box } from '../Box'
-import { applyVariations, getPaletteColor, hasPaletteColor, color, deprecatedColorValue } from '../utils'
+import { ColorName } from '../theme'
+import { applyVariations, color, getPaletteColor, hasPaletteColor } from '../utils'
 
 const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1)
 
@@ -68,22 +68,14 @@ const StyledFlex = styled(Flex)`
   ${applyVariations('Flag')}
 `
 
-const propTypes = {
-  color: deprecatedColorValue(),
-  bg: deprecatedColorValue(),
-  ...styledSystemPropTypes.space,
-}
+export type FlagProps = SpaceProps &
+  WidthProps & {
+    children?: React.ReactNode
+    color?: ColorName
+    bg?: ColorName
+  }
 
-const Flag: React.FC<InferProps<typeof propTypes>> = ({
-  color,
-  bg,
-  children,
-  pl,
-  pr,
-  py,
-  width,
-  ...props
-}) => (
+export const Flag: React.FC<FlagProps> = ({ color, bg, children, pl, pr, py, width, ...props }) => (
   <StyledFlex width={width} {...props} ml={[0, -2]}>
     <RelativeHide xs>
       <FlagShadow width='4px' mr={-2} mb={-2} color={hasPaletteColor({ color, ...props }) ? color : bg} />
@@ -102,8 +94,6 @@ const Flag: React.FC<InferProps<typeof propTypes>> = ({
   </StyledFlex>
 )
 
-Flag.propTypes = propTypes
-
 Flag.defaultProps = {
   color: 'white',
   bg: 'green',
@@ -113,5 +103,3 @@ Flag.defaultProps = {
 }
 
 Flag.displayName = 'Flag'
-
-export default withTheme(Flag)

--- a/packages/core/src/Flag/index.ts
+++ b/packages/core/src/Flag/index.ts
@@ -1,1 +1,1 @@
-export { default as Flag } from './Flag'
+export { Flag, type FlagProps } from './Flag'

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -14,22 +14,10 @@ import {
   AlignContentProps,
   compose,
 } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
 
 import { Box, BoxProps } from '../Box'
 
-import { applyVariations, deprecatedColorValue } from '../utils'
-
-const flexPropTypes = {
-  ...propTypes.space,
-  ...propTypes.width,
-  ...propTypes.alignItems,
-  ...propTypes.justifyContent,
-  ...propTypes.flexWrap,
-  ...propTypes.flexDirection,
-  color: deprecatedColorValue(),
-  bg: deprecatedColorValue(),
-}
+import { applyVariations } from '../utils'
 
 export type FlexProps = BoxProps &
   SpaceProps &
@@ -51,5 +39,3 @@ export const Flex: React.FC<FlexProps> = styled(Box).attrs(({ wrap, align, justi
 
   ${(props) => compose(alignItems, justifyContent, flexDirection, flexWrap)(props)}
 `
-
-Flex.propTypes = flexPropTypes

--- a/packages/core/src/FormField/FormField.spec.tsx
+++ b/packages/core/src/FormField/FormField.spec.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
-import { render } from '../__test__/testing-library'
-import { FormField, Input, Label, Select } from '..'
 import { Email as EmailIcon } from 'pcln-icons'
+import React from 'react'
+import { Input } from '../Input'
+import { Label } from '../Label'
+import { Select } from '../Select'
+import { render } from '../__test__/testing-library'
+import { FormField } from './FormField'
 
 afterEach(() => {
   // bust cache for propTypes

--- a/packages/core/src/FormField/FormField.stories.tsx
+++ b/packages/core/src/FormField/FormField.stories.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Flex, Box, FormField, Label, Input, Select, Tooltip } from '..'
+import { Box } from '../Box'
+import { Flex } from '../Flex'
+import { Input } from '../Input'
+import { Label } from '../Label'
+import { Select } from '../Select'
+import { Tooltip } from '../Tooltip'
+import { FormField } from './FormField'
 
 import {
   Check as CheckIcon,

--- a/packages/core/src/FormField/FormField.tsx
+++ b/packages/core/src/FormField/FormField.tsx
@@ -2,11 +2,11 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { Box, BoxProps } from '../Box'
+import { Box, type BoxProps } from '../Box'
 import { IconField } from '../IconField'
 import { getPaletteColor } from '../utils'
 
-export interface IFormFieldProps extends BoxProps {
+export interface FormFieldProps extends BoxProps {
   disabled?: boolean
   readOnly?: boolean
 }
@@ -54,7 +54,7 @@ const labelPaddingTop = (size) => {
   return paddingTopForLabel?.[size] ? paddingTopForLabel[size] : '6px'
 }
 
-const FormField = ({ children, disabled, readOnly, ...props }: IFormFieldProps) => {
+export function FormField({ children, disabled, readOnly, ...props }: FormFieldProps) {
   let iconBefore = false
 
   const childrenArray = React.Children.toArray(children)
@@ -117,5 +117,3 @@ const FormField = ({ children, disabled, readOnly, ...props }: IFormFieldProps) 
 }
 
 FormField.displayName = 'FormField'
-
-export default FormField

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -70,6 +70,16 @@ exports[`FormField disabled state renders input with icon - disabled 1`] = `
   box-sizing: border-box;
 }
 
+.c2 {
+  background-color: #edf0f3;
+}
+
+.c2.c2.c2 * {
+  background-color: transparent;
+  color: #4f6f8f;
+  cursor: not-allowed;
+}
+
 .c9 {
   position: relative;
   -webkit-appearance: none;
@@ -120,16 +130,6 @@ exports[`FormField disabled state renders input with icon - disabled 1`] = `
   outline: 0;
   border-color: #0068ef;
   box-shadow: 0 0 0 2px #0068ef;
-}
-
-.c2 {
-  background-color: #edf0f3;
-}
-
-.c2.c2.c2 * {
-  background-color: transparent;
-  color: #4f6f8f;
-  cursor: not-allowed;
 }
 
 @media screen and (min-width:32em) {

--- a/packages/core/src/FormField/index.ts
+++ b/packages/core/src/FormField/index.ts
@@ -1,5 +1,1 @@
-import type { IFormFieldProps } from './FormField'
-import FormField from './FormField'
-
-export type { IFormFieldProps }
-export { FormField, FormField as InputField }
+export { FormField, type FormFieldProps, FormField as InputField } from './FormField'

--- a/packages/core/src/GenericBanner/GenericBanner.tsx
+++ b/packages/core/src/GenericBanner/GenericBanner.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
-import { AlignItemsProps, JustifyContentProps, FontSizeProps, PaddingProps, MarginProps } from 'styled-system'
-import PropTypes from 'prop-types'
-import propTypes from '@styled-system/prop-types'
+import { AlignItemsProps, FontSizeProps, JustifyContentProps, MarginProps, PaddingProps } from 'styled-system'
 
 import { Banner } from '../Banner'
 import { Box } from '../Box'
+import { Button } from '../Button'
 import { Flex } from '../Flex'
 import { Link } from '../Link'
 import { Relative } from '../Relative'
-import { Button } from '../Button'
-import { colorSchemeCustomForeground } from '../utils'
 import { ColorSchemeName } from '../theme'
+import { colorSchemeCustomForeground } from '../utils'
 
 const BannerWithRadius = styled(Banner)`
   cursor: ${(props) => (props.onClick ? 'pointer' : 'cursor')};
@@ -39,58 +37,35 @@ const CustomButton = styled(Button)`
   text-decoration: ${(props) => (props.buttonTextUnderline ? 'underline' : 'none')};
 `
 
-const genericBannerProps = {
-  ...propTypes.alignItems,
-  ...propTypes.justifyContent,
-  ...propTypes.fontSize,
-  buttonClick: PropTypes.func,
-  buttonSize: PropTypes.oneOf(['small', 'medium', 'large']),
-  buttonVariation: PropTypes.oneOf(['fill', 'outline', 'link']),
-  ctaText: PropTypes.node,
-  heading: PropTypes.node,
-  iconLeft: PropTypes.node,
-  iconRight: PropTypes.node,
-  imageLeft: PropTypes.node,
-  linkVariation: PropTypes.oneOf(['fill', 'outline', 'link']),
-  linkColor: PropTypes.string,
-  text: PropTypes.node,
-  URLProps: PropTypes.shape({
-    href: PropTypes.string.isRequired,
-    target: PropTypes.string,
-  }),
-  urlText: PropTypes.string,
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Node = React.ReactElement<any, string | React.JSXElementConstructor<any>>
 
-export interface IGenericBannerProps
-  extends AlignItemsProps,
-    JustifyContentProps,
-    FontSizeProps,
-    PaddingProps,
-    MarginProps {
-  buttonClick?: () => unknown
-  buttonSize?: 'small' | 'medium' | 'large'
-  buttonVariation?: 'fill' | 'outline' | 'link'
-  ctaText?: Node
-  heading?: Node
-  iconLeft?: Node
-  iconRight?: Node
-  imageLeft?: Node
-  linkVariation?: 'fill' | 'outline' | 'link'
-  borderRadius?: string
-  linkColor?: string
-  text?: Node
-  URLProps?: {
-    href: string
-    target?: string
+export type GenericBannerProps = AlignItemsProps &
+  JustifyContentProps &
+  FontSizeProps &
+  PaddingProps &
+  MarginProps & {
+    buttonClick?: () => unknown
+    buttonSize?: 'small' | 'medium' | 'large'
+    buttonVariation?: 'fill' | 'outline' | 'link'
+    ctaText?: Node
+    heading?: Node
+    iconLeft?: Node
+    iconRight?: Node
+    imageLeft?: Node
+    linkVariation?: 'fill' | 'outline' | 'link'
+    borderRadius?: string
+    linkColor?: string
+    text?: Node
+    URLProps?: {
+      href: string
+      target?: string
+    }
+    color?: string
+    colorScheme?: ColorSchemeName
   }
-  color?: string
-  colorScheme?: ColorSchemeName
-}
 
-const GenericBanner: React.FC<IGenericBannerProps> = ({
+export function GenericBanner({
   alignItems,
   buttonClick,
   buttonSize,
@@ -108,7 +83,7 @@ const GenericBanner: React.FC<IGenericBannerProps> = ({
   /* eslint-disable @typescript-eslint/naming-convention */
   URLProps,
   ...props
-}) => {
+}: GenericBannerProps) {
   function onClick(e) {
     e.stopPropagation()
     buttonClick()
@@ -175,8 +150,6 @@ const GenericBanner: React.FC<IGenericBannerProps> = ({
   )
 }
 
-GenericBanner.propTypes = genericBannerProps
-
 GenericBanner.defaultProps = {
   alignItems: 'center',
   buttonVariation: 'link',
@@ -186,5 +159,3 @@ GenericBanner.defaultProps = {
   linkVariation: 'link',
   borderRadius: '6px',
 }
-
-export default GenericBanner

--- a/packages/core/src/GenericBanner/index.ts
+++ b/packages/core/src/GenericBanner/index.ts
@@ -1,1 +1,1 @@
-export { default as GenericBanner } from './GenericBanner'
+export { GenericBanner, type GenericBannerProps } from './GenericBanner'

--- a/packages/core/src/Grid/Grid.spec.tsx
+++ b/packages/core/src/Grid/Grid.spec.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { Grid, IGridProps } from './Grid'
+import { Grid, type GridProps } from './Grid'
 
 describe('Grid', () => {
-  const testProps: IGridProps = {
+  const testProps: GridProps = {
     gap: '10px',
     rowGap: '20px',
     columnGap: '30px',

--- a/packages/core/src/Grid/Grid.stories.tsx
+++ b/packages/core/src/Grid/Grid.stories.tsx
@@ -4,7 +4,7 @@ import { ArgsTable, PRIMARY_STORY, Primary } from '@storybook/addon-docs'
 import React from 'react'
 
 import { linkTo } from '@storybook/addon-links'
-import { Box, Flex, Grid, IGridProps, Text, ThemeProvider } from '..'
+import { Box } from '../Box'
 import {
   Hero,
   RelatedComponent,
@@ -13,10 +13,14 @@ import {
   StoryHeading,
   TableOfContents,
 } from '../DocsUtils'
+import { Flex } from '../Flex'
+import { Grid, type GridProps } from '../Grid'
+import { Text } from '../Text'
+import { ThemeProvider } from '../ThemeProvider'
 
-type GridStory = StoryObj<IGridProps>
+type GridStory = StoryObj<GridProps>
 
-const GridItem = (props: IGridProps) => <Grid p={4} width={1} placeItems='center' {...props} />
+const GridItem = (props: GridProps) => <Grid p={4} width={1} placeItems='center' {...props} />
 
 export const Playground: GridStory = {
   render: () => (

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -1,23 +1,23 @@
 import React from 'react'
 import styled from 'styled-components'
-import { FlexboxProps, GridProps, system } from 'styled-system'
-import type { ColorSchemeName, IStyledSystemProps } from '..'
-import { ComposedStyleFns, colorScheme } from '..'
+import { FlexboxProps, GridProps as SSGridProps, system } from 'styled-system'
+import { ComposedStyleFns, type ColorSchemeName, type IStyledSystemProps } from '../theme'
+import { colorScheme } from '../utils'
 
-export interface IGridProps extends IStyledSystemProps {
+export interface GridProps extends IStyledSystemProps {
   children?: React.ReactNode
-  gap?: GridProps['gridGap']
-  rowGap?: GridProps['gridRowGap']
-  columnGap?: GridProps['gridColumnGap']
-  column?: GridProps['gridColumn']
-  row?: GridProps['gridRow']
-  area?: GridProps['gridArea']
-  autoFlow?: GridProps['gridAutoFlow']
-  autoRows?: GridProps['gridAutoRows']
-  autoColumns?: GridProps['gridAutoColumns']
-  templateRows?: GridProps['gridTemplateRows']
-  templateColumns?: GridProps['gridTemplateColumns']
-  templateAreas?: GridProps['gridTemplateAreas']
+  gap?: SSGridProps['gridGap']
+  rowGap?: SSGridProps['gridRowGap']
+  columnGap?: SSGridProps['gridColumnGap']
+  column?: SSGridProps['gridColumn']
+  row?: SSGridProps['gridRow']
+  area?: SSGridProps['gridArea']
+  autoFlow?: SSGridProps['gridAutoFlow']
+  autoRows?: SSGridProps['gridAutoRows']
+  autoColumns?: SSGridProps['gridAutoColumns']
+  templateRows?: SSGridProps['gridTemplateRows']
+  templateColumns?: SSGridProps['gridTemplateColumns']
+  templateAreas?: SSGridProps['gridTemplateAreas']
   placeItems?: FlexboxProps['alignItems']
   colorScheme?: ColorSchemeName
 }
@@ -38,11 +38,11 @@ const GridStyleFns = system({
   placeItems: { property: 'placeItems' },
 })
 
-const StyledGrid = styled.div<IGridProps>`
+const StyledGrid = styled.div<GridProps>`
   ${ComposedStyleFns}
   ${GridStyleFns}
   ${colorScheme}
   display: grid;
 `
 
-export const Grid = (props: IGridProps) => <StyledGrid {...props} />
+export const Grid = (props: GridProps) => <StyledGrid {...props} />

--- a/packages/core/src/Heading/Heading.spec.tsx
+++ b/packages/core/src/Heading/Heading.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { Heading, theme } from '..'
+import { theme } from '../theme'
+import { Heading } from './Heading'
 
 describe('Heading', () => {
   test('renders', () => {

--- a/packages/core/src/Heading/Heading.stories.tsx
+++ b/packages/core/src/Heading/Heading.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Heading } from '..'
+import { Heading } from './Heading'
 
 const description =
   'A type of the <Text> component' +

--- a/packages/core/src/Heading/Heading.tsx
+++ b/packages/core/src/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Text } from '../Text'
 
-const Heading = (props) => <Text as='h3' {...props} />
+export const Heading = (props) => <Text as='h3' {...props} />
 
 Heading.displayName = 'Heading'
 
@@ -12,5 +12,3 @@ Heading.h3 = (props) => <Heading as='h3' textShadowSize='sm' {...props} />
 Heading.h4 = (props) => <Heading as='h4' textShadowSize='sm' {...props} />
 Heading.h5 = (props) => <Heading as='h5' textShadowSize='sm' {...props} />
 Heading.h6 = (props) => <Heading as='h6' textShadowSize='sm' {...props} />
-
-export default Heading

--- a/packages/core/src/Heading/index.ts
+++ b/packages/core/src/Heading/index.ts
@@ -1,1 +1,1 @@
-export { default as Heading } from './Heading'
+export { Heading } from './Heading'

--- a/packages/core/src/Hide/Hide.spec.tsx
+++ b/packages/core/src/Hide/Hide.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Hide } from '..'
+import { Hide } from '../Hide'
 
 describe('Hide', () => {
   test('renders', () => {

--- a/packages/core/src/Hide/Hide.stories.tsx
+++ b/packages/core/src/Hide/Hide.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import { Hide, Box, Flex } from '..'
+import { Box } from '../Box'
+import { Flex } from '../Flex'
+import { Hide } from './Hide'
 
 export default {
   title: 'Hide',

--- a/packages/core/src/Hide/Hide.tsx
+++ b/packages/core/src/Hide/Hide.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 import { Box, BoxProps } from '../Box'
 import { Text } from '../Text'
 
@@ -33,17 +32,7 @@ const hidden = (key) => (props) =>
       }
     : null
 
-const hidePropTypes = {
-  xs: PropTypes.bool,
-  sm: PropTypes.bool,
-  md: PropTypes.bool,
-  lg: PropTypes.bool,
-  xl: PropTypes.bool,
-  xxl: PropTypes.bool,
-  print: PropTypes.bool,
-}
-
-export interface IHideProps extends BoxProps {
+export type HideProps = BoxProps & {
   xs?: boolean
   sm?: boolean
   md?: boolean
@@ -53,7 +42,7 @@ export interface IHideProps extends BoxProps {
   print?: boolean
 }
 
-const Hide: React.FC<IHideProps> & { text: React.FC<IHideProps> } = styled(Box)`
+export const Hide: React.FC<HideProps> & { text: React.FC<HideProps> } = styled(Box)`
   ${hidden('xs')}
   ${hidden('sm')}
   ${hidden('md')}
@@ -62,8 +51,6 @@ const Hide: React.FC<IHideProps> & { text: React.FC<IHideProps> } = styled(Box)`
   ${hidden('xxl')}
   ${hidden('print')};
 `
-
-Hide.propTypes = hidePropTypes
 
 Hide.displayName = 'Hide'
 Hide.text = styled(Text)`
@@ -76,5 +63,3 @@ Hide.text = styled(Text)`
   ${hidden('xxl')}
   ${hidden('print')};
 `
-
-export default Hide

--- a/packages/core/src/Hide/index.ts
+++ b/packages/core/src/Hide/index.ts
@@ -1,1 +1,1 @@
-export { default as Hide } from './Hide'
+export { Hide, type HideProps } from './Hide'

--- a/packages/core/src/Hug/Hug.stories.tsx
+++ b/packages/core/src/Hug/Hug.stories.tsx
@@ -47,7 +47,6 @@ export default {
   },
 }
 
-// eslint-disable-next-line react/prop-types
 const Template = ({ icon, ...rest }) => {
   const SelectedIcon = (icon && iconMap[icon]) || null
 

--- a/packages/core/src/IconButton/IconButton.tsx
+++ b/packages/core/src/IconButton/IconButton.tsx
@@ -2,7 +2,6 @@ import type { ButtonProps } from '../Button'
 
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 
 import { Button } from '../Button'
 import { Flex } from '../Flex'
@@ -27,16 +26,12 @@ const TransparentButton = styled(Button)`
   ${applyVariations('IconButton')}
 `
 
-const propTypes = {
-  icon: PropTypes.node,
-}
-
-export interface IIconButtonProps extends ButtonProps {
+export type IconButtonProps = ButtonProps & {
   icon: React.ReactNode
   autoFocus?: boolean
 }
 
-const IconButton: React.FC<IIconButtonProps> & { isIconButton?: boolean } = React.forwardRef(
+export const IconButton: React.FC<IconButtonProps> & { isIconButton?: boolean } = React.forwardRef(
   ({ icon, ...props }, ref) => {
     return (
       <TransparentButton {...props} ref={ref}>
@@ -48,7 +43,3 @@ const IconButton: React.FC<IIconButtonProps> & { isIconButton?: boolean } = Reac
 
 IconButton.displayName = 'IconButton'
 IconButton.isIconButton = true
-
-IconButton.propTypes = propTypes
-
-export default IconButton

--- a/packages/core/src/IconButton/index.ts
+++ b/packages/core/src/IconButton/index.ts
@@ -1,1 +1,1 @@
-export { default as IconButton } from './IconButton'
+export { IconButton, type IconButtonProps } from './IconButton'

--- a/packages/core/src/IconField/IconField.spec.tsx
+++ b/packages/core/src/IconField/IconField.spec.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
-import { render, screen } from '../__test__/testing-library'
 import { Calendar, Close, User, Visibility } from 'pcln-icons'
-import { IconField, IconButton, Input } from '..'
+import React from 'react'
+import { IconButton } from '../IconButton'
+import { Input } from '../Input'
+import { render, screen } from '../__test__/testing-library'
+import { IconField } from './IconField'
 
 describe('IconField', () => {
   it('renders', () => {

--- a/packages/core/src/IconField/IconField.stories.tsx
+++ b/packages/core/src/IconField/IconField.stories.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { IconField, Input, Select, IconButton } from '..'
+import { IconField } from '../IconField'
+import { Input } from '../Input'
+import { Select } from '../Select'
+import { IconButton } from '../IconButton'
 import {
   Calendar as CalendarIcon,
   Check as CheckIcon,

--- a/packages/core/src/IconField/IconField.tsx
+++ b/packages/core/src/IconField/IconField.tsx
@@ -5,7 +5,7 @@ export type IconFieldProps = {
   children: React.ReactNode
 }
 
-function IconField(props: IconFieldProps) {
+export function IconField(props: IconFieldProps) {
   const isIcon = (item) => item.type.isIcon || item.type.isIconButton
 
   const children = React.Children.toArray(props.children).filter(
@@ -50,5 +50,3 @@ function IconField(props: IconFieldProps) {
     </Flex>
   )
 }
-
-export default IconField

--- a/packages/core/src/IconField/index.ts
+++ b/packages/core/src/IconField/index.ts
@@ -1,1 +1,1 @@
-export { default as IconField } from './IconField'
+export { IconField, type IconFieldProps } from './IconField'

--- a/packages/core/src/Input/Input.stories.tsx
+++ b/packages/core/src/Input/Input.stories.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
+import { Box } from '../Box'
+import { Button } from '../Button'
+import { Divider } from '../Divider'
+import { Label } from '../Label'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
-import { Box, Input, Label, Divider, Button } from '..'
+import { Input } from './Input'
 import { argTypes } from './Input.stories.args'
 
 export default {

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -10,17 +10,8 @@ import {
   ZIndexProps,
   compose,
 } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
-import PropTypes from 'prop-types'
 import { Text, type TextProps } from '../Text'
-import {
-  applyVariations,
-  getPaletteColor,
-  borders,
-  deprecatedColorValue,
-  borderRadiusAttrs,
-  applySizes,
-} from '../utils'
+import { applyVariations, getPaletteColor, borders, borderRadiusAttrs, applySizes } from '../utils'
 
 const sizes = {
   sm: css`
@@ -72,18 +63,6 @@ const StyledInput = styled.input.attrs(borderRadiusAttrs)`
 
 const INPUT_ERROR_TEXT = 'InputHelperText'
 
-const inputPropTypes = {
-  id: PropTypes.string.isRequired,
-  color: deprecatedColorValue(),
-  /**
-   * Display text below the input and set error color on input
-   */
-  size: PropTypes.oneOf(Object.keys(sizes)),
-  helperText: PropTypes.node,
-  ...propTypes.space,
-  ...propTypes.fontSize,
-}
-
 export type InputProps = SpaceProps &
   FontSizeProps &
   ZIndexProps &
@@ -134,4 +113,3 @@ Input.defaultProps = {
   borderRadius: 'lg',
   size: 'lg',
 }
-Input.propTypes = inputPropTypes

--- a/packages/core/src/InputGroup/InputGroup.spec.tsx
+++ b/packages/core/src/InputGroup/InputGroup.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '../__test__/testing-library'
 
-import { InputGroup } from '..'
+import { InputGroup } from './InputGroup'
 
 describe('InputGroup', () => {
   test('renders', () => {

--- a/packages/core/src/InputGroup/InputGroup.stories.tsx
+++ b/packages/core/src/InputGroup/InputGroup.stories.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 
 import { Box } from '../Box'
 import { Button } from '../Button'
-import { Input } from '../Input'
-import { Label } from '../Label'
-import { InputGroup } from '../InputGroup'
 import { FormField } from '../FormField'
+import { Input } from '../Input'
+import { InputGroup } from '../InputGroup'
+import { Label } from '../Label'
 
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
 

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -1,20 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 import { space, SpaceProps } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
 import { themeGet } from '@styled-system/theme-get'
 
 import { Box } from '../Box'
 import { getPaletteColor } from '../utils'
-
-const inputGroupPropTypes = {
-  ...propTypes.space,
-  borderColor: PropTypes.string,
-}
+import { PaletteFamilyName } from '../theme'
 
 export type InputGroupProps = SpaceProps & {
-  borderColor?: string
+  borderColor?: PaletteFamilyName
   children?: React.ReactNode
 }
 
@@ -38,8 +32,6 @@ export const InputGroup: React.FC<InputGroupProps> = styled.div`
 
   ${space}
 `
-
-InputGroup.propTypes = inputGroupPropTypes
 
 InputGroup.defaultProps = {
   borderColor: 'border',

--- a/packages/core/src/Label/Label.stories.tsx
+++ b/packages/core/src/Label/Label.stories.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
-import { Label, Input, Radio, Flex } from '..'
-import { ILabelProps } from './Label'
+import { Flex } from '../Flex'
+import { Input } from '../Input'
+import { Label } from './Label'
+import { Radio } from '../Radio'
+import { LabelProps } from './Label'
 import { argTypes, defaultArgs } from './Label.stories.args'
 
 export default {
@@ -17,7 +20,7 @@ export default {
   },
 }
 
-const Template = (args: ILabelProps) => <Label {...args} />
+const Template = (args: LabelProps) => <Label {...args} />
 
 export const _Label = Template.bind({})
 

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -1,30 +1,22 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {
-  space,
+  FontSizeProps,
+  FontWeightProps,
+  LineHeightProps,
+  SpaceProps,
+  TextStyleProps,
+  WidthProps,
+  compose,
   fontSize,
   fontWeight,
   letterSpacing,
   lineHeight,
+  space,
   textStyle,
   width,
-  SpaceProps,
-  FontSizeProps,
-  FontWeightProps,
-  LineHeightProps,
-  TextStyleProps,
-  WidthProps,
-  compose,
 } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
-import {
-  applyVariations,
-  getPaletteColor,
-  deprecatedColorValue,
-  textStylesValues,
-  typographyAttrs,
-} from '../utils'
+import { applyVariations, getPaletteColor, typographyAttrs } from '../utils'
 
 const nowrap = (props) =>
   props.nowrap
@@ -43,34 +35,22 @@ const accessiblyHide = (props) =>
       }
     : null
 
-const labelPropTypes = {
-  ...propTypes.space,
-  ...propTypes.fontSize,
-  ...propTypes.fontWeight,
-  ...propTypes.lineHeight,
-  ...propTypes.textStyle,
-  ...propTypes.width,
-  color: deprecatedColorValue(),
-  textStyle: PropTypes.oneOf(textStylesValues),
-}
+export type LabelProps = SpaceProps &
+  FontSizeProps &
+  FontWeightProps &
+  LineHeightProps &
+  TextStyleProps &
+  WidthProps &
+  Partial<Omit<HTMLLabelElement, 'children'>> & {
+    children?: React.ReactNode | string
+    color?: string
+    autoHide?: boolean
+    nowrap?: boolean
+    for?: string
+    onClick?: (evt: unknown) => void
+  }
 
-export interface ILabelProps
-  extends SpaceProps,
-    FontSizeProps,
-    FontWeightProps,
-    LineHeightProps,
-    TextStyleProps,
-    WidthProps,
-    Partial<Omit<HTMLLabelElement, 'children'>> {
-  children?: React.ReactNode | string
-  color?: string
-  autoHide?: boolean
-  nowrap?: boolean
-  for?: string
-  onClick?: (evt: unknown) => void
-}
-
-const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs((props) => ({
+export const Label: React.FC<LabelProps> & { isLabel?: boolean } = styled.label.attrs((props) => ({
   ...typographyAttrs(props),
   ...props,
 }))`
@@ -90,8 +70,6 @@ const Label: React.FC<ILabelProps> & { isLabel?: boolean } = styled.label.attrs(
   ${(props) => compose(fontSize, fontWeight, lineHeight, letterSpacing, space, textStyle, width)(props)}
 `
 
-Label.propTypes = labelPropTypes
-
 Label.defaultProps = {
   color: 'text.light',
   textStyle: 'label',
@@ -99,5 +77,3 @@ Label.defaultProps = {
 
 Label.displayName = 'Label'
 Label.isLabel = true
-
-export default Label

--- a/packages/core/src/Label/index.ts
+++ b/packages/core/src/Label/index.ts
@@ -1,1 +1,1 @@
-export { default as Label } from './Label'
+export { Label, type LabelProps } from './Label'

--- a/packages/core/src/Link/Link.spec.tsx
+++ b/packages/core/src/Link/Link.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, screen } from '../__test__/testing-library'
 
-import { Link } from '..'
+import { Link } from './Link'
 
 describe('Link', () => {
   it('should render correctly with no props without throwing', () => {

--- a/packages/core/src/Link/Link.stories.tsx
+++ b/packages/core/src/Link/Link.stories.tsx
@@ -1,14 +1,17 @@
-import type { ButtonProps } from '../Button'
-
+import { StoryObj } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components'
-import { StoryObj } from '@storybook/react'
-import { Box, Button, getLinkStylesOn, Container, Grid, Link, Text } from '..'
-import { ILinkProps } from './Link'
-import { argTypes, defaultArgs } from './Link.stories.args'
-import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
+import { Box } from '../Box'
+import { Button, type ButtonProps } from '../Button'
+import { Container } from '../Container'
+import { Grid } from '../Grid'
+import { Link } from '../Link'
+import { Text } from '../Text'
 import { colors } from '../storybook/args'
-import { sizeOptions, variationOptions } from './Link.stories.args'
+import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
+import { getLinkStylesOn } from '../utils'
+import { LinkProps } from './Link'
+import { argTypes, defaultArgs, sizeOptions, variationOptions } from './Link.stories.args'
 
 export default {
   title: 'Link',
@@ -17,7 +20,7 @@ export default {
   argTypes,
 }
 
-const Template = (args: ILinkProps) => <Link {...args} />
+const Template = (args: LinkProps) => <Link {...args} />
 
 export const _Link = Template.bind({})
 

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { width, space, WidthProps, SpaceProps, compose } from 'styled-system'
+import { SpaceProps, WidthProps, compose, space, width } from 'styled-system'
 
-import type { Sizes, Variations } from '../Button'
-import { buttonStyles } from '../Button'
-import { applyVariations, getPaletteColor, deprecatedColorValue } from '../utils'
+import { buttonStyles, type Sizes, type Variations } from '../Button'
+import { applyVariations, getPaletteColor } from '../utils'
 
 const variations = {
   fill: css`
@@ -79,37 +77,32 @@ const variations = {
   `,
 }
 
-const propTypes = {
-  color: deprecatedColorValue(),
-  disabled: PropTypes.bool,
-  variation: PropTypes.oneOf(Object.keys(variations)),
-}
+export type LinkProps = WidthProps &
+  SpaceProps &
+  React.HTMLAttributes<HTMLAnchorElement> &
+  React.RefAttributes<unknown> & {
+    children?: React.ReactNode | string
+    color?: string
+    disabled?: boolean
+    href?: string
+    size?: Sizes | Sizes[]
+    target?: string
+    variation?: Variations
+    onClick?: (unknown) => unknown
+    onFocus?: (unknown) => unknown
+  }
 
-export interface ILinkProps
-  extends WidthProps,
-    SpaceProps,
-    React.HTMLAttributes<HTMLAnchorElement>,
-    React.RefAttributes<unknown> {
-  children?: React.ReactNode | string
-  color?: string
-  disabled?: boolean
-  href?: string
-  size?: Sizes | Sizes[]
-  target?: string
-  variation?: Variations
-  onClick?: (unknown) => unknown
-  onFocus?: (unknown) => unknown
-}
-
-const Link: React.FC<ILinkProps> = styled.a.attrs(({ color, disabled, href, target, onClick, ...props }) => ({
-  color: disabled ? 'text.light' : color,
-  disabled,
-  href: !disabled ? href : undefined,
-  rel: target === '_blank' ? 'noopener' : null,
-  target,
-  onClick: !disabled ? onClick : () => {},
-  ...props,
-}))`
+export const Link: React.FC<LinkProps> = styled.a.attrs(
+  ({ color, disabled, href, target, onClick, ...props }) => ({
+    color: disabled ? 'text.light' : color,
+    disabled,
+    href: !disabled ? href : undefined,
+    rel: target === '_blank' ? 'noopener' : null,
+    target,
+    onClick: !disabled ? onClick : () => {},
+    ...props,
+  })
+)`
   ${applyVariations('Link', variations)}
 
   ${(props) =>
@@ -132,7 +125,3 @@ Link.defaultProps = {
   variation: 'link',
   size: 'medium',
 }
-
-Link.propTypes = propTypes
-
-export default Link

--- a/packages/core/src/Link/index.ts
+++ b/packages/core/src/Link/index.ts
@@ -1,1 +1,1 @@
-export { default as Link } from './Link'
+export { Link, type LinkProps } from './Link'

--- a/packages/core/src/List/List.spec.tsx
+++ b/packages/core/src/List/List.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '../__test__/testing-library'
-import { List } from '..'
+import { List } from '../List'
 
 describe('List', () => {
   it('renders ordered list', () => {
@@ -52,8 +52,10 @@ describe('List', () => {
     expect(list).toHaveStyleRule('margin-left', '32px')
   })
 
-  it('should renders list with default listStyles and indentation if right props are not passed ', () => {
+  it('should render list with default listStyles and indentation if right props are not passed ', () => {
     render(
+      // Ignoring TS error to test case when invalid listStyle is provided
+      // @ts-ignore
       <List.ul color='text.light' fontSize={1} listStyle='roman' data-testid='list'>
         <li>Example Text 1</li>
         <li>Example Text 2</li>

--- a/packages/core/src/List/List.stories.tsx
+++ b/packages/core/src/List/List.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import List from './List'
-import { Text } from '..'
+import { Text } from '../Text'
+import { List } from './List'
 import { argTypes, defaultArgs } from './List.stories.args'
 
 export default {

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -1,7 +1,9 @@
-import styled, { css } from 'styled-components'
-import { fontSize, space, width, compose } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
+import styled, { css } from 'styled-components'
+import { FontSizeProps, compose, fontSize, space, width } from 'styled-system'
 import { getPaletteColor } from '../utils'
+import React from 'react'
+import { PaletteColor, PaletteFamilyName } from '../theme'
 
 const tabSpacingSize = {
   xsm: '16px',
@@ -20,7 +22,14 @@ const listStyles = [
   'decimal',
   'square',
   'circle',
-]
+] as const
+
+export type ListProps = FontSizeProps & {
+  children?: React.ReactNode
+  listStyle?: (typeof listStyles)[number]
+  indentSize?: keyof typeof tabSpacingSize
+  color?: PaletteFamilyName | PaletteColor
+}
 
 const BaseCSS = css`
   margin: ${themeGet('space.1')} 0;
@@ -37,7 +46,7 @@ const BaseCSS = css`
   margin-left: ${(props) => tabSpacingSize[props.indentSize ? props.indentSize : 'lg']};
 `
 
-const Ordered = styled('ol')`
+const Ordered: React.FC<ListProps> = styled('ol')`
   & > li > * {
     margin-left: ${themeGet('space.2')};
   }
@@ -45,16 +54,14 @@ const Ordered = styled('ol')`
   ${BaseCSS};
 `
 
-const Unordered = styled('ul')`
+const Unordered: React.FC<ListProps> & { ol: React.FC<ListProps>; ul: React.FC<ListProps> } = styled('ul')`
   ${BaseCSS};
 `
 
-const List = Unordered
+export const List = Unordered
 
 List.ol = Ordered
 List.ol.displayName = 'OrderedList'
 
 List.ul = Unordered
 List.ul.displayName = 'UnorderedList'
-
-export default List

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -1,1 +1,1 @@
-export { default as List } from './List'
+export { List, type ListProps } from './List'

--- a/packages/core/src/Motion/Motion.spec.tsx
+++ b/packages/core/src/Motion/Motion.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '../__test__/testing-library'
-import Motion from './Motion'
+import { Motion } from './Motion'
 
 describe('Motion', () => {
   test('isAnimatedState = null (default)', () => {

--- a/packages/core/src/Motion/Motion.stories.tsx
+++ b/packages/core/src/Motion/Motion.stories.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import Motion from './Motion'
-import { Relative } from '../Relative'
-import { Text } from '../Text'
 import { Absolute } from '../Absolute'
 import { Box } from '../Box'
 import { Flex } from '../Flex'
+import { Relative } from '../Relative'
+import { Text } from '../Text'
+import { Motion } from './Motion'
 
 const description = 'Motion'
 

--- a/packages/core/src/Motion/Motion.tsx
+++ b/packages/core/src/Motion/Motion.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes, { InferProps } from 'prop-types'
 import { Box } from '../Box'
 import { getAnimationCss } from './helpers'
 
@@ -8,22 +7,20 @@ const Wrapper = styled(Box)`
   ${getAnimationCss}
 `
 
-const propTypes = {
-  isAnimatedState: PropTypes.bool,
-  variation: PropTypes.string,
-  children: PropTypes.node,
+export type MotionProps = {
+  children?: React.ReactNode
+  isAnimatedState?: boolean
+  variation?: string
 }
 
-const Motion: React.FC<InferProps<typeof propTypes>> = ({ children, isAnimatedState, variation }) => (
-  <Wrapper isAnimatedState={isAnimatedState} variation={variation} data-testid='motion-wrapper'>
-    {children}
-  </Wrapper>
-)
+export function Motion({ children, isAnimatedState, variation }: MotionProps) {
+  return (
+    <Wrapper isAnimatedState={isAnimatedState} variation={variation} data-testid='motion-wrapper'>
+      {children}
+    </Wrapper>
+  )
+}
 
 Motion.defaultProps = {
   variation: 'growCenter',
 }
-
-Motion.propTypes = propTypes
-
-export default Motion

--- a/packages/core/src/PasswordInput/PasswordInput.spec.tsx
+++ b/packages/core/src/PasswordInput/PasswordInput.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent } from '../__test__/testing-library'
-import PasswordInput from './PasswordInput'
+import { PasswordInput } from './PasswordInput'
 
 const sampleRegexChecks = [
   { label: '1 Uppercase Letter', regex: /(?=.*[A-Z])/ },

--- a/packages/core/src/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/core/src/PasswordInput/PasswordInput.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { Box } from '../Box'
 import { Button } from '../Button'
 import { Text } from '../Text'
-import PasswordInput from './PasswordInput'
+import { PasswordInput } from './PasswordInput'
 
 export default {
   title: 'PasswordInput',

--- a/packages/core/src/PasswordInput/PasswordInput.tsx
+++ b/packages/core/src/PasswordInput/PasswordInput.tsx
@@ -1,9 +1,15 @@
-import React, { useState } from 'react'
-import PropTypes, { InferProps } from 'prop-types'
-import styled from 'styled-components'
 import { Check, Success, SuccessOutline, Visibility, VisibilityOff } from 'pcln-icons'
-import { Badge, Flex, IconButton, IconField, Input, Label, ProgressBar } from '..'
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { Badge } from '../Badge'
+import { Flex, type FlexProps } from '../Flex'
+import { IconButton } from '../IconButton'
+import { IconField } from '../IconField'
+import { Input } from '../Input'
+import { Label } from '../Label'
+import { ProgressBar } from '../ProgressBar'
 import { Text } from '../Text'
+import { type PaletteColor, type PaletteFamilyName } from '../theme'
 
 const NoWrapText = styled(Text)`
   white-space: nowrap;
@@ -11,20 +17,20 @@ const NoWrapText = styled(Text)`
 
 const maxProgressBarLength = 4
 
-const propTypes = {
-  id: PropTypes.string,
-  isValid: PropTypes.bool,
-  label: PropTypes.string,
-  hasProgressBar: PropTypes.bool,
-  progressBarSteps: PropTypes.arrayOf(PropTypes.shape({ color: PropTypes.string, text: PropTypes.string })),
-  progressBarDefaultStep: PropTypes.number,
-  regexChecks: PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string, regex: PropTypes.regex })),
-  value: PropTypes.string,
-  onChange: PropTypes.func,
-  autoComplete: PropTypes.string,
+export type PasswordInputProps = Omit<FlexProps, 'onChange'> & {
+  id?: string
+  isValid?: boolean
+  label?: string
+  hasProgressBar?: boolean
+  progressBarSteps?: { color: PaletteColor | PaletteFamilyName; text: string }[]
+  progressBarDefaultStep?: number
+  regexChecks?: { label: string; regex: RegExp }[]
+  value?: string
+  onChange?: (event: { isValid: boolean; value: string }) => void
+  autoComplete?: string
 }
 
-const PasswordInput: React.FC<InferProps<typeof propTypes>> = ({
+export function PasswordInput({
   id,
   isValid,
   label,
@@ -35,7 +41,7 @@ const PasswordInput: React.FC<InferProps<typeof propTypes>> = ({
   onChange,
   autoComplete,
   ...props
-}) => {
+}: PasswordInputProps) {
   const [showPassword, setShowPassword] = useState(false)
   const [passedChecks, setPassedChecks] = useState([])
 
@@ -48,10 +54,8 @@ const PasswordInput: React.FC<InferProps<typeof propTypes>> = ({
     const passedChecks = []
 
     if (hasProgressBar) {
-      regexChecks.reduce(
-        (acc, element, index) => element.regex.test(currentValue) && passedChecks.push(index),
-        passedChecks
-      )
+      regexChecks.forEach((element, index) => element.regex.test(currentValue) && passedChecks.push(index))
+
       setPassedChecks(passedChecks)
     }
 
@@ -154,7 +158,3 @@ PasswordInput.defaultProps = {
     { label: 'at least 12 Characters', regex: /.{12,}/ },
   ],
 }
-
-PasswordInput.propTypes = propTypes
-
-export default PasswordInput

--- a/packages/core/src/PasswordInput/index.ts
+++ b/packages/core/src/PasswordInput/index.ts
@@ -1,1 +1,1 @@
-export { default as PasswordInput } from './PasswordInput'
+export { PasswordInput, type PasswordInputProps } from './PasswordInput'

--- a/packages/core/src/PlaceholderImage/PlaceholderImage.tsx
+++ b/packages/core/src/PlaceholderImage/PlaceholderImage.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes, { InferProps } from 'prop-types'
 import styled from 'styled-components'
 
 import { Image } from '../Image'
@@ -26,15 +25,15 @@ const determineSRC = (blur, chooseSrc, height, width) => {
   return imageURLs[randomNum]
 }
 
-const propTypes = {
-  ariaHidden: PropTypes.bool,
-  blur: PropTypes.bool,
-  chooseSrc: PropTypes.string,
-  height: PropTypes.string,
-  width: PropTypes.string,
+export type PlaceholderImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+  ariaHidden?: boolean
+  blur?: boolean
+  chooseSrc?: string
+  height?: string
+  width?: string
 }
 
-const PlaceholderImage: React.FC<InferProps<typeof propTypes>> = (props) => {
+export function PlaceholderImage(props: PlaceholderImageProps) {
   const { alt, ariaHidden, blur, chooseSrc, className, height, width } = props
 
   return (
@@ -52,13 +51,9 @@ const PlaceholderImage: React.FC<InferProps<typeof propTypes>> = (props) => {
 
 PlaceholderImage.displayName = 'PlaceholderImage'
 
-PlaceholderImage.propTypes = propTypes
-
 PlaceholderImage.defaultProps = {
   ariaHidden: true,
   blur: false,
   height: '500',
   width: '500',
 }
-
-export default PlaceholderImage

--- a/packages/core/src/PlaceholderImage/index.ts
+++ b/packages/core/src/PlaceholderImage/index.ts
@@ -1,1 +1,1 @@
-export { default as PlaceholderImage } from './PlaceholderImage'
+export { PlaceholderImage, type PlaceholderImageProps } from './PlaceholderImage'

--- a/packages/core/src/Popout/Popout.tsx
+++ b/packages/core/src/Popout/Popout.tsx
@@ -1,8 +1,9 @@
 import React, { RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
-import { Box, ShadowOverlay } from '..'
+import { Box } from '../Box'
+import { ShadowOverlay } from '../ShadowEffect'
 
-export interface IPopoutProps {
+export interface PopoutProps {
   trigger: JSX.Element
   content?: JSX.Element | undefined
   triggerRef?: RefObject<HTMLElement>
@@ -30,7 +31,7 @@ const PopoutModal = styled(Box)`
   transition: padding 200ms ease-in-out, margin 200ms ease-in-out, border-radius 200ms ease-in-out;
 `
 
-export const Popout = (props: IPopoutProps) => {
+export function Popout(props: PopoutProps) {
   const { trigger, content, onOpen, onClose, triggerRef, closeOnTriggerRefClick } = props
   const [isOpen, setIsOpen] = useState(false)
   const [height, setHeight] = useState(0)

--- a/packages/core/src/Popout/index.ts
+++ b/packages/core/src/Popout/index.ts
@@ -1,1 +1,1 @@
-export * from './Popout'
+export { Popout, type PopoutProps } from './Popout'

--- a/packages/core/src/ProgressBar/ProgressBar.spec.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.spec.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import { render, screen } from '../__test__/testing-library'
+import { type PaletteFamilyName } from '../theme'
 import { ProgressBar } from './ProgressBar'
 
-const testProps = [{ color: 'warning' }, { color: 'caution' }, { color: 'primary' }, { color: 'success' }]
+const testProps = [
+  { color: 'warning' },
+  { color: 'caution' },
+  { color: 'primary' },
+  { color: 'success' },
+] as { color: PaletteFamilyName }[]
 
 describe('ProgressBar', () => {
   it('Default progress bar (no colors)', () => {

--- a/packages/core/src/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.stories.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import { Box } from '../Box'
 import { ProgressBar } from './ProgressBar'
+import { PaletteFamilyName } from '../theme'
 
 export default {
   title: 'ProgressBar',
   component: ProgressBar,
 }
 
-const steps = [{ color: 'warning' }, { color: 'caution' }, { color: 'primary' }, { color: 'success' }]
+const steps = [{ color: 'warning' }, { color: 'caution' }, { color: 'primary' }, { color: 'success' }] as {
+  color: PaletteFamilyName
+}[]
 
 export const EmptyProgressBar = () => <ProgressBar steps={steps} currentStep={0} />
 

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import PropTypes, { InferProps } from 'prop-types'
 import styled from 'styled-components'
-import { Flex, Box } from '..'
+import { Box } from '../Box'
+import { Flex } from '../Flex'
+import { type PaletteColor, type PaletteFamilyName } from '../theme'
 
 const CustomBox = styled(Box)`
   border-radius: 2px;
@@ -9,23 +10,14 @@ const CustomBox = styled(Box)`
 
 const defaultStepColor = 'background.light'
 
-const propTypes = {
-  steps: PropTypes.arrayOf(
-    PropTypes.shape({
-      color: PropTypes.string,
-    })
-  ).isRequired,
-  currentStep: PropTypes.number.isRequired,
-  stepHeight: PropTypes.string,
-  className: PropTypes.string,
+export type ProgressBarProps = {
+  steps: { color: PaletteColor | PaletteFamilyName }[]
+  currentStep: number
+  stepHeight?: string
+  className?: string
 }
 
-const ProgressBar: React.FC<InferProps<typeof propTypes>> = ({
-  steps,
-  currentStep,
-  stepHeight,
-  className,
-}) => {
+export function ProgressBar({ steps, currentStep, stepHeight, className }: ProgressBarProps) {
   return (
     <Flex className={className}>
       {steps.map((step, index) => {
@@ -45,10 +37,6 @@ const ProgressBar: React.FC<InferProps<typeof propTypes>> = ({
   )
 }
 
-ProgressBar.propTypes = propTypes
-
 ProgressBar.defaultProps = {
   stepHeight: '4px',
 }
-
-export { ProgressBar }

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -1,1 +1,1 @@
-export * from './ProgressBar'
+export { ProgressBar, type ProgressBarProps } from './ProgressBar'

--- a/packages/core/src/Radio/Radio.spec.tsx
+++ b/packages/core/src/Radio/Radio.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Radio } from '..'
+import { Radio } from './Radio'
 
 describe('Radio', () => {
   test('Selected, rendering', () => {

--- a/packages/core/src/Radio/Radio.stories.tsx
+++ b/packages/core/src/Radio/Radio.stories.tsx
@@ -1,10 +1,13 @@
-import React from 'react'
 import { action } from '@storybook/addon-actions'
+import React from 'react'
 import styled from 'styled-components'
 
-import { Radio, Label, Button } from '..'
+import { Button } from '../Button'
+import { Label } from '../Label'
+import { Radio } from '../Radio'
 import ForwardRefDemo from '../storybook/utils/ForwardRefsDemo'
 import { getPaletteColor } from '../utils'
+import { paletteFamilyNames } from '../theme'
 
 const bold = (props) => (props.bold ? { fontWeight: props.theme.fontWeights.bold } : null)
 const medium = (props) => (props.medium ? { fontWeight: props.theme.fontWeights.medium } : null)
@@ -137,4 +140,15 @@ export const FontWeight = () => (
       <LabelText medium>font weight - medium</LabelText>
     </RadioLabel>
   </div>
+)
+
+export const Colors = () => (
+  <>
+    {paletteFamilyNames.map((color) => (
+      <RadioLabel fontSize='14px' key={color}>
+        <Radio checked color={color} />
+        <LabelText>{color}</LabelText>
+      </RadioLabel>
+    ))}
+  </>
 )

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import { RadioChecked, RadioEmpty } from 'pcln-icons'
-import { applyVariations, deprecatedColorValue, getPaletteColor } from '../utils'
+import React from 'react'
+import styled from 'styled-components'
+import { type PaletteFamilyName } from '../theme'
+import { applyVariations, getPaletteColor } from '../utils'
 
 const RadioWrap = styled.div`
   display: inline-block;
@@ -54,27 +54,23 @@ const RadioCheckedIcon = styled(RadioChecked)`
 const RadioEmptyIcon = styled(RadioEmpty)`
   vertical-align: middle;
 `
-const RadioIcon = ({ checked, ...props }) => {
+
+type RadioIconProps = {
+  checked?: boolean
+  size?: number
+}
+
+const RadioIcon = ({ checked, ...props }: RadioIconProps) => {
   return checked ? <RadioCheckedIcon {...props} /> : <RadioEmptyIcon {...props} />
 }
-RadioIcon.propTypes = {
-  checked: PropTypes.bool,
-}
 
-const propTypes = {
-  color: deprecatedColorValue(),
-  size: PropTypes.number,
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
-}
-
-export interface IRadioProps extends Partial<Omit<HTMLInputElement, 'size'>> {
+export type RadioProps = React.InputHTMLAttributes<HTMLInputElement> & {
   size?: number
-  color?: string
+  color?: PaletteFamilyName
   onClick?: (unknown) => unknown
 }
 
-const Radio: React.FC<IRadioProps> = React.forwardRef((props, ref) => {
+export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => {
   const { checked, disabled, size } = props
 
   const borderAdjustedSize = size + 4
@@ -103,10 +99,7 @@ const Radio: React.FC<IRadioProps> = React.forwardRef((props, ref) => {
 })
 
 Radio.displayName = 'Radio'
-Radio.propTypes = propTypes
 Radio.defaultProps = {
   color: 'primary',
   size: 24,
 }
-
-export default Radio

--- a/packages/core/src/Radio/index.ts
+++ b/packages/core/src/Radio/index.ts
@@ -1,1 +1,1 @@
-export { default as Radio } from './Radio'
+export { Radio, type RadioProps } from './Radio'

--- a/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
+++ b/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
@@ -15,7 +15,7 @@ export type TCardTypes = (typeof cardTypes)[number]
 export type THPositions = (typeof hPositions)[number]
 export type TVPositions = (typeof vPositions)[number]
 
-export interface IRadioCheckToggleCard {
+export type RadioCheckToggleCardProps = {
   children?: React.ReactNode | string
   cardType?: TCardTypes
   hPosition?: THPositions
@@ -142,7 +142,7 @@ const buttonIcon = (cardType: TCardTypes) => {
   }
 }
 
-export const RadioCheckToggleCard = (props: IRadioCheckToggleCard) => {
+export function RadioCheckToggleCard(props: RadioCheckToggleCardProps) {
   const {
     children,
     cardType,
@@ -196,10 +196,10 @@ export const RadioCheckToggleCard = (props: IRadioCheckToggleCard) => {
 RadioCheckToggleCard.displayName = 'RadioCheckToggleCard'
 
 RadioCheckToggleCard.defaultProps = {
-  cardType: 'radio',
+  cardType: 'radio' as TCardTypes,
   isTitleBold: false,
-  hPosition: 'right',
-  vPosition: 'top',
+  hPosition: 'right' as THPositions,
+  vPosition: 'top' as TVPositions,
   isTakingFullHeightOfCard: false,
-  onChange: (e) => {},
-} as IRadioCheckToggleCard
+  onChange: () => {},
+}

--- a/packages/core/src/RadioCheckToggleCard/index.ts
+++ b/packages/core/src/RadioCheckToggleCard/index.ts
@@ -1,1 +1,1 @@
-export { RadioCheckToggleCard } from './RadioCheckToggleCard'
+export { RadioCheckToggleCard, type RadioCheckToggleCardProps } from './RadioCheckToggleCard'

--- a/packages/core/src/Relative/Relative.spec.tsx
+++ b/packages/core/src/Relative/Relative.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-import { Absolute, Text, Relative } from '..'
+import { Absolute } from '../Absolute'
+import { Text } from '../Text'
+import { Relative } from '../Relative'
 import { Coupon as CouponIcon } from 'pcln-icons'
 
 describe('Relative', () => {

--- a/packages/core/src/Relative/Relative.stories.tsx
+++ b/packages/core/src/Relative/Relative.stories.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { Absolute, Card, Flag, Image, Relative, Text } from '..'
+import { Absolute } from '../Absolute'
+import { Card } from '../Card'
+import { Flag } from '../Flag'
+import { Image } from '../Image'
+import { Relative } from '../Relative'
+import { Text } from '../Text'
 import { Close as CloseIcon } from 'pcln-icons'
 
 export default {

--- a/packages/core/src/Relative/Relative.tsx
+++ b/packages/core/src/Relative/Relative.tsx
@@ -1,38 +1,25 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box, BoxProps } from '../Box'
 import {
-  top,
-  right,
-  bottom,
-  left,
-  zIndex,
-  TopProps,
-  RightProps,
   BottomProps,
   LeftProps,
+  RightProps,
+  TopProps,
   ZIndexProps,
+  bottom,
+  left,
+  right,
+  top,
+  zIndex,
 } from 'styled-system'
-import propTypes from '@styled-system/prop-types'
+import { Box, BoxProps } from '../Box'
 
-const relativePropTypes = {
-  ...propTypes.top,
-  ...propTypes.right,
-  ...propTypes.bottom,
-  ...propTypes.left,
-  ...propTypes.zIndex,
-}
+export type RelativeProps = TopProps & RightProps & BottomProps & LeftProps & ZIndexProps & BoxProps
 
-export interface IRelativeProps extends TopProps, RightProps, BottomProps, LeftProps, ZIndexProps, BoxProps {}
-
-const Relative: React.FC<IRelativeProps> = styled(Box)`
+export const Relative: React.FC<RelativeProps> = styled(Box)`
   position: relative;
   ${top} ${bottom} ${left} ${right}
   ${zIndex}
 `
 
-Relative.propTypes = relativePropTypes
-
 Relative.displayName = 'Relative'
-
-export default Relative

--- a/packages/core/src/Relative/index.ts
+++ b/packages/core/src/Relative/index.ts
@@ -1,1 +1,1 @@
-export { default as Relative } from './Relative'
+export { Relative, type RelativeProps } from './Relative'

--- a/packages/core/src/Select/Select.spec.tsx
+++ b/packages/core/src/Select/Select.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { Select } from '../Select/Select'
 import { render, screen } from '../__test__/testing-library'
-import { Select, theme, createTheme, getPaletteColor } from '..'
+import { theme } from '../theme'
+import { createTheme, getPaletteColor } from '../utils'
 
 describe('Select', () => {
   test('renders', () => {

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-import { InferProps } from 'prop-types'
-import styled, { css } from 'styled-components'
-import { borderRadius, compose, fontSize, space, FontSizeProps, SpaceProps } from 'styled-system'
 import themeGet from '@styled-system/theme-get'
-import styledSystemPropTypes from '@styled-system/prop-types'
 import { ChevronDown } from 'pcln-icons'
+import React from 'react'
+import styled, { css } from 'styled-components'
+import { FontSizeProps, SpaceProps, borderRadius, compose, fontSize, space } from 'styled-system'
 import { Flex } from '../Flex'
-import { applySizes, borderRadiusAttrs, borders, deprecatedColorValue, getPaletteColor } from '../utils'
+import { applySizes, borderRadiusAttrs, borders, getPaletteColor } from '../utils'
+import { BorderRadius, PaletteColor } from '../theme'
 
 const sizes = {
   sm: css`
@@ -27,12 +26,17 @@ const ClickableIcon = styled(ChevronDown)`
   pointer-events: none;
 `
 
-const propTypes = {
-  ...styledSystemPropTypes.space,
-  ...styledSystemPropTypes.fontSize,
-  color: deprecatedColorValue(),
-}
-const SelectBase: React.FC<InferProps<typeof propTypes>> = styled.select.attrs(borderRadiusAttrs)`
+export type SelectProps = SpaceProps &
+  FontSizeProps &
+  Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> & {
+    children?: React.ReactNode
+    color?: PaletteColor
+    borderRadius?: BorderRadius
+    size?: keyof typeof sizes
+    ref?: React.Ref<React.ForwardedRef<unknown>>
+  }
+
+const SelectBase: React.FC<SelectProps> = styled.select.attrs(borderRadiusAttrs)`
   appearance: none;
   background-color: transparent;
   border-radius: ${themeGet('borderRadii.lg')};
@@ -68,14 +72,7 @@ SelectBase.defaultProps = {
   size: 'lg',
 }
 
-SelectBase.propTypes = propTypes
-
-export interface ISelectProps extends SpaceProps, FontSizeProps {}
-
-const Select: React.FC<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Pick<any, string | number | symbol> & React.RefAttributes<unknown>
-> & { isField?: boolean } = React.forwardRef((props, ref) => (
+export const Select: React.FC<SelectProps> & { isField?: boolean } = React.forwardRef((props, ref) => (
   <Flex width={1} alignItems='center'>
     <SelectBase {...props} ref={ref} />
     <ClickableIcon ml={-32} color='text.light' />
@@ -84,5 +81,3 @@ const Select: React.FC<
 
 Select.displayName = 'Select'
 Select.isField = true
-
-export default Select

--- a/packages/core/src/Select/index.ts
+++ b/packages/core/src/Select/index.ts
@@ -1,1 +1,1 @@
-export { default as Select } from './Select'
+export { Select, type SelectProps } from './Select'

--- a/packages/core/src/ShadowEffect/ShadowEffect.spec.tsx
+++ b/packages/core/src/ShadowEffect/ShadowEffect.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { fireEvent, render, screen } from '../__test__/testing-library'
-import { ShadowEffect } from '../ShadowEffect'
 import { Input } from '../Input'
+import { ShadowEffect } from '../ShadowEffect'
+import { fireEvent, render, screen } from '../__test__/testing-library'
 
 describe.skip('ShadowEffect', () => {
   it('opens when clicked', () => {

--- a/packages/core/src/ShadowEffect/ShadowEffect.stories.tsx
+++ b/packages/core/src/ShadowEffect/ShadowEffect.stories.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-no-bind */
+import { action } from '@storybook/addon-actions'
 import React, { useState } from 'react'
 import styled from 'styled-components'
-import { action } from '@storybook/addon-actions'
-import ShadowEffect, { ShadowOverlay } from './ShadowEffect'
 import { Input } from '../Input'
 import { getPaletteColor } from '../utils'
+import { ShadowEffect, ShadowOverlay } from './ShadowEffect'
 
 const LightestBackgroundInput = styled(Input)`
   background-color: ${getPaletteColor('background.lightest')};

--- a/packages/core/src/ShadowEffect/ShadowEffect.tsx
+++ b/packages/core/src/ShadowEffect/ShadowEffect.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 
 import React, { useState } from 'react'
-import PropTypes, { InferProps } from 'prop-types'
 import styled from 'styled-components'
 import { zIndex } from 'styled-system'
 
@@ -16,16 +15,16 @@ export const ShadowOverlay = styled.div`
   ${zIndex};
 `
 
-const propTypes = {
-  shouldCloseOnBlur: PropTypes.bool,
-  shouldOpenOnFocus: PropTypes.bool,
-  zIndex: PropTypes.number,
-  children: PropTypes.node,
-  onClose: PropTypes.func,
-  onOpen: PropTypes.func,
+export type ShadowEffectProps = {
+  shouldCloseOnBlur?: boolean
+  shouldOpenOnFocus?: boolean
+  zIndex?: number | string
+  children?: React.ReactNode
+  onClose?: () => void
+  onOpen?: () => void
 }
 
-const ShadowEffect: React.FC<InferProps<typeof propTypes>> = ({
+export function ShadowEffect({
   shouldCloseOnBlur,
   shouldOpenOnFocus,
   zIndex = 'overlay',
@@ -33,7 +32,7 @@ const ShadowEffect: React.FC<InferProps<typeof propTypes>> = ({
   onClose,
   onOpen,
   ...props
-}) => {
+}: ShadowEffectProps) {
   const [isOpen, setOpen] = useState(false)
 
   const child = React.Children.only(children)
@@ -59,33 +58,37 @@ const ShadowEffect: React.FC<InferProps<typeof propTypes>> = ({
   return (
     <>
       {isOpen && <ShadowOverlay zIndex={zIndex} onClick={handleClose} {...props} />}
-      {React.cloneElement(child, {
-        zIndex: isOpen && (zIndex !== 'overlay' ? zIndex : 'onOverlay'),
-        onBlur: () => {
-          const onBlur = child.props.onBlur
-          onBlur && onBlur()
-          shouldCloseOnBlur && handleClose()
-        },
-        onClick: () => {
-          const onClick = child.props.onClick
-          onClick && onClick()
-          handleOpen()
-        },
-        onFocus: () => {
-          const onFocus = child.props.onFocus
-          onFocus && onFocus()
-          shouldOpenOnFocus && handleOpen()
-        },
-        onKeyDown: (evt) => {
-          const onKeyDown = child.props.onKeyDown
-          onKeyDown && onKeyDown(evt)
-          handleKeyDown(evt)
-        },
-      })}
+      {React.isValidElement(child) &&
+        React.cloneElement<
+          ShadowEffectProps & {
+            onBlur?: () => void
+            onClick?: () => void
+            onFocus?: () => void
+            onKeyDown?: (evt) => void
+          }
+        >(child, {
+          zIndex: isOpen && (zIndex !== 'overlay' ? zIndex : 'onOverlay'),
+          onBlur: () => {
+            const onBlur = child.props.onBlur
+            onBlur && onBlur()
+            shouldCloseOnBlur && handleClose()
+          },
+          onClick: () => {
+            const onClick = child.props.onClick
+            onClick && onClick()
+            handleOpen()
+          },
+          onFocus: () => {
+            const onFocus = child.props.onFocus
+            onFocus && onFocus()
+            shouldOpenOnFocus && handleOpen()
+          },
+          onKeyDown: (evt) => {
+            const onKeyDown = child.props.onKeyDown
+            onKeyDown && onKeyDown(evt)
+            handleKeyDown(evt)
+          },
+        })}
     </>
   )
 }
-
-ShadowEffect.propTypes = propTypes
-
-export default ShadowEffect

--- a/packages/core/src/ShadowEffect/index.ts
+++ b/packages/core/src/ShadowEffect/index.ts
@@ -1,2 +1,1 @@
-export { default as ShadowEffect } from './ShadowEffect'
-export { ShadowOverlay } from './ShadowEffect'
+export { ShadowEffect, ShadowOverlay, type ShadowEffectProps } from './ShadowEffect'

--- a/packages/core/src/SkipMenu/SkipMenu.spec.tsx
+++ b/packages/core/src/SkipMenu/SkipMenu.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '../__test__/testing-library'
 
-import { SkipMenu } from '.'
+import { SkipMenu } from './SkipMenu'
 
 describe('SkipMenu', () => {
   it('should not render if not links array is empty', () => {

--- a/packages/core/src/SkipMenu/SkipMenu.stories.tsx
+++ b/packages/core/src/SkipMenu/SkipMenu.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { SkipMenu } from '.'
-import { Flex } from '..'
+import { SkipMenu } from './SkipMenu'
+import { Flex } from '../Flex/Flex'
 
 const skipLinks = [
   {

--- a/packages/core/src/SkipMenu/SkipMenu.tsx
+++ b/packages/core/src/SkipMenu/SkipMenu.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes, { InferProps } from 'prop-types'
 import { Flex } from '../Flex'
 import { Link } from '../Link'
 import { SrOnly } from '../SrOnly'
@@ -20,17 +19,12 @@ const OffScreenPanel = styled(SrOnly)`
   }
 `
 
-const propTypes = {
-  className: PropTypes.string,
-  skipLinks: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string,
-      targetId: PropTypes.string,
-    })
-  ),
+export type SkipMenuProps = {
+  className?: string
+  skipLinks?: { label: string; targetId: string }[]
 }
 
-const SkipMenu: React.FC<InferProps<typeof propTypes>> = ({ className, skipLinks, ...props }) => {
+export function SkipMenu({ className, skipLinks, ...props }: SkipMenuProps) {
   if (!skipLinks?.length) return null
   return (
     <OffScreenPanel data-testid='skip-menu' as={Flex} className={className} {...props}>
@@ -44,7 +38,3 @@ const SkipMenu: React.FC<InferProps<typeof propTypes>> = ({ className, skipLinks
 }
 
 SkipMenu.displayName = 'SkipMenu'
-
-SkipMenu.propTypes = propTypes
-
-export default SkipMenu

--- a/packages/core/src/SkipMenu/index.ts
+++ b/packages/core/src/SkipMenu/index.ts
@@ -1,1 +1,1 @@
-export { default as SkipMenu } from './SkipMenu'
+export { SkipMenu, type SkipMenuProps } from './SkipMenu'

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import React, { useEffect, useRef } from 'react'
 import { type ArrowPosition } from './Arrow'
 import { BottomArrows } from './BottomArrows'
@@ -59,7 +58,7 @@ export function SlideBox({
     <SlideBoxWrapper arrowPosition={arrowPosition}>
       <TopArrows arrowProps={arrowProps} arrowPosition={arrowPosition} />
       <ScrollFlex width='100%' py={2} data-testid='slide-box' ref={ref}>
-        {childArray.map((item: PropTypes.node, index: number) => (
+        {childArray.map((item: string & React.JSX.Element, index: number) => (
           <Slide
             key={item.props.key || `slide${index}`}
             width={layout ? getCustomWidths(layout.split('-'), index) : getVisibleSlides(visibleSlides)}

--- a/packages/core/src/Spinner/Spinner.spec.tsx
+++ b/packages/core/src/Spinner/Spinner.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '../__test__/testing-library'
 import { Hotels } from 'pcln-icons'
-import Spinner from './Spinner'
+import { Spinner } from './Spinner'
 
 describe('Spinner', () => {
   it('renders a lonely spinner', () => {

--- a/packages/core/src/Spinner/Spinner.stories.tsx
+++ b/packages/core/src/Spinner/Spinner.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Hotels } from 'pcln-icons'
-import Spinner from './Spinner'
+import { Spinner } from './Spinner'
 import { argTypes, defaultArgs, iconMap } from './Spinner.stories.args'
 
 export default {

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import PropTypes, { InferProps } from 'prop-types'
 import styled, { css, keyframes, useTheme } from 'styled-components'
-import { Flex, Absolute } from '..'
+import { type Theme } from 'styled-system'
+import { Absolute } from '../Absolute/Absolute'
+import { Flex } from '../Flex/Flex'
+import { PaletteFamilyName } from '../theme'
 import { applySizes, getPaletteColor } from '../utils'
 
 const sizes = {
@@ -65,20 +67,12 @@ const GradientRingWrapper = styled(Absolute)`
   height: 100%;
 `
 
-const propTypes = {
-  children: PropTypes.node,
-  color: PropTypes.string,
-  size: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.oneOf(Object.keys(sizes)),
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.oneOf(Object.keys(sizes)), PropTypes.string, PropTypes.number])
-    ),
-  ]),
-}
+type GradientRingProps = {
+  strokeWidth?: string
+  theme?: Theme
+} & SpinnerProps
 
-const GradientRing: React.FC<InferProps<typeof propTypes>> = ({ strokeWidth = '6px', ...props }) => {
+function GradientRing({ strokeWidth = '6px', ...props }: GradientRingProps) {
   const strokeColor = getPaletteColor(props.color, 'base')(props)
   return (
     <GradientRingWrapper>
@@ -119,12 +113,16 @@ const GradientRing: React.FC<InferProps<typeof propTypes>> = ({ strokeWidth = '6
   )
 }
 
-const Spinner: React.FC<InferProps<typeof propTypes>> = ({
-  children,
-  color,
-  useGradient = false,
-  ...props
-}) => {
+export type SpinnerSizes = 'small' | 'medium' | 'large' | number
+
+export type SpinnerProps = {
+  children?: React.ReactNode
+  color?: PaletteFamilyName
+  size?: SpinnerSizes | SpinnerSizes[]
+  useGradient?: boolean
+}
+
+export function Spinner({ children, color, useGradient = false, ...props }: SpinnerProps) {
   if (children) {
     React.Children.only(children)
   }
@@ -134,18 +132,15 @@ const Spinner: React.FC<InferProps<typeof propTypes>> = ({
     <RelativeFlex justifyContent='center' alignItems='center' {...props}>
       {useGradient ? <GradientRing color={color} theme={theme} {...props} /> : <Ring color={color} />}
       {children &&
-        React.cloneElement(children, {
+        React.isValidElement(children) &&
+        React.cloneElement<{ color?: PaletteFamilyName }>(children, {
           color: children?.props?.color || color,
         })}
     </RelativeFlex>
   )
 }
 
-Spinner.propTypes = propTypes
-
 Spinner.defaultProps = {
   color: 'primary',
   size: 'medium',
 }
-
-export default Spinner

--- a/packages/core/src/Spinner/index.ts
+++ b/packages/core/src/Spinner/index.ts
@@ -1,1 +1,1 @@
-export { default as Spinner } from './Spinner'
+export { Spinner, type SpinnerProps } from './Spinner'

--- a/packages/core/src/ToastProvider/ToastProvider.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useCallback, useContext, useEffect, useState } fr
 import styled, { withTheme } from 'styled-components'
 import { createPortal } from 'react-dom'
 import { Absolute } from '../Absolute'
-import { Animate, MotionVariant } from '../Animate'
+import { Animate, type MotionVariant } from '../Animate/Animate'
 import { Flex } from '../Flex'
 import { Toast } from '../Toast'
 import { ThemeProvider } from '../ThemeProvider'

--- a/packages/core/src/Truncate/Truncate.spec.tsx
+++ b/packages/core/src/Truncate/Truncate.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Truncate } from '..'
+import { Truncate } from './Truncate'
 
 describe('Truncate', () => {
   test('renders', () => {

--- a/packages/core/src/Truncate/Truncate.stories.tsx
+++ b/packages/core/src/Truncate/Truncate.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Truncate } from '..'
+import { Box } from '../Box'
+import { Truncate } from './Truncate'
 
 const loripsum = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quis est, qui non oderit libidinosam, protervam adolescentiam? Sed ego in hoc resisto; Ratio enim nostra consentit, pugnat oratio. Nihil enim hoc differt.

--- a/packages/core/src/Truncate/Truncate.tsx
+++ b/packages/core/src/Truncate/Truncate.tsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components'
 import { Text } from '../Text'
 
-const Truncate = styled(Text)`
+export const Truncate = styled(Text)`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 `
 
 Truncate.displayName = 'Truncate'
-
-export default Truncate

--- a/packages/core/src/Truncate/index.ts
+++ b/packages/core/src/Truncate/index.ts
@@ -1,1 +1,1 @@
-export { default as Truncate } from './Truncate'
+export { Truncate } from './Truncate'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,18 +1,27 @@
-import * as storybookArgs from './storybook/args'
-
 export { Absolute, type AbsoluteProps } from './Absolute/Absolute'
 export { Accordion, type AccordionItemProps, type AccordionProps } from './Accordion/Accordion'
+export { Animate, type AnimateProps } from './Animate/Animate'
 export { Avatar, type AvatarProps } from './Avatar/Avatar'
 export { BackgroundImage, type BackgroundImageProps } from './BackgroundImage/BackgroundImage'
 export { Badge, type BadgeProps } from './Badge/Badge'
 export { Banner, type BannerProps } from './Banner/Banner'
+export { BlockLink } from './BlockLink/BlockLink'
 export { Box, type BoxProps } from './Box/Box'
 export { Breadcrumbs, type BreadcrumbsProps } from './Breadcrumbs/Breadcrumbs'
 export { Button, type ButtonProps } from './Button/Button'
 export { Card, type CardProps } from './Card/Card'
+export { ChatActionContainer } from './ChatActionContainer/ChatActionContainer'
 export { ChatHeader, type ChatHeaderProps } from './ChatHeader/ChatHeader'
 export { ChatMessage, type ChatMessageProps } from './ChatMessage/ChatMessage'
-export { Flex, type FlexProps } from './Flex/Flex'
+export {
+  ChatMessageContainer,
+  type ChatMessageContainerProps,
+  type ChatMessageVariation,
+} from './ChatMessageContainer/ChatMessageContainer'
+export {
+  ChatMessageSeparator,
+  type ChatMessageSeparatorProps,
+} from './ChatMessageSeparator/ChatMessageSeparator'
 export { ChatTrigger, type ChatTriggerProps } from './ChatTrigger/ChatTrigger'
 export { Checkbox, type CheckboxProps } from './Checkbox/Checkbox'
 export { ButtonChip, type ButtonChipProps } from './Chip/ButtonChip/ButtonChip'
@@ -21,74 +30,65 @@ export { FilterChip as Chip, FilterChip, type FilterChipProps } from './Chip/Fil
 export { CloseButton, type CloseButtonProps } from './CloseButton/CloseButton'
 export { Container, type ContainerProps } from './Container/Container'
 export { Dialog, type DialogProps } from './Dialog/Dialog'
+export { Divider, type DividerProps } from './Divider/Divider'
+export { DotLoader, type DotLoaderProps } from './DotLoader/DotLoader'
+export { Flag, type FlagProps } from './Flag/Flag'
+export { Flex, type FlexProps } from './Flex/Flex'
 export {
   FloatingActionButton,
   type FloatingActionButtonProps,
 } from './FloatingActionButton/FloatingActionButton'
+export { FormField, InputField, type FormFieldProps } from './FormField'
+export { GenericBanner, type GenericBannerProps } from './GenericBanner/GenericBanner'
+export { Grid, type GridProps } from './Grid/Grid'
+export { Heading } from './Heading/Heading'
+export { Hide, type HideProps } from './Hide/Hide'
 export { Hug, type HugProps } from './Hug/Hug'
+export { Icon } from './Icon'
+export { IconButton, type IconButtonProps } from './IconButton/IconButton'
+export { IconField, type IconFieldProps } from './IconField/IconField'
 export { Image, type ImageProps } from './Image/Image'
 export { Input, type InputProps } from './Input/Input'
 export { InputGroup, type InputGroupProps } from './InputGroup/InputGroup'
+export { Label, type LabelProps } from './Label/Label'
+export { Layout, type LayoutProps } from './Layout/Layout'
+export { Link, type LinkProps } from './Link/Link'
+export { List, type ListProps } from './List/List'
+export { Motion, type MotionProps } from './Motion/Motion'
+export { PasswordInput, type PasswordInputProps } from './PasswordInput/PasswordInput'
+export { PlaceholderImage, type PlaceholderImageProps } from './PlaceholderImage/PlaceholderImage'
+export { Popout, type PopoutProps } from './Popout/Popout'
+export { ProgressBar, type ProgressBarProps } from './ProgressBar/ProgressBar'
+export { Radio, type RadioProps } from './Radio/Radio'
+export {
+  RadioCheckToggleCard,
+  type RadioCheckToggleCardProps,
+} from './RadioCheckToggleCard/RadioCheckToggleCard'
 export { RatingBadge, type RatingBadgeProps } from './RatingBadge/RatingBadge'
+export { Relative, type RelativeProps } from './Relative/Relative'
+export { Select, type SelectProps } from './Select'
+export { ShadowEffect, ShadowOverlay, type ShadowEffectProps } from './ShadowEffect'
 export { Shimmer, type ShimmerProps } from './Shimmer/Shimmer'
+export { SkipMenu, type SkipMenuProps } from './SkipMenu/SkipMenu'
+export { SlideBox, type SlideBoxProps } from './SlideBox/SlideBox'
+export { Spinner, type SpinnerProps } from './Spinner/Spinner'
+export { SrOnly } from './SrOnly'
 export { Stamp, type StampProps } from './Stamp/Stamp'
-export { Text, type TextProps } from './Text/Text'
-export { Base, ThemeProvider, type ThemeProviderProps } from './ThemeProvider/ThemeProvider'
-export { Stepper, type StepperProps } from './Stepper/Stepper'
 export { Step, type StepProps } from './Step/Step'
+export { Stepper, type StepperProps } from './Stepper/Stepper'
 export { Swatch, type SwatchProps } from './Swatch/Swatch'
+export { Text, type TextProps } from './Text/Text'
 export { TextArea, type TextAreaProps } from './TextArea/TextArea'
+export { Base, ThemeProvider, type ThemeProviderProps } from './ThemeProvider/ThemeProvider'
 export { Toast, type ToastProps } from './Toast/Toast'
-export { ToastProvider, type ToastProviderProps } from './ToastProvider/ToastProvider'
+export { ToastProvider, useToast, type ToastProviderProps } from './ToastProvider/ToastProvider'
 export { Toggle, type ToggleProps } from './Toggle/Toggle'
 export { ToggleBadge, type ToggleBadgeProps } from './ToggleBadge/ToggleBadge'
 export { Tooltip, type TooltipProps } from './Tooltip/Tooltip'
-
-export type { IGridProps } from './Grid'
-
-export * from './Animate'
-
-export { BlockLink } from './BlockLink'
-
-export * from './ChatActionContainer/ChatActionContainer'
-export * from './ChatMessageContainer/ChatMessageContainer'
-export * from './ChatMessageSeparator/ChatMessageSeparator'
-
-export { Divider } from './Divider'
-export { DotLoader } from './DotLoader'
-export { Flag } from './Flag'
-export { FormField, InputField } from './FormField'
-export { GenericBanner } from './GenericBanner'
-export * from './Grid'
-export { Heading } from './Heading'
-export { Hide } from './Hide'
-export { Icon } from './Icon'
-export { IconButton } from './IconButton'
-export { IconField } from './IconField'
-export { Label } from './Label'
-export * from './Layout'
-export { Link } from './Link'
-export { List } from './List'
-export { PasswordInput } from './PasswordInput'
-export { PlaceholderImage } from './PlaceholderImage'
-export * from './Popout'
-export * from './ProgressBar'
-export { Radio } from './Radio'
-export { RadioCheckToggleCard } from './RadioCheckToggleCard'
-
-export { Relative } from './Relative'
-export { Select } from './Select'
-export { ShadowEffect, ShadowOverlay } from './ShadowEffect'
-
-export { SkipMenu } from './SkipMenu'
-export { SlideBox } from './SlideBox'
-export { Spinner } from './Spinner'
-export { SrOnly } from './SrOnly'
-export { Truncate } from './Truncate'
-
-export { useToast } from './ToastProvider'
+export { Truncate } from './Truncate/Truncate'
 
 export * from './utils'
+export * from './theme'
 
 // DocsUtils
 export * from './DocsUtils/DoDont'
@@ -101,6 +101,7 @@ export * from './DocsUtils/Section'
 export * from './DocsUtils/StoryHeading'
 export * from './DocsUtils/StoryStage'
 export * from './DocsUtils/TableOfContents'
-export { storybookArgs }
 
-export * from './theme'
+// Storybook
+import * as storybookArgs from './storybook/args'
+export { storybookArgs }

--- a/packages/core/src/stories/Colors.stories.tsx
+++ b/packages/core/src/stories/Colors.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react'
 import { Box, Flex, Text, Card, createTheme } from '..'
 import type { ColorScheme as ColorSchemeType } from '..'

--- a/packages/core/src/stories/ZIndices.stories.tsx
+++ b/packages/core/src/stories/ZIndices.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import {

--- a/packages/core/src/storybook/utils/ForwardRefsDemo.tsx
+++ b/packages/core/src/storybook/utils/ForwardRefsDemo.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react'
-import PropTypes from 'prop-types'
 
 /**
  * This is a demo component for Storybook that provides a ref to content using a render prop
@@ -8,11 +7,4 @@ export default function ForwardRefsDemo({ refChild }) {
   const dsRef = useRef(null)
 
   return <>{refChild(dsRef)}</>
-}
-
-ForwardRefsDemo.propTypes = {
-  /**
-   * Render prop that receives a ref stored on the instance of <ForwardRefsDemo/>
-   */
-  refChild: PropTypes.func,
 }

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -617,6 +617,9 @@ export type ColorSchemeName = (typeof colorSchemeNames)[number]
 export type ColorSchemes = Record<ColorSchemeName, ColorScheme>
 
 /** @public */
+export type ColorName = keyof typeof colors
+
+/** @public */
 export type DesignSystemTheme = {
   space: string[]
   colors: Record<string, string>

--- a/packages/menu/src/MenuList/MenuList.stories.jsx
+++ b/packages/menu/src/MenuList/MenuList.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Text } from 'pcln-design-system'
-import { fireEvent, within } from '@storybook/testing-library'
+import { fireEvent, within, userEvent } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
 
 import MenuList from './MenuList'
@@ -71,6 +71,7 @@ export const KeyboardNavigation = () => (
 )
 KeyboardNavigation.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
+  await userEvent.tab()
   await fireEvent.keyDown(canvas.getByRole('listbox'), {
     key: 'ArrowUp',
     code: 'ArrowUp',


### PR DESCRIPTION
This PR updates the remaining `core` components to use TS types for prop types instead of React prop types. It also includes cleanup of many imports/exports.