### PR TITLE
adding optional onClose prop

### DIFF
--- a/common/changes/pcln-design-system/addOnCloseToDialog_2023-12-28-21-04.json
+++ b/common/changes/pcln-design-system/addOnCloseToDialog_2023-12-28-21-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Updated the dialog component to have an optionalProp onClose",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -45,6 +45,17 @@ export const WithHeaderText: DialogStory = {
     ...exampleHeaderProps,
   },
 }
+
+export const WithOnCloseFunction: DialogStory = {
+  ...Playground,
+  args: {
+    onClose: () => {
+      alert('closed')
+    },
+    ...exampleHeaderProps,
+  },
+}
+
 export const WithHeaderContent: DialogStory = {
   ...Playground,
   args: {

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -26,6 +26,7 @@ export interface IDialogProps {
   size?: DialogSize
   triggerNode?: React.ReactNode
   zIndex?: ZIndex
+  onClose?: () => void
   onOpenChange?: (open: boolean) => void
 }
 
@@ -50,12 +51,16 @@ const PclnDialog = ({
   triggerNode,
   zIndex = 'overlay',
   onOpenChange,
+  onClose,
 }: IDialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
   useEffect(() => setOpen(open), [open])
 
   const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen && onClose) {
+      onClose()
+    }
     onOpenChange?.(newOpen)
     setOpen(newOpen)
   }


### PR DESCRIPTION

Currently working on implementing Dialog in replace of Modal in Next-landing. Theres a use case where we need to pass an onClose function. For our speicific situation we need to pass a closeDialog function which removes qs parameters. 


https://github.com/priceline/design-system/assets/25209141/d9bb1ee9-9740-4a96-8bb5-1c256226826d


