### PR TITLE
AIR-59977 Passed missing currentSlide prop to SlideBox component in Carousel

### DIFF
--- a/common/changes/pcln-carousel/bugfix-AIR-59977-carousel_2024-01-05-15-04.json
+++ b/common/changes/pcln-carousel/bugfix-AIR-59977-carousel_2024-01-05-15-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "AIR-59977 Passed missing currentSlide prop to SlideBox component in Carousel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -77,6 +77,7 @@ export const Carousel = ({
         layout={layout}
         onSlideChange={onSlideChange}
         visibleSlides={mobileVisibleSlides || getMobileVisibleSlides(visibleSlides)}
+        currentSlideOverride={currentSlide}
       >
         {React.Children.map(children, (item) => item)}
       </SlideBox>

--- a/packages/carousel/src/Carousel.stories.jsx
+++ b/packages/carousel/src/Carousel.stories.jsx
@@ -273,7 +273,7 @@ SetVisibleSlidesByViewport.args = {
 }
 
 export const SetCurrentSlide = () => (
-  <Carousel layout='50-50' arrowsPosition='bottom' currentSlide={1}>
+  <Carousel layout='50-50' arrowsPosition='bottom' currentSlide={2}>
     <Flex>Slide 1</Flex>
     <Flex>Slide 2</Flex>
     <Flex>Slide 3</Flex>


### PR DESCRIPTION
This sends the currentSlide property to the SliceBox component, ensuring it automatically scrolls to the indicated slide. This functionality was already in place for the Desktop Carousel but was previously absent in the Mobile Carousel.