### PR TITLE
Add OverflowX & OverflowY Props to the dialog component

### DIFF
--- a/common/changes/pcln-design-system/SITE-22333_2024-01-16-20-31.json
+++ b/common/changes/pcln-design-system/SITE-22333_2024-01-16-20-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Updated dialog Component to have an option overflowX & Y prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.stories.args.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.args.tsx
@@ -5,7 +5,7 @@ import { Grid } from '../Grid'
 import { Text } from '../Text'
 import { borderRadii, colorSchemeNames, paletteColors } from '../theme'
 import type { DialogProps } from './Dialog'
-import { dialogSizes } from './Dialog.styled'
+import { dialogSizes, overflow } from './Dialog.styled'
 
 export const argTypes: Partial<ArgTypes<DialogProps>> = {
   borderRadius: { control: { type: 'select' }, options: Object.keys(borderRadii) },
@@ -21,6 +21,8 @@ export const argTypes: Partial<ArgTypes<DialogProps>> = {
   showCloseButton: { control: { type: 'boolean' } },
   size: { control: { type: 'select' }, options: dialogSizes },
   triggerNode: { control: { type: 'none' } },
+  overflowX: { control: { type: 'select' }, options: overflow },
+  overflowY: { control: { type: 'select' }, options: overflow },
 }
 
 export const defaultArgs: Partial<DialogProps> = {
@@ -50,4 +52,6 @@ export const defaultArgs: Partial<DialogProps> = {
   showCloseButton: true,
   size: 'md',
   triggerNode: <Button>Open Dialog</Button>,
+  overflowX: 'auto',
+  overflowY: 'auto',
 }

--- a/packages/core/src/Dialog/Dialog.stories.args.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.args.tsx
@@ -5,8 +5,9 @@ import { Grid } from '../Grid'
 import { Text } from '../Text'
 import { borderRadii, colorSchemeNames, paletteColors } from '../theme'
 import type { DialogProps } from './Dialog'
-import { dialogSizes, overflow } from './Dialog.styled'
+import { dialogSizes } from './Dialog.styled'
 
+const overflowArgs = ['scroll', 'visible', 'hidden', 'auto']
 export const argTypes: Partial<ArgTypes<DialogProps>> = {
   borderRadius: { control: { type: 'select' }, options: Object.keys(borderRadii) },
   children: { control: { type: 'none' } },
@@ -21,8 +22,8 @@ export const argTypes: Partial<ArgTypes<DialogProps>> = {
   showCloseButton: { control: { type: 'boolean' } },
   size: { control: { type: 'select' }, options: dialogSizes },
   triggerNode: { control: { type: 'none' } },
-  overflowX: { control: { type: 'select' }, options: overflow },
-  overflowY: { control: { type: 'select' }, options: overflow },
+  overflowX: { control: { type: 'select' }, options: overflowArgs },
+  overflowY: { control: { type: 'select' }, options: overflowArgs },
 }
 
 export const defaultArgs: Partial<DialogProps> = {

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -10,7 +10,6 @@ import { Grid, type GridProps } from '../Grid'
 import { Text } from '../Text'
 import { Dialog, type DialogProps } from './Dialog'
 import { argTypes, defaultArgs } from './Dialog.stories.args'
-import { Select } from '../Select'
 
 type DialogStory = StoryObj<DialogProps>
 

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -10,6 +10,7 @@ import { Grid, type GridProps } from '../Grid'
 import { Text } from '../Text'
 import { Dialog, type DialogProps } from './Dialog'
 import { argTypes, defaultArgs } from './Dialog.stories.args'
+import { Select } from '../Select'
 
 type DialogStory = StoryObj<DialogProps>
 
@@ -107,10 +108,39 @@ const ExampleOverflowingContent = (props: GridProps) => (
   </Grid>
 )
 
+const ExampleOverflowingAbsolute = (props: GridProps) => {
+  const [showText, setShowText] = React.useState(false)
+  return (
+    <Box>
+      <Grid p={24} gap={5} {...props}>
+        <Button onClick={() => setShowText(!showText)}>Show text overflow</Button>
+      </Grid>
+      {showText && (
+        <Text style={{ overflow: 'visible', position: 'absolute' }}>
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ex quas voluptas, vel id doloribus
+          delectus deleniti minus eius ullam vero dolorum laboriosam dolor cupiditate sequi quia itaque
+          corrupti quaerat hic! Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ex quas voluptas,
+          vel id doloribus delectus deleniti minus eius ullam vero dolorum laboriosam dolor cupiditate sequi
+          quia itaque corrupti quaerat hic!
+        </Text>
+      )}
+    </Box>
+  )
+}
+
 export const OverflowModal: DialogStory = {
   ...Playground,
   args: {
     children: <ExampleOverflowingContent overflow='auto' />,
+  },
+}
+
+export const OverflowOutsideContainer: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingAbsolute overflow='visible' />,
+    overflowX: 'visible',
+    overflowY: 'visible',
   },
 }
 

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -110,7 +110,7 @@ const ExampleOverflowingContent = (props: GridProps) => (
 export const OverflowModal: DialogStory = {
   ...Playground,
   args: {
-    children: <ExampleOverflowingContent />,
+    children: <ExampleOverflowingContent overflow='auto' />,
   },
 }
 

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from '../ThemeProvider'
 import { type DialogProps } from './Dialog'
 
 export const dialogSizes = ['sm', 'md', 'lg', 'xl', 'full'] as const
+export const overflow = ['visible', 'hidden', 'scroll', 'auto'] as const
 export type DialogSize = (typeof dialogSizes)[number]
 
 const sizeStyles: Record<DialogSize, { width?: string; height?: string }> = {
@@ -103,7 +104,8 @@ const DialogContentWrapper = styled(motion.div)`
 
 const DialogInnerContentWrapper = styled.div`
   position: relative;
-  overflow: auto;
+  overflow-x: ${(props) => props.overflowX && props.overflowX};
+  overflow-y: ${(props) => props.overflowY && props.overflowY};
   border-radius: ${(props: DialogProps) =>
     props.sheet
       ? `${themeGet(`borderRadii.${props.borderRadius}`)(props)} ${themeGet(
@@ -152,6 +154,8 @@ export const DialogContent = ({
   size,
   zIndex,
   onOpenChange,
+  overflowX,
+  overflowY,
 }: DialogProps) => {
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
@@ -198,7 +202,14 @@ export const DialogContent = ({
           <Dialog.Title>{ariaTitle}</Dialog.Title>
         </VisuallyHidden>
 
-        <DialogInnerContentWrapper sheet={sheet} hugColor={hugColor} size={size} borderRadius={borderRadius}>
+        <DialogInnerContentWrapper
+          overflowX={overflowX}
+          overflowY={overflowY}
+          sheet={sheet}
+          hugColor={hugColor}
+          size={size}
+          borderRadius={borderRadius}
+        >
           {headerContent && (
             <Grid
               colorScheme={headerColorScheme}

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -104,8 +104,8 @@ const DialogContentWrapper = styled(motion.div)`
 
 const DialogInnerContentWrapper = styled.div`
   position: relative;
-  overflow-x: ${(props) => props.overflowX && props.overflowX};
-  overflow-y: ${(props) => props.overflowY && props.overflowY};
+  overflow-x: ${(props) => props.overflowX};
+  overflow-y: ${(props) => props.overflowY};
   border-radius: ${(props: DialogProps) =>
     props.sheet
       ? `${themeGet(`borderRadii.${props.borderRadius}`)(props)} ${themeGet(

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -4,7 +4,7 @@ import themeGet from '@styled-system/theme-get'
 import { HTMLMotionProps, Transition, motion } from 'framer-motion'
 import React from 'react'
 import styled from 'styled-components'
-import { zIndex } from 'styled-system'
+import { overflowX, overflowY, zIndex } from 'styled-system'
 import { Box } from '../Box'
 import { CloseButton, type CloseButtonProps } from '../CloseButton/CloseButton'
 import { Grid } from '../Grid'
@@ -103,8 +103,8 @@ const DialogContentWrapper = styled(motion.div)`
 
 const DialogInnerContentWrapper = styled.div`
   position: relative;
-  overflow-x: ${(props: DialogProps) => props.overflowX};
-  overflow-y: ${(props: DialogProps) => props.overflowY};
+  ${overflowX}
+  ${overflowY}
   border-radius: ${(props: DialogProps) =>
     props.sheet
       ? `${themeGet(`borderRadii.${props.borderRadius}`)(props)} ${themeGet(

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -13,7 +13,6 @@ import { ThemeProvider } from '../ThemeProvider'
 import { type DialogProps } from './Dialog'
 
 export const dialogSizes = ['sm', 'md', 'lg', 'xl', 'full'] as const
-export const overflow = ['visible', 'hidden', 'scroll', 'auto'] as const
 export type DialogSize = (typeof dialogSizes)[number]
 
 const sizeStyles: Record<DialogSize, { width?: string; height?: string }> = {
@@ -104,8 +103,8 @@ const DialogContentWrapper = styled(motion.div)`
 
 const DialogInnerContentWrapper = styled.div`
   position: relative;
-  overflow-x: ${(props) => props.overflowX};
-  overflow-y: ${(props) => props.overflowY};
+  overflow-x: ${(props: DialogProps) => props.overflowX};
+  overflow-y: ${(props: DialogProps) => props.overflowY};
   border-radius: ${(props: DialogProps) =>
     props.sheet
       ? `${themeGet(`borderRadii.${props.borderRadius}`)(props)} ${themeGet(

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,12 +1,12 @@
 import { AnimatePresence } from 'framer-motion'
-import type { BorderRadius, ColorSchemes, Overflow, PaletteColor, ZIndex } from '../theme'
+import type { BorderRadius, ColorSchemes, PaletteColor, ZIndex } from '../theme'
 import type { DialogSize } from './Dialog.styled'
 import { DialogContent, DialogOverlay } from './Dialog.styled'
-
+import { OverflowProps } from 'styled-system'
 import * as Dialog from '@radix-ui/react-dialog'
 import React, { useEffect } from 'react'
 
-export type DialogProps = {
+export type DialogProps = OverflowProps & {
   ariaDescription: string
   ariaTitle: string
   borderRadius?: BorderRadius
@@ -25,8 +25,6 @@ export type DialogProps = {
   showCloseButton?: boolean
   size?: DialogSize
   triggerNode?: React.ReactNode
-  overflowX?: Overflow
-  overflowY?: Overflow
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
 }

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -25,6 +25,8 @@ export type DialogProps = {
   showCloseButton?: boolean
   size?: DialogSize
   triggerNode?: React.ReactNode
+  overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto'
+  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto'
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
 }
@@ -49,6 +51,8 @@ const PclnDialog = ({
   size = 'md',
   triggerNode,
   zIndex = 'overlay',
+  overflowX = 'auto',
+  overflowY = 'auto',
   onOpenChange,
 }: DialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
@@ -67,6 +71,8 @@ const PclnDialog = ({
         {_open && (
           <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet} zIndex={zIndex}>
             <DialogContent
+              overflowX={overflowX}
+              overflowY={overflowY}
               ariaDescription={ariaDescription}
               ariaTitle={ariaTitle}
               borderRadius={borderRadius}

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence } from 'framer-motion'
-import type { BorderRadius, ColorSchemes, PaletteColor, ZIndex } from '../theme'
+import type { BorderRadius, ColorSchemes, Overflow, PaletteColor, ZIndex } from '../theme'
 import type { DialogSize } from './Dialog.styled'
 import { DialogContent, DialogOverlay } from './Dialog.styled'
 
@@ -25,8 +25,8 @@ export type DialogProps = {
   showCloseButton?: boolean
   size?: DialogSize
   triggerNode?: React.ReactNode
-  overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto'
-  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto'
+  overflowX?: Overflow
+  overflowY?: Overflow
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
 }

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -6,7 +6,7 @@ import { OverflowProps } from 'styled-system'
 import * as Dialog from '@radix-ui/react-dialog'
 import React, { useEffect } from 'react'
 
-export type DialogProps = OverflowProps & {
+export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   ariaDescription: string
   ariaTitle: string
   borderRadius?: BorderRadius

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -313,7 +313,7 @@ export const borderRadii = {
 }
 
 export type BorderRadius = keyof typeof borderRadii
-
+export type Overflow = 'visible' | 'hidden' | 'scroll' | 'auto' | 'clip'
 export const maxContainerWidth = '1280px'
 
 export const shadows = {

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -313,7 +313,6 @@ export const borderRadii = {
 }
 
 export type BorderRadius = keyof typeof borderRadii
-export type Overflow = 'visible' | 'hidden' | 'scroll' | 'auto' | 'clip'
 export const maxContainerWidth = '1280px'
 
 export const shadows = {


### PR DESCRIPTION
Ticket: https://priceline.atlassian.net/browse/SITE-22333

As per the discussion from DS guild on Friday this PR adds an overflowX & overflowY Control to the dialog while also not losing functionality.  

I changed the overflow on one of the containers in devtools within NL to confirm the change that was needed. Screenshot here: 
![Screenshot 2024-01-16 at 3 35 46 PM](https://github.com/priceline/design-system/assets/25209141/a73cf6c0-a57b-4249-aeee-8bb64ecdc03e)

Attached is the dialog without devtools changes using controls in storybook: DEFAULT
![Screenshot 2024-01-16 at 3 43 33 PM](https://github.com/priceline/design-system/assets/25209141/97b8f54e-415a-4d26-b385-e8bed5955992)

OverflowX & Y set to visible: 
![Screenshot 2024-01-16 at 3 46 46 PM](https://github.com/priceline/design-system/assets/25209141/87667af6-3c7e-4cfe-9ed4-f8cdcb532812)

One unintended addition of adding overflowX is that the scrollbar when overflowX="visible" is not rounded. 


Unfortunately with the DSV6 upgrade we will not be able to implement this change at this exact moment - but once Next-landing is migrated we will pick the effort back up. 


