### PR TITLE
fix(UXPT-6159): Storybook Build with TurboSnap Disabled

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,4 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import turbosnap from 'vite-plugin-turbosnap'
+import { mergeConfig } from 'vite'
 
 const packagesWithStories = [
   'carousel',
@@ -31,6 +33,19 @@ const config: StorybookConfig = {
   stories,
   typescript: {
     check: false,
+  },
+  async viteFinal(config, { configType }) {
+    return mergeConfig(config, {
+      plugins:
+        configType === 'PRODUCTION'
+          ? [
+              turbosnap({
+                // This should be the base path of your storybook.  In monorepos, you may only need process.cwd().
+                rootDir: config.root ?? process.cwd(),
+              }),
+            ]
+          : [],
+    })
   },
 }
 

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -51,6 +51,7 @@
     "storybook": "^7.6.4",
     "styled-components": "^5.3.11",
     "typescript": "^5.3.3",
-    "vite": "^4.5.1"
+    "vite": "^4.5.1",
+    "vite-plugin-turbosnap": "^1.0.3"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: ^4.5.1
         version: 4.5.1
+      vite-plugin-turbosnap:
+        specifier: ^1.0.3
+        version: 1.0.3
 
   ../../packages/autocomplete:
     dependencies:
@@ -16139,6 +16142,10 @@ packages:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite-plugin-turbosnap@1.0.3:
+    resolution: {integrity: sha512-p4D8CFVhZS412SyQX125qxyzOgIFouwOcvjZWk6bQbNPR1wtaEzFT6jZxAjf1dejlGqa6fqHcuCvQea6EWUkUA==}
     dev: true
 
   /vite@4.5.1:


### PR DESCRIPTION
### Before: 
https://github.com/priceline/design-system/actions/runs/7559225507/job/20582564930?pr=1436#step:7:354
<img width="560" alt="Screenshot 2024-01-18 at 11 06 07 AM" src="https://github.com/priceline/design-system/assets/18338545/1c8b737e-d7ae-407e-b424-4fcbedf49db4">

### After
https://github.com/priceline/design-system/actions/runs/7561952594/job/20591337985?pr=1437#step:7:410
<img width="794" alt="Screenshot 2024-01-18 at 11 08 12 AM" src="https://github.com/priceline/design-system/assets/18338545/f3616177-5047-4238-8b57-a0c08e39d5c8">

### Note: 

The **before** message shows that the flag `--webpack-stats-json` is needed, but only for [Storybook 6.3](https://www.chromatic.com/docs/turbosnap/#prebuilt-storybook), we're on 7, so I observed locally that the `preview-stats.json` generates without this flag.  

