### PR TITLE
fix(AIR-60631): update accordion shadow state for open

### DIFF
--- a/common/changes/pcln-design-system/AIR-60631_2024-01-24-20-07.json
+++ b/common/changes/pcln-design-system/AIR-60631_2024-01-24-20-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "update accordion shadow state for open",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -101,7 +101,9 @@ export const Ladder = {
   ),
 }
 
-export const Card = {
+export const Card = { render: (args) => <Accordion {...args} items={items} variation='card' /> }
+
+export const DefaultStateCard = {
   render: (args) => <Accordion {...args} items={items} variation='card' itemsState={['item-1', 'item-2']} />,
 }
 

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -103,7 +103,7 @@ export const Ladder = {
 
 export const Card = { render: (args) => <Accordion {...args} items={items} variation='card' /> }
 
-export const DefaultStateCard = {
+export const ItemStatePropCard = {
   render: (args) => <Accordion {...args} items={items} variation='card' itemsState={['item-1', 'item-2']} />,
 }
 

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -100,7 +100,18 @@ export const Ladder = {
     />
   ),
 }
-export const Card = { render: (args) => <Accordion {...args} items={items} variation='card' /> }
+
+export const Card = {
+  render: (args) => (
+    <Accordion
+      {...args}
+      items={items}
+      variation='card'
+      itemsState={['item-1', 'item-2']}
+      isExternallyControlled={true}
+    />
+  ),
+}
 
 export const FlatCard = { render: (args) => <Accordion {...args} items={items} variation='flatCard' /> }
 

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -102,15 +102,7 @@ export const Ladder = {
 }
 
 export const Card = {
-  render: (args) => (
-    <Accordion
-      {...args}
-      items={items}
-      variation='card'
-      itemsState={['item-1', 'item-2']}
-      isExternallyControlled={true}
-    />
-  ),
+  render: (args) => <Accordion {...args} items={items} variation='card' itemsState={['item-1', 'item-2']} />,
 }
 
 export const FlatCard = { render: (args) => <Accordion {...args} items={items} variation='flatCard' /> }

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -158,7 +158,6 @@ export const StyledItem = styled(Box)<IStyledItem>`
         ? `border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;`
         : ''}
-    box-shadow: ${(props) =>
-      props.variation === 'card' || props.variation === 'flatCard' ? themeGet('shadows.sm') : ''};
+    box-shadow: ${(props) => (['card', 'flatCard'].includes(props.variation) ? themeGet('shadows.sm') : '')};
   }
 `

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -127,7 +127,6 @@ export interface IStyledItem {
 }
 
 export const StyledItem = styled(Box)<IStyledItem>`
-  box-shadow: ${(props) => (props.variation === 'card' ? themeGet('shadows.sm') : '')};
   ${(props) =>
     props.variation === 'default' ? `background-color: ${getPaletteColor('background.light')(props)};` : ''}
   ${(props) =>
@@ -148,8 +147,10 @@ export const StyledItem = styled(Box)<IStyledItem>`
       : ''}
   &[data-state='open'],
   &:hover {
-    box-shadow: ${(props) =>
-      props.variation === 'card' || props.variation === 'flatCard' ? themeGet('shadows.xl') : ''};
+    ${(props) =>
+      props.variation === 'card' || props.variation === 'flatCard'
+        ? `border: solid 1px ${getPaletteColor('border.base')(props)}`
+        : ''}
   }
   &[data-state='closed'] {
     ${(props) =>
@@ -157,5 +158,7 @@ export const StyledItem = styled(Box)<IStyledItem>`
         ? `border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;`
         : ''}
+    box-shadow: ${(props) =>
+      props.variation === 'card' || props.variation === 'flatCard' ? themeGet('shadows.sm') : ''};
   }
 `

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -126,10 +126,6 @@ export interface IStyledItem {
   headerDividerColor?: string
 }
 
-// hover & open -- no shadow, border
-// open - border, no shadow
-// hover & close - xl shadow, no border
-// close - sm shadow, no border
 export const StyledItem = styled(Box)<IStyledItem>`
   ${(props) => (['card', 'flatCard'].includes(props.variation) ? 'border: solid 1px transparent;' : '')}
   ${(props) =>
@@ -150,28 +146,41 @@ export const StyledItem = styled(Box)<IStyledItem>`
         border-radius: 0px; margin-bottom: 0px;
         `
       : ''}
-  &[data-state='open'] {
-    border-color: ${(props) => getPaletteColor('border.base')(props)};
-    box-shadow: none;
 
-    &:hover {
-      box-shadow: none;
-      border-color: ${(props) => getPaletteColor('border.base')(props)};
-    }
+  &[data-state='open'],
+  &:hover {
+    ${(props) =>
+      ['card', 'flatCard'].includes(props.variation)
+        ? `
+        border-color: ${getPaletteColor('border.base')(props)};
+        box-shadow: none;
+        `
+        : ''}
   }
+
   &[data-state='closed'] {
     ${(props) =>
       props.variation === 'underline'
-        ? `border-bottom-left-radius: 0px;
-    border-bottom-right-radius: 0px;`
+        ? `
+          border-bottom-left-radius: 0px;
+          border-bottom-right-radius: 0px;`
         : ''}
-    box-shadow: ${(props) => (['card', 'flatCard'].includes(props.variation) ? themeGet('shadows.sm') : '')};
-    border-color: transparent;
-
+    ${(props) =>
+      ['card', 'flatCard'].includes(props.variation)
+        ? `
+          box-shadow: ${themeGet('shadows.sm')(props)}; 
+          border-color: transparent;
+        `
+        : ''}
+    
     &:hover {
-      box-shadow: ${(props) =>
-        ['card', 'flatCard'].includes(props.variation) ? themeGet('shadows.xl') : ''};
-      border-color: red;
+      ${(props) =>
+        ['card', 'flatCard'].includes(props.variation)
+          ? `
+            box-shadow: ${themeGet('shadows.xl')(props)};
+            border-color: transparent;
+          `
+          : ''}
     }
   }
 `

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -166,7 +166,7 @@ export const StyledItem = styled(Box)<IStyledItem>`
           border-bottom-right-radius: 0px;`
         : ''}
     ${(props) =>
-      ['card', 'flatCard'].includes(props.variation)
+      ['card'].includes(props.variation)
         ? `
           box-shadow: ${themeGet('shadows.sm')(props)}; 
           border-color: transparent;

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -126,7 +126,12 @@ export interface IStyledItem {
   headerDividerColor?: string
 }
 
+// hover & open -- no shadow, border
+// open - border, no shadow
+// hover & close - xl shadow, no border
+// close - sm shadow, no border
 export const StyledItem = styled(Box)<IStyledItem>`
+  ${(props) => (['card', 'flatCard'].includes(props.variation) ? 'border: solid 1px transparent;' : '')}
   ${(props) =>
     props.variation === 'default' ? `background-color: ${getPaletteColor('background.light')(props)};` : ''}
   ${(props) =>
@@ -145,12 +150,14 @@ export const StyledItem = styled(Box)<IStyledItem>`
         border-radius: 0px; margin-bottom: 0px;
         `
       : ''}
-  &[data-state='open'],
-  &:hover {
-    ${(props) =>
-      props.variation === 'card' || props.variation === 'flatCard'
-        ? `border: solid 1px ${getPaletteColor('border.base')(props)}`
-        : ''}
+  &[data-state='open'] {
+    border-color: ${(props) => getPaletteColor('border.base')(props)};
+    box-shadow: none;
+
+    &:hover {
+      box-shadow: none;
+      border-color: ${(props) => getPaletteColor('border.base')(props)};
+    }
   }
   &[data-state='closed'] {
     ${(props) =>
@@ -159,5 +166,12 @@ export const StyledItem = styled(Box)<IStyledItem>`
     border-bottom-right-radius: 0px;`
         : ''}
     box-shadow: ${(props) => (['card', 'flatCard'].includes(props.variation) ? themeGet('shadows.sm') : '')};
+    border-color: transparent;
+
+    &:hover {
+      box-shadow: ${(props) =>
+        ['card', 'flatCard'].includes(props.variation) ? themeGet('shadows.xl') : ''};
+      border-color: red;
+    }
   }
 `

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -65,9 +65,6 @@ export function Accordion({
             headerBg={child.headerBg}
             data-testid={`styled-item-${child.value}`}
             headerDividerColor={index > 0 && headerDividerColor}
-            boxShadowSize={
-              itemsState === child.value && ['card', 'flatCard'].includes(variation) ? 'xl' : undefined
-            }
           >
             <StyledTrigger {...props} p={p} variation={variation}>
               <Flex width='100%' justifyContent='space-between' alignItems='center'>

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -65,6 +65,9 @@ export function Accordion({
             headerBg={child.headerBg}
             data-testid={`styled-item-${child.value}`}
             headerDividerColor={index > 0 && headerDividerColor}
+            boxShadowSize={
+              itemsState === child.value && ['card', 'flatCard'].includes(variation) ? 'xl' : undefined
+            }
           >
             <StyledTrigger {...props} p={p} variation={variation}>
               <Flex width='100%' justifyContent='space-between' alignItems='center'>


### PR DESCRIPTION
When card or flatCard variant  closed no changes are needed, when open both would have no shadow and use the border of 1px and color border.base.