### PR TITLE
[UXPT]: create stories for dialog use cases

### DIFF
--- a/common/changes/pcln-design-system/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
+++ b/common/changes/pcln-design-system/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Created stories for Menu, Popover, and Tooltip in a Dialog",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-menu/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
+++ b/common/changes/pcln-menu/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Created story for a Menu inside a Dialog",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/common/changes/pcln-popover/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
+++ b/common/changes/pcln-popover/UXPT-6348-fix-dialog-trapFocus_2024-02-07-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Created story for a Popover inside a Dialog",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -12,7 +12,6 @@ import { Dialog, type DialogProps } from './Dialog'
 import { argTypes, defaultArgs } from './Dialog.stories.args'
 import { Flex } from '../Flex/Flex'
 import { Tooltip } from '../Tooltip/Tooltip'
-import { text } from 'stream/consumers'
 
 type DialogStory = StoryObj<DialogProps>
 
@@ -95,12 +94,11 @@ export const WithHeaderContentProps: DialogStory = {
 export const WithTooltip: DialogStory = {
   ...Playground,
   args: {
-   children: (
-      <Box width={300} p={2} my={2}>
+    children: (
+      <Box width={400} p={2} my={2} height={200}>
         <Tooltip bottom center color='primary'>
           top center tooltip
         </Tooltip>
-        <div>some text in a dialog</div>
       </Box>
     )
   }

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -11,6 +11,8 @@ import { Text } from '../Text/Text'
 import { Dialog, type DialogProps } from './Dialog'
 import { argTypes, defaultArgs } from './Dialog.stories.args'
 import { Flex } from '../Flex/Flex'
+import { Tooltip } from '../Tooltip/Tooltip'
+import { text } from 'stream/consumers'
 
 type DialogStory = StoryObj<DialogProps>
 
@@ -89,6 +91,21 @@ export const WithHeaderContentProps: DialogStory = {
     headerColorScheme: 'neutralDarkOnLightest',
   },
 }
+
+export const WithTooltip: DialogStory = {
+  ...Playground,
+  args: {
+   children: (
+      <Box width={300} p={2} my={2}>
+        <Tooltip bottom center color='primary'>
+          top center tooltip
+        </Tooltip>
+        <div>some text in a dialog</div>
+      </Box>
+    )
+  }
+}
+
 
 const ExampleImage = () => (
   <img

--- a/packages/core/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/Tooltip/Tooltip.stories.tsx
@@ -9,6 +9,7 @@ import { Label } from '../Label/Label'
 import { colorSchemeNames } from '../storybook/args'
 import { Tooltip } from './Tooltip'
 import { argTypes } from './Tooltip.stories.args'
+import { Dialog } from '../Dialog/Dialog'
 
 const FlexColumn = styled(Flex)`
   flex-direction: column;
@@ -148,6 +149,17 @@ export const WithAnchors = () => (
       </FormField>
     </Box>
   </FlexColumn>
+)
+
+export const InDialogWithAnchors = () => (
+  <Dialog open size='md'>
+    <Box width={300} p={2} my={2}>
+      <Tooltip bottom center color='primary'>
+        top center tooltip
+      </Tooltip>
+      <div>some text in a dialog</div>
+    </Box>
+  </Dialog>
 )
 
 const ColorSchemesTemplate = () => {

--- a/packages/core/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/Tooltip/Tooltip.stories.tsx
@@ -9,7 +9,6 @@ import { Label } from '../Label/Label'
 import { colorSchemeNames } from '../storybook/args'
 import { Tooltip } from './Tooltip'
 import { argTypes } from './Tooltip.stories.args'
-import { Dialog } from '../Dialog/Dialog'
 
 const FlexColumn = styled(Flex)`
   flex-direction: column;
@@ -149,17 +148,6 @@ export const WithAnchors = () => (
       </FormField>
     </Box>
   </FlexColumn>
-)
-
-export const InDialogWithAnchors = () => (
-  <Dialog open size='md'>
-    <Box width={300} p={2} my={2}>
-      <Tooltip bottom center color='primary'>
-        top center tooltip
-      </Tooltip>
-      <div>some text in a dialog</div>
-    </Box>
-  </Dialog>
 )
 
 const ColorSchemesTemplate = () => {

--- a/packages/menu/src/Menu/Menu.stories.jsx
+++ b/packages/menu/src/Menu/Menu.stories.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { argTypes, defaultArgs } from './Menu.stories.args'
 import { Bed as BedIcon } from 'pcln-icons'
-import { Box, ButtonChip, Divider, Flex, Link, Text } from 'pcln-design-system'
+import { Box, ButtonChip, Dialog, Divider, Flex, Link, Text } from 'pcln-design-system'
 import { listItems, currencies } from '../../test/mocks/Menu'
 import Menu from './Menu'
 import MenuItem from '../MenuItem'
@@ -191,6 +191,14 @@ export const UsingButtonPropsPropForStylingButtonText = () => (
   >
     <MenuItems />
   </Menu>
+)
+
+export const InDialog = () => (
+  <Dialog open size='md'>
+    <Menu width={300} buttonText='Menu'>
+      <MenuItems />
+    </Menu>
+  </Dialog>
 )
 
 export const CustomMenuWithoutMenuItems = () => {

--- a/packages/menu/src/Menu/Menu.stories.jsx
+++ b/packages/menu/src/Menu/Menu.stories.jsx
@@ -196,7 +196,7 @@ export const UsingButtonPropsPropForStylingButtonText = () => (
 
 export const InDialog = {
   render: () => (
-    <Dialog size='md' triggerNode={<Button>Open Menu</Button>}>
+    <Dialog size='md' triggerNode={<Button>Open Dialog</Button>}>
       <Box height={200} p={4}>
         <Menu width={300} buttonText='Menu'>
           <MenuItems />
@@ -206,7 +206,7 @@ export const InDialog = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    const openButton = canvas.getByText('Open Menu')
+    const openButton = canvas.getByText('Open Dialog')
     await userEvent.click(openButton)
   },
 }

--- a/packages/menu/src/Menu/Menu.stories.jsx
+++ b/packages/menu/src/Menu/Menu.stories.jsx
@@ -195,9 +195,11 @@ export const UsingButtonPropsPropForStylingButtonText = () => (
 
 export const InDialog = () => (
   <Dialog open size='md'>
-    <Menu width={300} buttonText='Menu'>
-      <MenuItems />
-    </Menu>
+    <Box height={200} p={4}>
+      <Menu width={300} buttonText='Menu'>
+        <MenuItems />
+      </Menu>
+    </Box>
   </Dialog>
 )
 

--- a/packages/menu/src/Menu/Menu.stories.jsx
+++ b/packages/menu/src/Menu/Menu.stories.jsx
@@ -1,7 +1,8 @@
+import { userEvent, within } from '@storybook/testing-library'
 import React, { useState } from 'react'
 import { argTypes, defaultArgs } from './Menu.stories.args'
 import { Bed as BedIcon } from 'pcln-icons'
-import { Box, ButtonChip, Dialog, Divider, Flex, Link, Text } from 'pcln-design-system'
+import { Box, Button, ButtonChip, Dialog, Divider, Flex, Link, Text } from 'pcln-design-system'
 import { listItems, currencies } from '../../test/mocks/Menu'
 import Menu from './Menu'
 import MenuItem from '../MenuItem'
@@ -193,15 +194,22 @@ export const UsingButtonPropsPropForStylingButtonText = () => (
   </Menu>
 )
 
-export const InDialog = () => (
-  <Dialog open size='md'>
-    <Box height={200} p={4}>
-      <Menu width={300} buttonText='Menu'>
-        <MenuItems />
-      </Menu>
-    </Box>
-  </Dialog>
-)
+export const InDialog = {
+  render: () => (
+    <Dialog size='md' triggerNode={<Button>Open Menu</Button>}>
+      <Box height={200} p={4}>
+        <Menu width={300} buttonText='Menu'>
+          <MenuItems />
+        </Menu>
+      </Box>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const openButton = canvas.getByText('Open Menu')
+    await userEvent.click(openButton)
+  },
+}
 
 export const CustomMenuWithoutMenuItems = () => {
   return (

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -142,13 +142,7 @@ export const bottom = () => (
 export const InDialog = () => (
   <Dialog open size='md' zIndex={0}>
     <Box height={300}>
-      <Popover
-        renderContent={SimpleTextContent}
-        placement='bottom'
-        ariaLabel='Dialog Popover'
-        idx={2}
-        width={400}
-      >
+      <Popover renderContent={InnerContent} placement='bottom' ariaLabel='Dialog Popover' idx={2} width={400}>
         <Button m={3}>Open Popover</Button>
       </Popover>
     </Box>

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   CloseButton,
+  Dialog,
   FilterChip,
   Flex,
   IconButton,
@@ -136,6 +137,20 @@ export const bottom = () => (
   <Popover renderContent={InnerContent} placement='bottom' ariaLabel='Bottom Popover' idx={2} width={400}>
     <Link m={3}>Open Popover</Link>
   </Popover>
+)
+
+export const InDialog = () => (
+  <Dialog open size='md'>
+    <Popover
+      renderContent={SimpleTextContent}
+      placement='bottom'
+      ariaLabel='Dialog Popover'
+      idx={2}
+      width={400}
+    >
+      <Link m={3}>Open Popover</Link>
+    </Popover>
+  </Dialog>
 )
 
 export const hideOverlay = () => (

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -140,7 +140,7 @@ export const bottom = () => (
 )
 
 export const InDialog = () => (
-  <Dialog open size='md' zIndex={0}>
+  <Dialog triggerNode={<Button>Open Dialog</Button>} size='md' zIndex={0}>
     <Box height={300}>
       <Popover renderContent={InnerContent} placement='bottom' ariaLabel='Dialog Popover' idx={2} width={400}>
         <Button m={3}>Open Popover</Button>

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -140,16 +140,18 @@ export const bottom = () => (
 )
 
 export const InDialog = () => (
-  <Dialog open size='md'>
-    <Popover
-      renderContent={SimpleTextContent}
-      placement='bottom'
-      ariaLabel='Dialog Popover'
-      idx={2}
-      width={400}
-    >
-      <Link m={3}>Open Popover</Link>
-    </Popover>
+  <Dialog open size='md' zIndex={0}>
+    <Box height={300}>
+      <Popover
+        renderContent={SimpleTextContent}
+        placement='bottom'
+        ariaLabel='Dialog Popover'
+        idx={2}
+        width={400}
+      >
+        <Button m={3}>Open Popover</Button>
+      </Popover>
+    </Box>
   </Dialog>
 )
 


### PR DESCRIPTION
Recently found issues with focus trap when placing a menu/popover in a Dialog component.

Created some simple stories to test focus trap for simple cases for a menu, popover, and tooltip inside a Dialog.

## Screenshots

### Menu
<img width="778" alt="image" src="https://github.com/priceline/design-system/assets/156821810/cbba509c-de23-4a4d-bfed-143e4f8264fa">

### Popover
<img width="674" alt="image" src="https://github.com/priceline/design-system/assets/156821810/78ca676e-8ec2-48a9-805b-4417e19edae9">

### Tooltip
<img width="666" alt="image" src="https://github.com/priceline/design-system/assets/156821810/394ebddf-a0d7-410d-a089-8be1fa834200">
