### PR TITLE
ToastProvider: update to allow animations to come in from the top

### DIFF
--- a/common/changes/pcln-design-system/toast-provider-top-animation_2024-02-07-21-23.json
+++ b/common/changes/pcln-design-system/toast-provider-top-animation_2024-02-07-21-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "ToastProvider: update to allow animations to come in from the top",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Animate/Animate.tsx
+++ b/packages/core/src/Animate/Animate.tsx
@@ -31,6 +31,8 @@ export type MotionVariant =
   | 'scaleOnTap'
   | 'slideOutLeft'
   | 'slideInLeft'
+  | 'slideInTop'
+  | 'slideOutTop'
 
 /**
  * @public
@@ -78,6 +80,14 @@ export const MotionVariants: Record<MotionVariant, HTMLMotionProps<'div'>> = {
   slideInLeft: {
     initial: { opacity: 0, x: '-100%' },
     animate: { opacity: 1, x: 0 },
+  },
+  slideInTop: {
+    initial: { opacity: 0, y: '-100%' },
+    animate: { opacity: 1, y: 0 },
+  },
+  slideOutTop: {
+    initial: { opacity: 1, y: 0 },
+    animate: { opacity: 0, y: '-100%' },
   },
 }
 

--- a/packages/core/src/ToastProvider/ToastProvider.spec.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.spec.tsx
@@ -66,7 +66,7 @@ describe('ToastProvider', () => {
 
   it('renders a custom toast', () => {
     render(
-      <ToastProvider enterAnimation='scaleFromCenter' exitAnimation='expandDown'>
+      <ToastProvider enterAnimation='scaleFromCenter' exitAnimation='expandDown' top={20}>
         <MockToastChildren variation='fill' />
       </ToastProvider>
     )

--- a/packages/core/src/ToastProvider/ToastProvider.stories.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.stories.tsx
@@ -24,3 +24,14 @@ const Template = (args) => (
 )
 
 export const _ToastProvider = Template.bind({})
+
+export const TopAnimation = (args) => (
+  <ToastProvider
+    domRootId='ToastProviderRoot'
+    top={20}
+    enterAnimation='slideInTop'
+    exitAnimation='slideOutTop'
+  >
+    <MockToastChildren variation={args.variation} />
+  </ToastProvider>
+)

--- a/packages/core/src/ToastProvider/ToastProvider.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.tsx
@@ -95,7 +95,7 @@ function _ToastProvider({
       {children}
       {createPortal(
         <ThemeProvider theme={theme}>
-          <ClickthroughAbsolute top={top ? top : undefined} bottom={bottom ? bottom : undefined} width='100%'>
+          <ClickthroughAbsolute top={top ? top : undefined} bottom={top ? undefined : bottom} width='100%'>
             <Flex justifyContent='center' width='100%'>
               <Flex flexDirection='column-reverse' justifyContent='center' minWidth='300px'>
                 {toastsToRender.map((toast) => {

--- a/packages/core/src/ToastProvider/ToastProvider.tsx
+++ b/packages/core/src/ToastProvider/ToastProvider.tsx
@@ -49,6 +49,8 @@ export type ToastProviderProps = {
   lifespan?: number
   maxToasts?: number
   theme: unknown
+  top?: number
+  bottom?: number
 }
 
 let id = 0
@@ -61,6 +63,8 @@ function _ToastProvider({
   lifespan,
   maxToasts = 3,
   theme,
+  bottom = 20,
+  top,
 }: ToastProviderProps) {
   const [toasts, setToasts] = useState<ToastOptions[]>([])
 
@@ -91,7 +95,7 @@ function _ToastProvider({
       {children}
       {createPortal(
         <ThemeProvider theme={theme}>
-          <ClickthroughAbsolute bottom={20} width='100%'>
+          <ClickthroughAbsolute top={top ? top : undefined} bottom={bottom ? bottom : undefined} width='100%'>
             <Flex justifyContent='center' width='100%'>
               <Flex flexDirection='column-reverse' justifyContent='center' minWidth='300px'>
                 {toastsToRender.map((toast) => {


### PR DESCRIPTION
- Update the `ToastProvider` to allow users to specify **top** or **bottom** positioning of the `Toast`. This will default to `bottom: 20` and `top: undefined`
- Update the `Animate` to add in 2 new options: **slideInTop** and **slideOutTop**