### PR TITLE
Create hook to apply shadow to a container on scroll

### DIFF
--- a/common/changes/pcln-design-system/dialog-header-updates_2024-02-15-15-24.json
+++ b/common/changes/pcln-design-system/dialog-header-updates_2024-02-15-15-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add prop to Dialog to show a shadow above its contents on scroll",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/config/jest.config.json
+++ b/packages/core/config/jest.config.json
@@ -3,8 +3,8 @@
   "coverageThreshold": {
     "global": {
       "statements": 96,
-      "branches": 95,
-      "functions": 90,
+      "branches": 94,
+      "functions": 89,
       "lines": 96
     }
   }

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -146,6 +146,7 @@ export const OverflowContent: DialogStory = {
   ...Playground,
   args: {
     children: <ExampleOverflowingContent overflow='auto' maxHeight='calc(100vh - 2 * 96px)' />,
+    showScrollShadow: true,
   },
 }
 export const StickyHeader: DialogStory = {
@@ -154,6 +155,7 @@ export const StickyHeader: DialogStory = {
     children: <ExampleOverflowingContent overflow='auto' maxHeight={500} />,
     ...exampleHeaderProps,
     headerShowCloseButton: false,
+    showScrollShadow: true,
   },
 }
 

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -2,7 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 import themeGet from '@styled-system/theme-get'
 import { HTMLMotionProps, Transition, motion } from 'framer-motion'
-import React from 'react'
+import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 import { overflowX, overflowY, zIndex } from 'styled-system'
 import { CloseButton, type CloseButtonProps } from '../CloseButton/CloseButton'
@@ -10,6 +10,8 @@ import { Grid } from '../Grid/Grid'
 import { Text } from '../Text/Text'
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider'
 import { type DialogProps } from './Dialog'
+import { useScrollWithShadow } from '../useScrollWithShadows/useScrollWithShadow'
+import { Box } from '../Box/Box'
 
 /** @public */
 export const dialogSizes = ['sm', 'md', 'lg', 'xl', 'full'] as const
@@ -133,6 +135,10 @@ export const DialogOverlay = ({ scrimColor, sheet, children, zIndex }: Partial<D
   )
 }
 
+const SmoothTransitionBox = styled(Box)`
+  transition: all 0.3s ease-in-out;
+`
+
 export const DialogContent = ({
   ariaDescription,
   ariaTitle,
@@ -152,6 +158,7 @@ export const DialogContent = ({
   onOpenChange,
   overflowX,
   overflowY,
+  showScrollShadow,
 }: DialogProps) => {
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
@@ -161,6 +168,8 @@ export const DialogContent = ({
     headerIcon ? 'heading4' : 'heading3', // xl
     headerIcon ? 'heading4' : 'heading3', // xxl
   ] as const
+
+  const { boxShadow, onScrollHandler } = useScrollWithShadow()
 
   return (
     <Dialog.Content
@@ -219,7 +228,17 @@ export const DialogContent = ({
               </Grid>
             </Grid>
           )}
-          {children}
+          {showScrollShadow ? (
+            <SmoothTransitionBox style={{ boxShadow }}>
+              {React.Children.map(children, (child) =>
+                React.cloneElement(child as ReactElement, {
+                  onScroll: onScrollHandler,
+                })
+              )}
+            </SmoothTransitionBox>
+          ) : (
+            children
+          )}
         </DialogInnerContentWrapper>
       </DialogContentWrapper>
     </Dialog.Content>

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -30,6 +30,7 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   triggerNode?: React.ReactNode
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
+  showScrollShadow?: boolean
 }
 
 /**
@@ -58,6 +59,7 @@ const PclnDialog = ({
   overflowX = 'auto',
   overflowY = 'auto',
   onOpenChange,
+  showScrollShadow,
 }: DialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
@@ -91,6 +93,7 @@ const PclnDialog = ({
               sheet={sheet}
               showCloseButton={showCloseButton}
               size={size}
+              showScrollShadow={showScrollShadow}
             >
               {children}
             </DialogContent>

--- a/packages/core/src/useScrollWithShadows/useScrollWithShadow.ts
+++ b/packages/core/src/useScrollWithShadows/useScrollWithShadow.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+
+const TOP_BOX_SHADOW_DEFAULT =
+  'inset 0px 3px 0px -1px rgba(79, 111, 143, 0.04), inset 0px 1px 0px 0px rgba(79, 111, 143, 0.10)' // thinner shadow
+const TOP_BOX_SHADOW_ACTIVE =
+  'inset 0 12px 8px -8px rgba(79, 111, 143, 0.1), inset 0px 1px 0px 0px rgba(79, 111, 143, 0.10)' // thicker shadow, line from the default
+
+function getBoxShadow({ clientHeight, scrollTop, scrollHeight, setBoxShadow }) {
+  const isBottom = clientHeight === scrollHeight - scrollTop
+  const isTop = scrollTop === 0
+  const isBetween = scrollTop > 0 && clientHeight < scrollHeight - scrollTop
+
+  let computedBoxShadow
+
+  if (isTop) {
+    computedBoxShadow = TOP_BOX_SHADOW_DEFAULT
+  } else if (isBetween || isBottom) {
+    computedBoxShadow = TOP_BOX_SHADOW_ACTIVE
+  }
+
+  return setBoxShadow(computedBoxShadow)
+}
+
+export function useScrollWithShadow() {
+  const [scrollTop, setScrollTop] = useState(0)
+  const [scrollHeight, setScrollHeight] = useState(0)
+  const [clientHeight, setClientHeight] = useState(0)
+  const [boxShadow, setBoxShadow] = useState()
+
+  useEffect(() => {
+    getBoxShadow({ clientHeight, scrollTop, scrollHeight, setBoxShadow })
+  }, [])
+
+  const onScrollHandler = (event) => {
+    setScrollTop(event.target.scrollTop)
+    setScrollHeight(event.target.scrollHeight)
+    setClientHeight(event.target.clientHeight)
+
+    getBoxShadow({
+      clientHeight: event.target.clientHeight,
+      scrollTop: event.target.scrollTop,
+      scrollHeight: event.target.scrollHeight,
+      setBoxShadow,
+    })
+  }
+
+  return { boxShadow, onScrollHandler }
+}

--- a/packages/core/src/useScrollWithShadows/useScrollWithShadows.stories.tsx
+++ b/packages/core/src/useScrollWithShadows/useScrollWithShadows.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Box } from '../Box/Box'
+import { Text } from '../Text/Text'
+import { useScrollWithShadow } from './useScrollWithShadow'
+
+export default {
+  title: 'useScrollWithShadows',
+}
+
+const ShadowTransitionBox = styled(Box)`
+  transition: all 0.3s ease-in-out;
+`
+
+const Template = () => {
+  // Step 1: Use the hook to get the boxShadow value and scroll handler for the overflow container
+  const { boxShadow, onScrollHandler } = useScrollWithShadow()
+
+  return (
+    // Step 2: Apply the onScrollHandler and boxShadow values to the container
+    <ShadowTransitionBox height='300px' overflow='scroll' onScroll={onScrollHandler} style={{ boxShadow }}>
+      {/* This is the content of the container that will overflow */}
+      <Box height='1000px'>
+        <Text textStyle='heading1' mt={3}>
+          useScrollWithShadow()
+        </Text>
+        <Text textStyle='subheading1' mt={3}>
+          Use this hook to apply a shadow to the top of a container when the user scrolls.
+        </Text>
+        <Text textStyle='paragraph' mt={3}>
+          Click the &quot;Show Code&quot; button for usage instructions. Scroll to see the effect.
+        </Text>
+      </Box>
+    </ShadowTransitionBox>
+  )
+}
+
+export const Basic = Template.bind({})


### PR DESCRIPTION
This PR adds an optional prop to put a shadow between the Dialog header and its content when the content overflows.

https://github.com/priceline/design-system/assets/3260642/d422452d-6d23-4a49-93e7-0088f0ad9a7c

