### PR TITLE
Dialog - Add footerContent section

### DIFF
--- a/common/changes/pcln-design-system/add-footer-content-to-dialog_2024-02-15-21-16.json
+++ b/common/changes/pcln-design-system/add-footer-content-to-dialog_2024-02-15-21-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add footerContent to Dialog",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.spec.tsx
+++ b/packages/core/src/Dialog/Dialog.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Dialog } from './Dialog'
 
@@ -31,6 +31,26 @@ describe('Dialog', () => {
 
     const contentNode = screen.getByText(contentText)
     expect(contentNode).toBeInTheDocument()
+  })
+
+  it('renders the dialog with footer content', async () => {
+    render(
+      <Dialog
+        triggerNode={<button>{triggerText}</button>}
+        ariaDescription='Description'
+        ariaTitle='Title'
+        footerContent={<div>Footer Content</div>}
+      >
+        {contentText}
+      </Dialog>
+    )
+
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    await waitFor(() => {
+      expect(screen.getByText('Footer Content')).toBeInTheDocument()
+    })
   })
 
   it.skip('calls onOpenChange when trigger is clicked', () => {

--- a/packages/core/src/Dialog/Dialog.stories.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.tsx
@@ -19,6 +19,10 @@ const exampleHeaderProps: Partial<DialogProps> = {
   headerShowCloseButton: true,
 }
 
+const exampleFooterProps: Partial<DialogProps> = {
+  footerContent: <Button borderRadius='lg'>Done</Button>,
+}
+
 export const Playground: DialogStory = {
   render: (args) => (
     <Box height='1000px'>
@@ -159,6 +163,17 @@ export const StickyHeader: DialogStory = {
   },
 }
 
+export const StickyFooter: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingContent overflow='auto' maxHeight={500} />,
+    ...exampleHeaderProps,
+    ...exampleFooterProps,
+    headerShowCloseButton: false,
+    showScrollShadow: true,
+  },
+}
+
 export const ScrimColors: DialogStory = {
   render: (args) => {
     const [scrimColor, setScrimColor] = useState<DialogProps['scrimColor']>('dark')
@@ -210,6 +225,17 @@ export const SheetMode: DialogStory = {
   args: {
     sheet: true,
     size: 'full',
+  },
+}
+
+export const SheetWithHeaderAndFooter: DialogStory = {
+  ...Playground,
+  args: {
+    children: <ExampleOverflowingContent />,
+    ...SheetMode.args,
+    ...exampleHeaderProps,
+    ...exampleFooterProps,
+    showScrollShadow: true,
   },
 }
 

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -107,7 +107,6 @@ const DialogInnerContentWrapper = styled.div`
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr auto;
   height: 100%;
-  overflow: scroll;
 
   ${overflowX}
   ${overflowY}
@@ -238,7 +237,7 @@ export const DialogContent = ({
             </Grid>
           )}
           {showScrollShadow ? (
-            <SmoothTransitionBox style={{ boxShadow }} height='100%'>
+            <SmoothTransitionBox style={{ boxShadow }} height='100%' onScroll={onScrollHandler}>
               {React.Children.map(children, (child) =>
                 React.cloneElement(child as ReactElement, {
                   onScroll: onScrollHandler,

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -98,10 +98,17 @@ const DialogContentWrapper = styled(motion.div)`
       ? 'none'
       : themeGet(`borderRadii.${props.borderRadius}`)(props)};
   box-shadow: ${(props: DialogProps) => themeGet('shadows.overlay-lg')(props)};
+  overflow: ${(props: DialogProps) => (props.sheet ? 'scroll' : 'visible')};
 `
 
 const DialogInnerContentWrapper = styled.div`
   position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
+  overflow: scroll;
+
   ${overflowX}
   ${overflowY}
   border-radius: ${(props: DialogProps) =>
@@ -136,6 +143,7 @@ export const DialogOverlay = ({ scrimColor, sheet, children, zIndex }: Partial<D
 }
 
 const SmoothTransitionBox = styled(Box)`
+  overflow: scroll;
   transition: all 0.3s ease-in-out;
 `
 
@@ -144,6 +152,7 @@ export const DialogContent = ({
   ariaTitle,
   borderRadius,
   children,
+  footerContent,
   fullWidth,
   headerColorScheme = 'heading',
   headerContent,
@@ -229,7 +238,7 @@ export const DialogContent = ({
             </Grid>
           )}
           {showScrollShadow ? (
-            <SmoothTransitionBox style={{ boxShadow }}>
+            <SmoothTransitionBox style={{ boxShadow }} height='100%'>
               {React.Children.map(children, (child) =>
                 React.cloneElement(child as ReactElement, {
                   onScroll: onScrollHandler,
@@ -237,7 +246,22 @@ export const DialogContent = ({
               )}
             </SmoothTransitionBox>
           ) : (
-            children
+            <Box height='100%' style={{ overflowY: 'scroll' }}>
+              {children}
+            </Box>
+          )}
+          {footerContent && (
+            <Box boxShadow={showScrollShadow ? 'lg' : 'none'} color='background.lightest'>
+              <Grid
+                px={[3, 3, 3, 3, '24px', '24px']}
+                py={3}
+                autoFlow='column'
+                templateColumns='1fr'
+                alignItems='center'
+              >
+                {footerContent}
+              </Grid>
+            </Box>
           )}
         </DialogInnerContentWrapper>
       </DialogContentWrapper>

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -15,6 +15,7 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   borderRadius?: BorderRadius
   children?: React.ReactNode
   defaultOpen?: boolean
+  footerContent?: React.ReactNode
   fullWidth?: boolean
   headerColorScheme?: keyof ColorSchemes
   headerContent?: string | React.ReactNode
@@ -42,6 +43,7 @@ const PclnDialog = ({
   borderRadius = '2xl',
   children,
   defaultOpen = false,
+  footerContent,
   fullWidth = false,
   headerColorScheme = 'heading',
   headerContent,
@@ -82,6 +84,7 @@ const PclnDialog = ({
               ariaDescription={ariaDescription}
               ariaTitle={ariaTitle}
               borderRadius={borderRadius}
+              footerContent={footerContent}
               fullWidth={fullWidth}
               headerColorScheme={headerColorScheme}
               headerContent={headerContent}


### PR DESCRIPTION
Add footerContent section to the Dialog to support DatePicker, TravelerSelection and Typeahead mobile versions.


https://github.com/priceline/design-system/assets/62619213/da30d7f9-4a26-41d5-b074-c45ab086510b

