### PR TITLE
Carousel: add in arrowsAlignment and nodeBesideArrows props

### DIFF
--- a/common/changes/pcln-carousel/feat-carousel-arrows-alignment_2024-02-20-19-41.json
+++ b/common/changes/pcln-carousel/feat-carousel-arrows-alignment_2024-02-20-19-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Carousel: add in arrowsAlignment and nodeBesideArrows props",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -13,7 +13,7 @@ import {
   getMobileVisibleSlides,
 } from './helpers'
 import { RenderInView } from './RenderInView'
-import { CAROUSEL_BREAKPOINT_1 } from './constants'
+import { CAROUSEL_BREAKPOINT_1, ARROW_MARGIN, ARROW_JUSTIFY_CONTENT } from './constants'
 
 const ChangeDetector = ({ onSlideChange }) => {
   const carouselContext = useContext(CarouselContext)
@@ -63,6 +63,8 @@ export const Carousel = ({
   displayArrowsMobile,
   buttonSize = '60px',
   showArrowsOnHover = false,
+  nodeBesideArrows,
+  arrowsAlignment = 'center',
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
   const layoutSize = layout?.split('-').length
@@ -102,7 +104,12 @@ export const Carousel = ({
       >
         <ChangeDetector onSlideChange={onSlideChange} />
         {arrowsPosition === 'top' ? (
-          <Flex justifyContent='flex-end' mb={2} mr={slideSpacing}>
+          <Flex justifyContent='flex-end' alignItems='center' mb={2} mr={slideSpacing}>
+            {nodeBesideArrows ? (
+              <Box ml={2} mr='auto'>
+                {nodeBesideArrows}
+              </Box>
+            ) : null}
             <ArrowButton type='prev' position='top' setPosition={arrowsPosition} buttonSize={buttonSize} />
             <ArrowButton
               type='next'
@@ -183,10 +190,30 @@ export const Carousel = ({
           )}
         </Relative>
         {arrowsPosition === 'bottom' || showDots ? (
-          <Flex alignItems='center' justifyContent='center' pt={2}>
-            <ArrowButton mr={3} type='prev' position='bottom' setPosition={arrowsPosition} />
+          <Flex alignItems='center' justifyContent={ARROW_JUSTIFY_CONTENT[arrowsAlignment]} pt={2}>
+            {nodeBesideArrows && arrowsAlignment === 'right' ? (
+              <Box ml={2} mr='auto'>
+                {nodeBesideArrows}
+              </Box>
+            ) : null}
+            <ArrowButton
+              mr={ARROW_MARGIN[arrowsAlignment]}
+              type='prev'
+              position='bottom'
+              setPosition={arrowsPosition}
+            />
             {showDots && <Dots />}
-            <ArrowButton ml={3} type='next' position='bottom' setPosition={arrowsPosition} />
+            <ArrowButton
+              ml={ARROW_MARGIN[arrowsAlignment]}
+              type='next'
+              position='bottom'
+              setPosition={arrowsPosition}
+            />
+            {nodeBesideArrows && arrowsAlignment === 'left' ? (
+              <Box mr={2} ml='auto'>
+                {nodeBesideArrows}
+              </Box>
+            ) : null}
           </Flex>
         ) : null}
       </CarouselProvider>
@@ -251,4 +278,8 @@ Carousel.propTypes = {
   buttonSize: PropTypes.string,
   /** When arrow position is side, hide arrows and shows when hovers on carousel */
   showArrowsOnHover: PropTypes.bool,
+  /** Node that will display beside the arrows (available if arrows are top, bottomRight or bottomLeft) */
+  nodeBesideArrows: PropTypes.node,
+  /** String "left" or "right" (only available if arrowsPosition is set to "bottom") */
+  arrowsAlignment: PropTypes.oneOf(['left', 'right', 'center']),
 }

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -63,7 +63,8 @@ export const Carousel = ({
   displayArrowsMobile,
   buttonSize = '60px',
   showArrowsOnHover = false,
-  nodeBesideArrows,
+  nodeBesideArrowsLeft,
+  nodeBesideArrowsRight,
   arrowsAlignment = 'center',
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
@@ -105,9 +106,9 @@ export const Carousel = ({
         <ChangeDetector onSlideChange={onSlideChange} />
         {arrowsPosition === 'top' ? (
           <Flex justifyContent='flex-end' alignItems='center' mb={2} mr={slideSpacing}>
-            {nodeBesideArrows ? (
+            {nodeBesideArrowsLeft ? (
               <Box ml={2} mr='auto'>
-                {nodeBesideArrows}
+                {nodeBesideArrowsLeft}
               </Box>
             ) : null}
             <ArrowButton type='prev' position='top' setPosition={arrowsPosition} buttonSize={buttonSize} />
@@ -191,9 +192,9 @@ export const Carousel = ({
         </Relative>
         {arrowsPosition === 'bottom' || showDots ? (
           <Flex alignItems='center' justifyContent={ARROW_JUSTIFY_CONTENT[arrowsAlignment]} pt={2}>
-            {nodeBesideArrows && arrowsAlignment === 'right' ? (
+            {nodeBesideArrowsLeft && arrowsAlignment === 'right' ? (
               <Box ml={2} mr='auto'>
-                {nodeBesideArrows}
+                {nodeBesideArrowsLeft}
               </Box>
             ) : null}
             <ArrowButton
@@ -209,9 +210,9 @@ export const Carousel = ({
               position='bottom'
               setPosition={arrowsPosition}
             />
-            {nodeBesideArrows && arrowsAlignment === 'left' ? (
+            {nodeBesideArrowsRight && arrowsAlignment === 'left' ? (
               <Box mr={2} ml='auto'>
-                {nodeBesideArrows}
+                {nodeBesideArrowsRight}
               </Box>
             ) : null}
           </Flex>
@@ -278,8 +279,10 @@ Carousel.propTypes = {
   buttonSize: PropTypes.string,
   /** When arrow position is side, hide arrows and shows when hovers on carousel */
   showArrowsOnHover: PropTypes.bool,
-  /** Node that will display beside the arrows (available if arrows are top, bottomRight or bottomLeft) */
-  nodeBesideArrows: PropTypes.node,
-  /** String "left" or "right" (only available if arrowsPosition is set to "bottom") */
+  /** Node that will display to the left of the arrows (available if arrows are top, bottom-right) */
+  nodeBesideArrowsLeft: PropTypes.node,
+  /** Node that will display to the left of the arrows (availalbe if arrows are bottom-left) */
+  nodeBesideArrowsRight: PropTypes.node,
+  /** String "left" or "right" or "center" (only available if arrowsPosition is set to "bottom") */
   arrowsAlignment: PropTypes.oneOf(['left', 'right', 'center']),
 }

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -140,4 +140,22 @@ describe('Carousel', () => {
     )
     expect(queryByText('Hello')).not.toBeInTheDocument()
   })
+
+  it('Should render the nodeBesideArrowsRight when arrow right aligment bottom', () => {
+    window.innerWidth = 1400
+    const { getByText } = render(
+      <Carousel
+        layout='50-50'
+        arrowsPosition='bottom'
+        arrowsAlignment='left'
+        currentSlide={1}
+        nodeBesideArrowsRight={<Badge>Hello</Badge>}
+      >
+        <Flex>Slide 1</Flex>
+        <Flex>Slide 2</Flex>
+        <Flex>Slide 3</Flex>
+      </Carousel>
+    )
+    expect(getByText('Hello')).toBeInTheDocument()
+  })
 })

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent } from 'testing-library'
-import { Flex } from 'pcln-design-system'
+import { Flex, Badge } from 'pcln-design-system'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import { Carousel } from './Carousel'
 
@@ -95,5 +95,40 @@ describe('Carousel', () => {
     )
     const nextArrow = getByTestId('next-side')
     expect(nextArrow).toHaveStyleRule('opacity', '0')
+  })
+
+  it('Should render the nodeBesideArrows', () => {
+    window.innerWidth = 1400
+    const { getByText } = render(
+      <Carousel
+        layout='50-50'
+        arrowsPosition='bottom'
+        arrowsAlignment='left'
+        currentSlide={1}
+        nodeBesideArrows={<Badge>Hello</Badge>}
+      >
+        <Flex>Slide 1</Flex>
+        <Flex>Slide 2</Flex>
+        <Flex>Slide 3</Flex>
+      </Carousel>
+    )
+    expect(getByText('Hello')).toBeInTheDocument()
+  })
+
+  it('Should NOT render the nodeBesideArrows when arrow center aligment bottom', () => {
+    window.innerWidth = 1400
+    const { queryByText } = render(
+      <Carousel
+        layout='50-50'
+        arrowsPosition='bottom'
+        currentSlide={1}
+        nodeBesideArrows={<Badge>Hello</Badge>}
+      >
+        <Flex>Slide 1</Flex>
+        <Flex>Slide 2</Flex>
+        <Flex>Slide 3</Flex>
+      </Carousel>
+    )
+    expect(queryByText('Hello')).not.toBeInTheDocument()
   })
 })

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -97,15 +97,15 @@ describe('Carousel', () => {
     expect(nextArrow).toHaveStyleRule('opacity', '0')
   })
 
-  it('Should render the nodeBesideArrows', () => {
+  it('Should render the nodeBesideArrowsLeft', () => {
     window.innerWidth = 1400
     const { getByText } = render(
       <Carousel
         layout='50-50'
         arrowsPosition='bottom'
-        arrowsAlignment='left'
+        arrowsAlignment='right'
         currentSlide={1}
-        nodeBesideArrows={<Badge>Hello</Badge>}
+        nodeBesideArrowsLeft={<Badge>Hello</Badge>}
       >
         <Flex>Slide 1</Flex>
         <Flex>Slide 2</Flex>
@@ -115,14 +115,14 @@ describe('Carousel', () => {
     expect(getByText('Hello')).toBeInTheDocument()
   })
 
-  it('Should NOT render the nodeBesideArrows when arrow center aligment bottom', () => {
+  it('Should NOT render the nodeBesideArrowsLeft when arrow center aligment bottom', () => {
     window.innerWidth = 1400
     const { queryByText } = render(
       <Carousel
         layout='50-50'
         arrowsPosition='bottom'
         currentSlide={1}
-        nodeBesideArrows={<Badge>Hello</Badge>}
+        nodeBesideArrowsLeft={<Badge>Hello</Badge>}
       >
         <Flex>Slide 1</Flex>
         <Flex>Slide 2</Flex>

--- a/packages/carousel/src/Carousel.stories.jsx
+++ b/packages/carousel/src/Carousel.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { within } from '@storybook/testing-library'
 import { expect } from '@storybook/jest'
-import { Flex, Card, Container, Image, Text, Box, BackgroundImage } from 'pcln-design-system'
+import { Flex, Card, Container, Image, Text, Box, BackgroundImage, Badge } from 'pcln-design-system'
 import styled from 'styled-components'
 import { action } from '@storybook/addon-actions'
 import { Carousel } from './Carousel'
@@ -120,12 +120,29 @@ Basic.args = {
   mobileVisibleSlides: [1.1, 2.1, 2.1],
   showDots: false,
   showForwardBackBtns: true,
-  arrowPositions: 'bottom',
   onSlideChange: action('Slide Change'),
   buttonSize: '60px',
   sideButtonMargin: '-30px',
 }
 Basic.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+
+  expect(canvas.queryByTestId('slide-box')).not.toBeInTheDocument()
+}
+
+export const NodesByArrows = BasicTemplate.bind({})
+NodesByArrows.args = {
+  visibleSlides: 3,
+  mobileVisibleSlides: [1.1, 2.1, 2.1],
+  showDots: false,
+  showForwardBackBtns: true,
+  onSlideChange: action('Slide Change'),
+  buttonSize: '60px',
+  arrowsPosition: 'bottom',
+  nodeBesideArrows: <Badge>More Content</Badge>,
+  arrowsAlignment: 'right',
+}
+NodesByArrows.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
 
   expect(canvas.queryByTestId('slide-box')).not.toBeInTheDocument()

--- a/packages/carousel/src/Carousel.stories.jsx
+++ b/packages/carousel/src/Carousel.stories.jsx
@@ -139,7 +139,8 @@ NodesByArrows.args = {
   onSlideChange: action('Slide Change'),
   buttonSize: '60px',
   arrowsPosition: 'bottom',
-  nodeBesideArrows: <Badge>More Content</Badge>,
+  nodeBesideArrowsLeft: <Badge>Left Content</Badge>,
+  nodeBesideArrowsRight: <Badge>Right Content</Badge>,
   arrowsAlignment: 'right',
 }
 NodesByArrows.play = async ({ canvasElement }) => {

--- a/packages/carousel/src/constants.js
+++ b/packages/carousel/src/constants.js
@@ -8,10 +8,24 @@ const CAROUSEL_BREAKPOINT_2 = 1024
 
 const MEDIA_QUERY_MATCH = `(max-width: ${CAROUSEL_BREAKPOINT_2}px) and (min-width: ${CAROUSEL_BREAKPOINT_1}px)`
 
+const ARROW_MARGIN = {
+  center: 3,
+  left: 2,
+  right: 2,
+}
+
+const ARROW_JUSTIFY_CONTENT = {
+  center: 'center',
+  left: 'flex-start',
+  right: 'flex-end',
+}
+
 export {
   VISIBLE_SLIDES_BREAKPOINT_1,
   VISIBLE_SLIDES_BREAKPOINT_2,
   CAROUSEL_BREAKPOINT_1,
   CAROUSEL_BREAKPOINT_2,
   MEDIA_QUERY_MATCH,
+  ARROW_MARGIN,
+  ARROW_JUSTIFY_CONTENT,
 }


### PR DESCRIPTION
Add 2 new props to the `Carousel`

**nodeBesideArrows**: Node that will display beside the arrows - will only display if arrows are top or bottom (with left or right alignment)

**arrowsAlignment**: String either "left", "right", or "center". Default to "center" only available if arrowsPosition is set to "bottom".