### PR TITLE
add BoxProps to Container type

### DIFF
--- a/common/changes/pcln-design-system/container-add-BoxProps-type_2024-02-27-19-38.json
+++ b/common/changes/pcln-design-system/container-add-BoxProps-type_2024-02-27-19-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add BoxProps type to Container type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Container/Container.tsx
+++ b/packages/core/src/Container/Container.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box, BoxProps } from '../Box/Box'
+import { Box, type BoxProps } from '../Box/Box'
 
 const sizes = {
   sm: 640,

--- a/packages/core/src/Container/Container.tsx
+++ b/packages/core/src/Container/Container.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box } from '../Box/Box'
+import { Box, BoxProps } from '../Box/Box'
 
 const sizes = {
   sm: 640,
@@ -24,7 +24,7 @@ export type ContainerSize = 'sm' | 'md' | 'lg' | 'xl'
 /**
  * @public
  */
-export type ContainerProps = {
+export type ContainerProps = BoxProps & {
   children?: React.ReactNode
   maxWidth?: number
   size?: ContainerSize


### PR DESCRIPTION
Container type was missing the BoxProps union which is valid as Container extends Box functionality via styled-components.