### PR TITLE
fix(AIR-61584): avoid render the hidden children

### DIFF
--- a/common/changes/pcln-carousel/fix-AIR-61584-carousel-test-id_2024-03-08-21-41.json
+++ b/common/changes/pcln-carousel/fix-AIR-61584-carousel-test-id_2024-03-08-21-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "fix the bug that render children twice.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -174,7 +174,11 @@ export const Carousel = ({
                     onSlideKeyDown(index, e)
                   }}
                 >
-                  <RenderInView index={index} onSlideChange={onSlideChange}>
+                  <RenderInView
+                    index={index}
+                    onSlideChange={onSlideChange}
+                    displayArrowsMobile={displayArrowsMobile}
+                  >
                     <Box p={slideSpacing} height='100%'>
                       {!layout && stretchSlideHeight
                         ? React.cloneElement(item, { style: { 'min-height': '100%' } })

--- a/packages/carousel/src/Carousel.spec.js
+++ b/packages/carousel/src/Carousel.spec.js
@@ -42,7 +42,7 @@ describe('Carousel', () => {
     )
 
     //Slide contains a <Hide> with separate mobile and desktop contents to allow mobile only RenderInView
-    const slide1 = queryAllByText('Slide 1')[1]
+    const slide1 = queryAllByText('Slide 1')[0]
 
     expect(slide1).toBeInTheDocument()
     expect(getByTestId('dot_group')).toBeInTheDocument()

--- a/packages/carousel/src/RenderInView/RenderInView.jsx
+++ b/packages/carousel/src/RenderInView/RenderInView.jsx
@@ -8,7 +8,7 @@ const FullHeightInView = styled(InView)`
   height: 100%;
 `
 
-const RenderInView = ({ children, onSlideChange, index }) => {
+const RenderInView = ({ children, onSlideChange, index, displayArrowsMobile }) => {
   const slideVisible = (inView) => {
     if (inView) {
       onSlideChange(index)
@@ -16,9 +16,11 @@ const RenderInView = ({ children, onSlideChange, index }) => {
   }
   return (
     <>
-      <Hide md lg xl xxl height='100%'>
-        <FullHeightInView onChange={slideVisible}>{children}</FullHeightInView>
-      </Hide>
+      {displayArrowsMobile === true ? (
+        <Hide md lg xl xxl height='100%'>
+          <FullHeightInView onChange={slideVisible}>{children}</FullHeightInView>
+        </Hide>
+      ) : null}
       <Hide xs sm height='100%'>
         {children}
       </Hide>


### PR DESCRIPTION
The carouse would render the children twice, which caused the same children component with same test-id appear twice. 

Before fix
<img width="769" alt="Screenshot 2024-03-11 at 10 44 06 AM" src="https://github.com/priceline/design-system/assets/120677881/662144d3-a48b-438e-8a71-c904e07d7792">


After fix
<img width="718" alt="Screenshot 2024-03-11 at 10 45 23 AM" src="https://github.com/priceline/design-system/assets/120677881/1f187fec-c8bb-4b37-833e-798ca333f43e">
