### PR TITLE
Carousel: add new prop arrowButtonZIndex to allow you to set zIndex f…

### DIFF
--- a/common/changes/pcln-carousel/feat-carousel-arrow-zindex_2024-03-12-19-57.json
+++ b/common/changes/pcln-carousel/feat-carousel-arrow-zindex_2024-03-12-19-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "Add new prop arrowButtonZIndex to allow z index for the arrow buttons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 import { CarouselProvider, Slide, CarouselContext, Slider } from 'pure-react-carousel'
 import { layoutToFlexWidths } from './layoutToFlexWidths'
-import { CarouselWrapper } from './Carousel.styles'
+import { CarouselWrapper, RelativeFlex } from './Carousel.styles'
 import { Flex, Relative, Box, SlideBox } from 'pcln-design-system'
 import { Dots } from './Dots'
 import { ArrowButton } from './ArrowButton'
@@ -70,6 +70,7 @@ export const Carousel = ({
   overflowAllowancePxY = 0,
   overflowAllowancePxTop = 0,
   maxHeight,
+  arrowButtonZIndex,
 }) => {
   const widths = layoutToFlexWidths(layout, children.length)
   const layoutSize = layout?.split('-').length
@@ -208,7 +209,12 @@ export const Carousel = ({
           )}
         </Relative>
         {arrowsPosition === 'bottom' || showDots ? (
-          <Flex alignItems='center' justifyContent={ARROW_JUSTIFY_CONTENT[arrowsAlignment]} pt={2}>
+          <RelativeFlex
+            alignItems='center'
+            justifyContent={ARROW_JUSTIFY_CONTENT[arrowsAlignment]}
+            pt={2}
+            zIndex={arrowButtonZIndex}
+          >
             {nodeBesideArrowsLeft && arrowsAlignment === 'right' ? (
               <Box ml={2} mr='auto'>
                 {nodeBesideArrowsLeft}
@@ -232,7 +238,7 @@ export const Carousel = ({
                 {nodeBesideArrowsRight}
               </Box>
             ) : null}
-          </Flex>
+          </RelativeFlex>
         ) : null}
       </CarouselProvider>
     </CarouselWrapper>
@@ -310,4 +316,6 @@ Carousel.propTypes = {
   overflowAllowancePxTop: PropTypes.number,
   /** Number of px to set maxHeight to counteract large overflow values*/
   maxHeight: PropTypes.number,
+  /** z-index for arrow buttons*/
+  arrowButtonZIndex: PropTypes.number,
 }

--- a/packages/carousel/src/Carousel.stories.jsx
+++ b/packages/carousel/src/Carousel.stories.jsx
@@ -203,6 +203,46 @@ OverflowAllowed.args = {
   maxHeight: 220,
 }
 
+const OverflowTemplateBottomArrows = (args) => (
+  <Box>
+    <Relative
+      width={1}
+      bg='background.light'
+      zIndex={2}
+      height='80px'
+      borderRadius='xl'
+      mb={[3, 3, 3, 4]}
+      mx={2}
+    >
+      Above
+    </Relative>
+    <Carousel {...args}>{renderOverflowCards()}</Carousel>
+    <Relative
+      width={1}
+      bg='background.light'
+      zIndex={3}
+      height='80px'
+      borderRadius='xl'
+      mt={[5, 3, 3, 5]}
+      mx={2}
+    >
+      Below
+    </Relative>
+  </Box>
+)
+
+export const OverflowArrowsBottomZIndex = OverflowTemplateBottomArrows.bind({ boxShadowSize: 'xl' })
+OverflowArrowsBottomZIndex.args = {
+  visibleSlides: 3,
+  mobileVisibleSlides: [1.1, 2.1, 2.1],
+  arrowsPosition: 'bottom',
+  overflowAllowancePxX: 46,
+  overflowAllowancePxY: 80,
+  overflowAllowancePxTop: 2,
+  maxHeight: 220,
+  arrowButtonZIndex: 2,
+}
+
 //Overflow With backround
 const OverflowBackgroundTemplate = (args) => (
   <Box>

--- a/packages/carousel/src/Carousel.styles.js
+++ b/packages/carousel/src/Carousel.styles.js
@@ -1,4 +1,9 @@
 import styled from 'styled-components'
+import { Flex } from 'pcln-design-system'
+
+export const RelativeFlex = styled(Flex)`
+  position: relative;
+`
 
 export const CarouselWrapper = styled.div`
   ${({ maxHeight }) => (maxHeight ? `max-height: ${maxHeight}px;` : '')}


### PR DESCRIPTION
Add in new prop:
**arrowButtonZIndex** - this will set the z-index on the arrows buttons. This is needed when you use a large `overflowAllowancePxY` value, it will go on top of the arrows when they are positioned at the bottom making them unclickable. This will allow you to place the arrow buttons on top