### PR TITLE
feat(RC-25645): Disable floating-ui for popover using a prop.

### DIFF
--- a/common/changes/pcln-popover/feat-RC-25645-disable-flip_2024-03-15-01-35.json
+++ b/common/changes/pcln-popover/feat-RC-25645-disable-flip_2024-03-15-01-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Use new prop \"diableFloating\" to toggle the mainAxis and crossAxis of the floating-ui middleware. ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/common/changes/pcln-popover/feat-RC-25645-disable-flip_2024-03-15-13-31.json
+++ b/common/changes/pcln-popover/feat-RC-25645-disable-flip_2024-03-15-13-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "Optionally disable floating for pcln-popover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/Popover/Popover.jsx
+++ b/packages/popover/src/Popover/Popover.jsx
@@ -9,6 +9,7 @@ function Popover({
   ariaLabel,
   borderRadius = 'xl',
   children,
+  disableFloating,
   hideOverlay,
   isOpen,
   openOnFocus,
@@ -41,6 +42,7 @@ function Popover({
     onBeforeOpen,
     onClose,
     onBeforeClose,
+    disableFloating,
   })
 
   return (
@@ -100,6 +102,7 @@ Popover.propTypes = {
   stopPropagation: PropTypes.bool,
   onBeforeOpen: PropTypes.func,
   onBeforeClose: PropTypes.func,
+  disableFloating: PropTypes.bool,
 }
 
 Popover.defaultProps = {
@@ -107,6 +110,7 @@ Popover.defaultProps = {
   toggleIsOpenOnClick: true,
   display: 'inline-block',
   stopPropagation: true,
+  disableFloating: false,
 }
 
 export default Popover

--- a/packages/popover/src/Popover/Popover.stories.args.jsx
+++ b/packages/popover/src/Popover/Popover.stories.args.jsx
@@ -22,6 +22,7 @@ export const defaultArgs = {
   placement: 'top',
   onClose: action('Popover Close'),
   onOpen: action('Popover Open'),
+  disableFloating: false,
 }
 
 export const argTypes = {
@@ -31,6 +32,15 @@ export const argTypes = {
     control: {
       type: 'select',
     },
+  },
+  disableFloating: {
+    name: 'disableFloating',
+    description: 'Disable floating-ui',
+    table: {
+      defaultValue: { summary: 'Sets crossAxis and mainAxis in the floating-ui' },
+    },
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
   },
   onClose: { action: true },
   onMinimize: { action: true },

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -202,6 +202,24 @@ const SimpleTextContent = () => (
   </Box>
 )
 
+const LongTextContent = () => (
+  <Box p={2}>
+    <Text textStyle='heading2'> Disable Floating: </Text>
+    <Text textStyle='heading5'>
+      {' '}
+      When the prop disableFloating is set to true, the popover will not float on the screen. Resize your
+      window/view-port to see the effect.{' '}
+    </Text>
+    <Text textAlign='center'>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+      dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+      ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+      deserunt mollit anim id est laborum.
+    </Text>
+  </Box>
+)
+
 const InnerContent = ({ handleClose }) => (
   <Box p={4}>
     <Absolute top={15} right={15}>
@@ -334,3 +352,58 @@ export const RendersOnSpecificArea = {
     await new Promise((resolve) => setTimeout(resolve, 2000))
   },
 }
+
+export const DisableFloating = (args) => (
+  <Flex flexDirection='row' justifyContent='space-between'>
+    <Flex m={200}>
+      <Popover
+        {...args}
+        disableFloating={false}
+        isOpen
+        color='primary'
+        openOnHover={false}
+        renderContent={LongTextContent}
+        placement='bottom'
+        ariaLabel='Default Popover'
+        width={330}
+      >
+        <Button color='primary' mx={2}>
+          Open popover (disableFloating=false )
+        </Button>
+      </Popover>
+    </Flex>
+    <Flex m={200}>
+      <Popover
+        {...args}
+        isOpen
+        disableFloating
+        color='primary'
+        openOnHover={false}
+        renderContent={LongTextContent}
+        placement='bottom'
+        ariaLabel='Default Popover'
+        width={330}
+      >
+        <Button color='primary' mx={2}>
+          Open popover (disableFloating=true)
+        </Button>
+      </Popover>
+    </Flex>
+    <Flex m={200}>
+      <Popover
+        {...args}
+        isOpen
+        color='secondary'
+        openOnHover={false}
+        renderContent={LongTextContent}
+        placement='bottom'
+        ariaLabel='Default Popover'
+        width={330}
+      >
+        <Button color='secondary' mx={2}>
+          Open popover (disableFloating using storybook control)
+        </Button>
+      </Popover>
+    </Flex>
+  </Flex>
+)

--- a/packages/popover/src/usePopover/usePopover.js
+++ b/packages/popover/src/usePopover/usePopover.js
@@ -22,7 +22,11 @@ function usePopover({
   onOpen,
   onBeforeOpen,
   onBeforeClose,
+  disableFloating,
 }) {
+  const crossAxis = !disableFloating
+  const mainAxis = !disableFloating
+
   const [isOpen, setOpen] = useState(openOnMount)
 
   const handleClose = (e) => {
@@ -65,7 +69,7 @@ function usePopover({
     placement,
     middleware: [
       offset(8),
-      flip({ fallbackPlacements: ['top', 'right', 'bottom', 'left', 'top'] }),
+      flip({ fallbackPlacements: ['top', 'bottom', 'left', 'right'], crossAxis, mainAxis }),
       shift({ padding: 8 }),
       arrow({ element: arrowRef }),
     ],
@@ -84,7 +88,6 @@ function usePopover({
   const { x: arrowX, y: arrowY } = middlewareData?.arrow || {}
 
   const styles = getPopoverStyles({ arrowX, arrowY, placement: actualPlacement, refs, strategy, x, y })
-
   return {
     ...floatingValues,
     arrowRef,


### PR DESCRIPTION
# Disable floating-ui for Popover component using a prop.
By default the Popover component implements floating. I have a case where this is not desired. Rather than recreate the component without it I found that it is possible to disable the floating using `floating-ui` props:  `crossAxis` and `mainAxis`. 

When both of those are set to false no floating occurs. The component remains "sticky" to its original `placement`

I implemented this with a defaultProp that doesn't change the existing implementation. To disable it you must pass the new prop.

![disableFloating-Popover-prop](https://github.com/priceline/design-system/assets/14102004/3d6ff63a-11f2-4c5d-ade5-5e4a865710dd)
