### PR TITLE
Site 22740 - Fix to strange behavior for next-landing

### DIFF
--- a/common/changes/pcln-design-system/SITE-22740_2024-03-28-19-37.json
+++ b/common/changes/pcln-design-system/SITE-22740_2024-03-28-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Added new prop to dialog innerContentScroll",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -173,6 +173,7 @@ export const DialogContent = ({
   overflowX,
   overflowY,
   showScrollShadow,
+  innerContentScroll,
 }: DialogProps) => {
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
@@ -254,7 +255,7 @@ export const DialogContent = ({
               )}
             </SmoothTransitionBox>
           ) : (
-            <Box height='100%' style={{ overflowY: 'scroll' }}>
+            <Box height='100%' style={innerContentScroll && { overflowY: 'scroll' }}>
               {children}
             </Box>
           )}

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -33,6 +33,7 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   triggerNode?: React.ReactNode
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
+  innerContentScroll?: boolean
   showScrollShadow?: boolean
 }
 
@@ -65,6 +66,7 @@ const PclnDialog = ({
   overflowY = 'auto',
   onOpenChange,
   showScrollShadow,
+  innerContentScroll = true,
 }: DialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
@@ -82,6 +84,7 @@ const PclnDialog = ({
         {_open && (
           <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet} zIndex={zIndex}>
             <DialogContent
+              innerContentScroll={innerContentScroll}
               overflowX={overflowX}
               overflowY={overflowY}
               ariaDescription={ariaDescription}


### PR DESCRIPTION
Ticket: https://priceline.atlassian.net/browse/SITE-22740

While attempting to bump design system up in NL, the dialog behavior for our express deal was showing the overflow issue again. this is the code to fix said issue via a default true set prop that we will set false as to not disrupt others that rely on the `overflowY: scroll`. 

