### PR TITLE
fix(RC-26187): center aligns banner icon

### DIFF
--- a/common/changes/pcln-design-system/fix-RC-26187-banner-icon_2024-04-10-17-18.json
+++ b/common/changes/pcln-design-system/fix-RC-26187-banner-icon_2024-04-10-17-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "center aligns icon in banner component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -99,12 +99,14 @@ export function Banner(props: BannerProps): React.ReactElement {
   return (
     <StyledBox {...props} bg={bannerColor.backgroundColor || props.bg} color={color}>
       <Flex justifyContent='space-between' alignItems='flex-start'>
-        {!!Icon && !!props.showIcon && React.cloneElement(Icon, { mr: 2, size: 24, mt: '-2px' })}
-        <Box textAlign={props.textAlign} width={1}>
-          {header}
-          <Text.span fontSize={1}>{props.text}</Text.span>
-          {props.children}
-        </Box>
+        <Flex alignItems='center'>
+          {!!Icon && !!props.showIcon && React.cloneElement(Icon, { mr: 2, size: 24, mt: '-2px' })}
+          <Box textAlign={props.textAlign} width={1}>
+            {header}
+            <Text.span fontSize={1}>{props.text}</Text.span>
+            {props.children}
+          </Box>
+        </Flex>
         {!!props.onClose && <CloseButton onClick={props.onClose} ml={2} size={24} title='close' mt='-2px' />}
       </Flex>
     </StyledBox>


### PR DESCRIPTION
Updates alignItems='center' to Flex wrapper in Banner component - to center align icon to match to designs

**Before**
<img width="1201" alt="image" src="https://github.com/priceline/design-system/assets/15201013/c8e58a3a-7b87-4c3e-b0ca-af0efe5be6ee">

**After**
<img width="1197" alt="image" src="https://github.com/priceline/design-system/assets/15201013/0ea1faa6-45ef-43c1-a26c-968f6ec7b25d">
