### PR TITLE
fix(RC-26177): zindex prop for menu

### DIFF
--- a/common/changes/pcln-menu/fix-RC-26177-menu-zindex_2024-04-16-14-30.json
+++ b/common/changes/pcln-menu/fix-RC-26177-menu-zindex_2024-04-16-14-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "Adding zindex to menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/packages/menu/src/Menu/Menu.jsx
+++ b/packages/menu/src/Menu/Menu.jsx
@@ -18,6 +18,7 @@ function Menu({
   placement,
   children,
   querySelectorPortal,
+  zIndex,
   ...props
 }) {
   const MenuContent = ({ handleClose }) => (
@@ -67,7 +68,7 @@ function Menu({
         renderContent={MenuContent}
         trapFocus={trapFocus}
         width={width}
-        zIndex={1600}
+        zIndex={zIndex}
         querySelectorPortal={`.${querySelectorPortal}`}
         {...props}
       >
@@ -95,12 +96,14 @@ Menu.propTypes = {
   placement: PropTypes.string,
   children: PropTypes.node,
   querySelectorPortal: PropTypes.string,
+  zIndex: PropTypes.number,
 }
 
 Menu.defaultProps = {
   size: 'singleColumn',
   trapFocus: true,
   width: '650px',
+  zIndex: 1600,
 }
 
 export default Menu


### PR DESCRIPTION
I am adding a prop for zindex for the pop up component inside menu. This is defaulted to 1600 the original value.  