### PR TITLE
Rename innerContentScroll prop to innerContentOverflow

### DIFF
--- a/common/changes/pcln-design-system/rename-innerContentOverflow-prop_2024-04-29-21-42.json
+++ b/common/changes/pcln-design-system/rename-innerContentOverflow-prop_2024-04-29-21-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Rename innerContentScroll prop to innerContentOverflow",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -147,7 +147,7 @@ export const DialogOverlay = ({ scrimColor, sheet, children, zIndex }: Partial<D
 }
 
 const SmoothTransitionBox = styled(Box)`
-  overflow: ${(props) => (props.innerContentScroll ? 'scroll' : 'auto')};
+  overflow: ${(props) => props.innerContentOverflow ?? 'auto'};
   transition: all 0.3s ease-in-out;
 `
 
@@ -164,16 +164,16 @@ export const DialogContent = ({
   headerIcon,
   headerShowCloseButton,
   hugColor,
+  innerContentOverflow,
+  overflowX,
+  overflowY,
   scrimDismiss,
   sheet,
   showCloseButton,
+  showScrollShadow,
   size,
   zIndex,
   onOpenChange,
-  overflowX,
-  overflowY,
-  showScrollShadow,
-  innerContentScroll,
 }: DialogProps) => {
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
@@ -248,7 +248,7 @@ export const DialogContent = ({
           )}
           {showScrollShadow ? (
             <SmoothTransitionBox
-              innerContentScroll={innerContentScroll}
+              innerContentOverflow={innerContentOverflow}
               style={{ boxShadow }}
               height='100%'
               onScroll={onScrollHandler}
@@ -260,7 +260,7 @@ export const DialogContent = ({
               )}
             </SmoothTransitionBox>
           ) : (
-            <Box height='100%' style={innerContentScroll ? { overflowY: 'scroll' } : undefined}>
+            <Box height='100%' style={innerContentOverflow ? { overflowY: innerContentOverflow } : undefined}>
               {children}
             </Box>
           )}

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -24,6 +24,7 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   headerIcon?: React.ReactNode
   headerShowCloseButton?: boolean
   hugColor?: PaletteColor
+  innerContentOverflow?: 'auto' | 'clip' | 'hidden' | 'scroll' | 'visible'
   open?: boolean
   scrimColor?: 'dark' | 'medium' | 'light' | (string & {})
   scrimDismiss?: boolean
@@ -33,7 +34,6 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   triggerNode?: React.ReactNode
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
-  innerContentScroll?: boolean
   showScrollShadow?: boolean
 }
 
@@ -54,19 +54,19 @@ const PclnDialog = ({
   headerIcon,
   headerShowCloseButton = false,
   hugColor,
+  innerContentOverflow = 'scroll',
   open,
   scrimColor = 'dark',
   scrimDismiss = true,
   sheet = false,
   showCloseButton = true,
+  showScrollShadow,
   size = 'md',
   triggerNode,
   zIndex = 'overlay',
   overflowX = 'auto',
   overflowY = 'auto',
   onOpenChange,
-  showScrollShadow,
-  innerContentScroll = true,
 }: DialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
@@ -84,7 +84,6 @@ const PclnDialog = ({
         {_open && (
           <DialogOverlay scrimDismiss={scrimDismiss} scrimColor={scrimColor} sheet={sheet} zIndex={zIndex}>
             <DialogContent
-              innerContentScroll={innerContentScroll}
               overflowX={overflowX}
               overflowY={overflowY}
               ariaDescription={ariaDescription}
@@ -98,6 +97,7 @@ const PclnDialog = ({
               headerIcon={headerIcon}
               headerShowCloseButton={headerShowCloseButton}
               hugColor={hugColor}
+              innerContentOverflow={innerContentOverflow}
               onOpenChange={handleOpenChange}
               scrimDismiss={scrimDismiss}
               sheet={sheet}


### PR DESCRIPTION
I need similar behaviour to what is being done with the `innerContentScroll` prop but I need to set the overflow to `hidden`. I don't want to create a whole new prop just to control this behaviour in a slightly different way so I thought renaming the prop and setting the changing the default value from `true` to `scroll` should help with backwards compatibility. This obviously isn't perfect, if anyone is setting this prop to false their code will be hurt by this but as this is the default functionality and a new prop anyway I think this is safe but I am happy to change the version bump if people disagree.