### PR TITLE
fix(ToggleBadge): unSelectedBg

### DIFF
--- a/packages/core/src/ToggleBadge/ToggleBadge.tsx
+++ b/packages/core/src/ToggleBadge/ToggleBadge.tsx
@@ -29,7 +29,7 @@ export const ToggleBadge: React.FC<ToggleBadgeProps> = styled.button.attrs(borde
   font-family: inherit;
   cursor: pointer;
   background-color: ${(props) =>
-    props.selected ? getPaletteColor(props.bg || props.color, 'light')(props) : props.unSelectedBg};
+    props.selected ? getPaletteColor(props.bg || props.color, 'light')(props) : getPaletteColor(props.unSelectedBg)(props)};
   color: ${getPaletteColor('base')};
   &:hover {
     background-color: ${(props) => getPaletteColor(props.bg || props.color, 'light')(props)};


### PR DESCRIPTION
Noticed palette color was not applying to `unSelectedBg` for `ToggleBadge`.