### PR TITLE
chore(): Update typings

### DIFF
--- a/common/changes/pcln-design-system/chore-update-types_2024-06-24-22-12.json
+++ b/common/changes/pcln-design-system/chore-update-types_2024-06-24-22-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update typings for several components",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Absolute/Absolute.tsx
+++ b/packages/core/src/Absolute/Absolute.tsx
@@ -17,7 +17,12 @@ import { Box, BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type AbsoluteProps = BoxProps & TopProps & RightProps & BottomProps & LeftProps & ZIndexProps
+export type AbsoluteProps<T extends HTMLElement = HTMLDivElement> = BoxProps<T> &
+  TopProps &
+  RightProps &
+  BottomProps &
+  LeftProps &
+  ZIndexProps
 
 /**
  * @public

--- a/packages/core/src/Absolute/Absolute.tsx
+++ b/packages/core/src/Absolute/Absolute.tsx
@@ -17,12 +17,7 @@ import { Box, BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type AbsoluteProps = BoxProps &
-  TopProps &
-  RightProps &
-  BottomProps &
-  LeftProps &
-  ZIndexProps
+export type AbsoluteProps = BoxProps & TopProps & RightProps & BottomProps & LeftProps & ZIndexProps
 
 /**
  * @public

--- a/packages/core/src/Absolute/Absolute.tsx
+++ b/packages/core/src/Absolute/Absolute.tsx
@@ -17,7 +17,7 @@ import { Box, BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type AbsoluteProps<T extends HTMLElement = HTMLDivElement> = BoxProps<T> &
+export type AbsoluteProps = BoxProps &
   TopProps &
   RightProps &
   BottomProps &

--- a/packages/core/src/BackgroundImage/BackgroundImage.tsx
+++ b/packages/core/src/BackgroundImage/BackgroundImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled, { css } from 'styled-components'
 import {
   BorderRadiusProps,
@@ -33,7 +33,7 @@ const image = (props) => (props.image ? { backgroundImage: `url(${props.image})`
 export type BackgroundImageProps = WidthProps &
   HeightProps &
   BorderRadiusProps &
-  Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'width' | 'height'> & {
+  Omit<ComponentPropsWithoutRef<'img'>, 'width' | 'height'> & {
     variation?: 'parallax' | 'static'
     image?: string
     borderRadius?: string

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -35,10 +35,7 @@ import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applyVariations, color, colorScheme } from '../utils/utils'
 
-/**
- * @public
- */
-export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps &
+export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadiusProps, 'borderRadius'> &
   BoxShadowProps &
   DisplayProps &
   HeightProps &
@@ -58,7 +55,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps
     bg?: string
     color?: string
     className?: string
-    borderRadiusSize?: ResponsiveValue<BorderRadius>
+    borderRadius?: ResponsiveValue<BorderRadius> | BorderRadiusProps['borderRadius']
     boxShadowSize?: ResponsiveValue<BoxShadowSize>
     boxShadowColor?:
       | 'primary'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -29,7 +29,7 @@ import {
   textAlign,
   width,
 } from 'styled-system'
-import type { BoxShadowSize, ColorSchemeName } from '../theme/theme'
+import type { BorderRadius, BoxShadowSize, ColorSchemeName } from '../theme/theme'
 import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applyVariations, color, colorScheme } from '../utils/utils'
@@ -57,19 +57,7 @@ export type BoxProps = BorderRadiusProps &
     bg?: string
     color?: string
     className?: string
-    borderRadiusSize?:
-      | 'none'
-      | 'xsm'
-      | 'sm'
-      | 'md'
-      | 'lg'
-      | 'xl'
-      | '2xl'
-      | '3xl'
-      | 'full'
-      | 'action-sm'
-      | 'action-md'
-      | 'action-lg'
+    borderRadiusSize?: BorderRadius
     boxShadowSize?: BoxShadowSize
     boxShadowColor?:
       | 'primary'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -35,6 +35,9 @@ import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applyVariations, color, colorScheme } from '../utils/utils'
 
+/**
+ * @public
+ */
 export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadiusProps, 'borderRadius'> &
   BoxShadowProps &
   DisplayProps &
@@ -77,7 +80,16 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadius
     colorScheme?: ColorSchemeName
     onClick?: (e: unknown) => void
     ref?: MutableRefObject<T | undefined>
-    rounded?: 'round' | 'top' | 'right' | 'bottom' | 'left' | 'topLeft' | 'topRight' | 'bottomRight' | 'bottomLeft'
+    rounded?:
+      | 'round'
+      | 'top'
+      | 'right'
+      | 'bottom'
+      | 'left'
+      | 'topLeft'
+      | 'topRight'
+      | 'bottomRight'
+      | 'bottomLeft'
   }
 
 /**

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -78,7 +78,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadius
       | 'border'
       | 'background'
     colorScheme?: ColorSchemeName
-    onClick?: (e: unknown) => void
+    onClick?: React.ComponentProps<'div'>['onClick']
     ref?: ForwardedRef<T>
     rounded?:
       | 'round'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -10,6 +10,7 @@ import {
   MinHeightProps,
   MinWidthProps,
   OverflowProps,
+  type ResponsiveValue,
   SizeProps,
   SpaceProps,
   TextAlignProps,
@@ -57,8 +58,8 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps
     bg?: string
     color?: string
     className?: string
-    borderRadiusSize?: BorderRadius
-    boxShadowSize?: BoxShadowSize
+    borderRadiusSize?: ResponsiveValue<BorderRadius>
+    boxShadowSize?: ResponsiveValue<BoxShadowSize>
     boxShadowColor?:
       | 'primary'
       | 'secondary'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -37,7 +37,7 @@ import { applyVariations, color, colorScheme } from '../utils/utils'
 /**
  * @public
  */
-export type BoxProps = BorderRadiusProps &
+export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps &
   BoxShadowProps &
   DisplayProps &
   HeightProps &
@@ -50,7 +50,7 @@ export type BoxProps = BorderRadiusProps &
   SpaceProps &
   TextAlignProps &
   WidthProps &
-  React.HTMLAttributes<HTMLDivElement> & {
+  React.HTMLAttributes<T> & {
     children?: React.ReactNode | string
     as?: unknown
     role?: string
@@ -78,7 +78,7 @@ export type BoxProps = BorderRadiusProps &
       | 'background'
     colorScheme?: ColorSchemeName
     onClick?: (unknown) => unknown
-    ref?: MutableRefObject<HTMLDivElement>
+    ref?: MutableRefObject<T | undefined>
     rounded?: 'top' | 'right' | 'bottom' | 'left' | 'topLeft' | 'topRight' | 'bottomRight' | 'bottomLeft'
   }
 

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -79,7 +79,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps
     colorScheme?: ColorSchemeName
     onClick?: (unknown) => unknown
     ref?: MutableRefObject<T | undefined>
-    rounded?: 'top' | 'right' | 'bottom' | 'left' | 'topLeft' | 'topRight' | 'bottomRight' | 'bottomLeft'
+    rounded?: 'round' | 'top' | 'right' | 'bottom' | 'left' | 'topLeft' | 'topRight' | 'bottomRight' | 'bottomLeft'
   }
 
 /**

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject } from 'react'
+import React, { type ForwardedRef } from 'react'
 import styled from 'styled-components'
 import {
   BorderRadiusProps,
@@ -79,7 +79,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadius
       | 'background'
     colorScheme?: ColorSchemeName
     onClick?: (e: unknown) => void
-    ref?: MutableRefObject<T | undefined>
+    ref?: ForwardedRef<T>
     rounded?:
       | 'round'
       | 'top'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -51,7 +51,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps
   TextAlignProps &
   WidthProps &
   React.HTMLAttributes<T> & {
-    children?: React.ReactNode | string
+    children?: React.ReactNode
     as?: unknown
     role?: string
     bg?: string

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -1,4 +1,4 @@
-import React, { type ForwardedRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import {
   BorderRadiusProps,
@@ -38,7 +38,7 @@ import { applyVariations, color, colorScheme } from '../utils/utils'
 /**
  * @public
  */
-export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadiusProps, 'borderRadius'> &
+export type BoxProps = Omit<BorderRadiusProps, 'borderRadius'> &
   BoxShadowProps &
   DisplayProps &
   HeightProps &
@@ -51,7 +51,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadius
   SpaceProps &
   TextAlignProps &
   WidthProps &
-  React.HTMLAttributes<T> & {
+  React.ComponentPropsWithRef<'div'> & {
     children?: React.ReactNode
     as?: unknown
     role?: string
@@ -79,7 +79,6 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = Omit<BorderRadius
       | 'background'
     colorScheme?: ColorSchemeName
     onClick?: React.ComponentProps<'div'>['onClick']
-    ref?: ForwardedRef<T>
     rounded?:
       | 'round'
       | 'top'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -77,7 +77,7 @@ export type BoxProps<T extends HTMLElement = HTMLDivElement> = BorderRadiusProps
       | 'border'
       | 'background'
     colorScheme?: ColorSchemeName
-    onClick?: (unknown) => unknown
+    onClick?: (e: unknown) => void
     ref?: MutableRefObject<T | undefined>
     rounded?: 'round' | 'top' | 'right' | 'bottom' | 'left' | 'topLeft' | 'topRight' | 'bottomRight' | 'bottomLeft'
   }

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -29,7 +29,7 @@ import {
   textAlign,
   width,
 } from 'styled-system'
-import type { ColorSchemeName } from '../theme/theme'
+import type { BoxShadowSize, ColorSchemeName } from '../theme/theme'
 import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applyVariations, color, colorScheme } from '../utils/utils'
@@ -70,7 +70,7 @@ export type BoxProps = BorderRadiusProps &
       | 'action-sm'
       | 'action-md'
       | 'action-lg'
-    boxShadowSize?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'overlay-lg' | 'overlay-xl'
+    boxShadowSize?: BoxShadowSize
     boxShadowColor?:
       | 'primary'
       | 'secondary'

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled from 'styled-components'
 import {
   BorderRadiusProps,
@@ -51,7 +51,7 @@ export type BoxProps = Omit<BorderRadiusProps, 'borderRadius'> &
   SpaceProps &
   TextAlignProps &
   WidthProps &
-  React.ComponentPropsWithRef<'div'> & {
+  ComponentPropsWithRef<'div'> & {
     children?: React.ReactNode
     as?: unknown
     role?: string
@@ -78,7 +78,6 @@ export type BoxProps = Omit<BorderRadiusProps, 'borderRadius'> &
       | 'border'
       | 'background'
     colorScheme?: ColorSchemeName
-    onClick?: React.ComponentProps<'div'>['onClick']
     rounded?:
       | 'round'
       | 'top'

--- a/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Flex } from '../Flex/Flex'
-import { Link } from '../Link/Link'
+import { Link, LinkProps } from '../Link/Link'
 import { Text } from '../Text/Text'
 
 /**
@@ -12,7 +12,7 @@ export type BreadcrumbLinkProps = React.RefAttributes<unknown> & {
   href?: string
   icon?: React.ReactNode
   label?: string
-  onClick?: (e: unknown) => unknown
+  onClick?: LinkProps['onClick']
 }
 
 /**

--- a/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
@@ -12,7 +12,7 @@ export type BreadcrumbLinkProps = React.RefAttributes<unknown> & {
   href?: string
   icon?: React.ReactNode
   label?: string
-  onClick?: (unknown) => unknown
+  onClick?: (e: unknown) => unknown
 }
 
 /**

--- a/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbLink.tsx
@@ -18,7 +18,7 @@ export type BreadcrumbLinkProps = React.RefAttributes<unknown> & {
 /**
  * @public
  */
-export const BreadcrumbLink: React.FC<BreadcrumbLinkProps> = React.forwardRef(
+export const BreadcrumbLink: React.FC<BreadcrumbLinkProps> = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
   ({ className, isLastChild, href, icon, label, onClick }, ref) => {
     const linkColor = isLastChild ? 'text.dark' : 'text.light'
 

--- a/packages/core/src/Button/Button.spec.tsx
+++ b/packages/core/src/Button/Button.spec.tsx
@@ -160,11 +160,7 @@ describe('Button', () => {
 
     expect(button).toHaveStyleRule('border-radius', borderRadius['action-md'])
 
-    rerender(
-      <Button size='small' borderRadius=''>
-        BUTTON
-      </Button>
-    )
+    rerender(<Button size='small'>BUTTON</Button>)
     expect(button).toHaveStyleRule('border-radius', borderRadius['action-sm'])
 
     rerender(

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -222,8 +222,8 @@ export type ButtonProps = WidthProps &
     borderRadius?: BorderRadius
     boxShadowSize?: BoxShadowSize
     autoFocus?: boolean
-    IconLeft?: React.Component
-    IconRight?: React.Component
+    IconLeft?: React.Component | React.FC
+    IconRight?: React.Component | React.FC
     flexProps?: FlexProps
     onClick?: (unknown) => unknown
     onFocus?: (unknown) => unknown

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -225,9 +225,9 @@ export type ButtonProps = WidthProps &
     IconLeft?: React.Component | React.FC
     IconRight?: React.Component | React.FC
     flexProps?: FlexProps
-    onClick?: (unknown) => unknown
-    onFocus?: (unknown) => unknown
-    onMouseEnter?: (unknown) => unknown
+    onClick?: (e: unknown) => void
+    onFocus?: (e: unknown) => void
+    onMouseEnter?: (e: unknown) => void
   }
 
 export const buttonStyles = css`

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 import {
   BoxShadowProps,
   HeightProps,
+  type ResponsiveValue,
   SpaceProps,
   WidthProps,
   borderRadius,
@@ -220,7 +221,7 @@ export type ButtonProps = WidthProps &
     variation?: ButtonVariations
     size?: ButtonSizes | ButtonSizes[]
     borderRadius?: BorderRadius
-    boxShadowSize?: BoxShadowSize
+    boxShadowSize?: ResponsiveValue<BoxShadowSize>
     autoFocus?: boolean
     IconLeft?: React.Component | React.FC
     IconRight?: React.Component | React.FC

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -226,9 +226,9 @@ export type ButtonProps = WidthProps &
     IconLeft?: React.ComponentType
     IconRight?: React.ComponentType
     flexProps?: FlexProps
-    onClick?: (e: unknown) => void
-    onFocus?: (e: unknown) => void
-    onMouseEnter?: (e: unknown) => void
+    onClick?: React.ComponentProps<'button'>['onClick']
+    onFocus?: React.ComponentProps<'button'>['onFocus']
+    onMouseEnter?: React.ComponentProps<'button'>['onMouseEnter']
   }
 
 export const buttonStyles = css`

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -222,8 +222,8 @@ export type ButtonProps = WidthProps &
     borderRadius?: BorderRadius
     boxShadowSize?: ResponsiveValue<BoxShadowSize>
     autoFocus?: boolean
-    IconLeft?: React.ComponentType
-    IconRight?: React.ComponentType
+    IconLeft?: React.Component | React.FC
+    IconRight?: React.Component | React.FC
     flexProps?: FlexProps
   }
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -17,6 +17,7 @@ import {
 import { Flex, type FlexProps } from '../Flex/Flex'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applySizes, applyVariations, borders, getPaletteColor, getTextColorOn } from '../utils/utils'
+import { type BoxShadowSize } from '../theme'
 
 /**
  * @public
@@ -219,7 +220,7 @@ export type ButtonProps = WidthProps &
     variation?: ButtonVariations
     size?: ButtonSizes | ButtonSizes[]
     borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'full' | ''
-    boxShadowSize?: '' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'overlay-md' | 'overlay-lg' | 'overlay-xl'
+    boxShadowSize?: BoxShadowSize
     autoFocus?: boolean
     IconLeft?: React.Component
     IconRight?: React.Component

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -1,5 +1,5 @@
 import { themeGet } from '@styled-system/theme-get'
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled, { css } from 'styled-components'
 import {
   BoxShadowProps,
@@ -215,8 +215,7 @@ export type ButtonProps = WidthProps &
   HeightProps &
   SpaceProps &
   BoxShadowProps &
-  React.ButtonHTMLAttributes<HTMLButtonElement> &
-  React.RefAttributes<unknown> & {
+  ComponentPropsWithRef<'button'> & {
     color?: string
     variation?: ButtonVariations
     size?: ButtonSizes | ButtonSizes[]
@@ -226,9 +225,6 @@ export type ButtonProps = WidthProps &
     IconLeft?: React.ComponentType
     IconRight?: React.ComponentType
     flexProps?: FlexProps
-    onClick?: React.ComponentProps<'button'>['onClick']
-    onFocus?: React.ComponentProps<'button'>['onFocus']
-    onMouseEnter?: React.ComponentProps<'button'>['onMouseEnter']
   }
 
 export const buttonStyles = css`
@@ -359,7 +355,7 @@ const ButtonIcon = ({ Component, ...props }) => {
 /**
  * @public
  */
-export const Button = React.forwardRef((props: ButtonProps, ref) => {
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   const { children, ...restProps } = props
   const { IconLeft, IconRight, size = 'medium', flexProps = {} } = props
   const hasChildren = React.Children.toArray(children).length > 0

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -17,7 +17,7 @@ import {
 import { Flex, type FlexProps } from '../Flex/Flex'
 import { boxShadowAttrs } from '../utils/attrs/boxShadowAttrs'
 import { applySizes, applyVariations, borders, getPaletteColor, getTextColorOn } from '../utils/utils'
-import { type BoxShadowSize } from '../theme'
+import { type BorderRadius, type BoxShadowSize } from '../theme'
 
 /**
  * @public
@@ -219,7 +219,7 @@ export type ButtonProps = WidthProps &
     color?: string
     variation?: ButtonVariations
     size?: ButtonSizes | ButtonSizes[]
-    borderRadius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'full' | ''
+    borderRadius?: BorderRadius
     boxShadowSize?: BoxShadowSize
     autoFocus?: boolean
     IconLeft?: React.Component

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -223,8 +223,8 @@ export type ButtonProps = WidthProps &
     borderRadius?: BorderRadius
     boxShadowSize?: ResponsiveValue<BoxShadowSize>
     autoFocus?: boolean
-    IconLeft?: React.Component | React.FC
-    IconRight?: React.Component | React.FC
+    IconLeft?: React.ComponentType
+    IconRight?: React.ComponentType
     flexProps?: FlexProps
     onClick?: (e: unknown) => void
     onFocus?: (e: unknown) => void

--- a/packages/core/src/Checkbox/Checkbox.tsx
+++ b/packages/core/src/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import { BoxChecked, BoxEmpty, BoxMinus } from 'pcln-icons'
-import React, { useEffect, useState } from 'react'
+import React, { type ComponentPropsWithRef, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { applyVariations, getPaletteColor } from '../utils/utils'
 
@@ -100,16 +100,14 @@ const StyledInput = styled.input`
 /**
  * @public
  */
-export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> & {
+export type CheckboxProps = ComponentPropsWithRef<'input'> & {
   id?: string
   indeterminate?: boolean
   size?: number
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   color?: string
   checked?: boolean
   defaultChecked?: boolean
   disabled?: boolean
-  ref?: React.Ref<HTMLInputElement>
   unselectedColor?: string
 }
 

--- a/packages/core/src/Checkbox/Checkbox.tsx
+++ b/packages/core/src/Checkbox/Checkbox.tsx
@@ -101,7 +101,7 @@ const StyledInput = styled.input`
  * @public
  */
 export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement> & {
-  id: string
+  id?: string
   indeterminate?: boolean
   size?: number
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -1,10 +1,9 @@
 import { ChevronDown } from 'pcln-icons'
 import React from 'react'
 import styled from 'styled-components'
-import { FontSizeProps, SpaceProps } from 'styled-system'
 import { Button } from '../../Button/Button'
 import { getPaletteColor } from '../../utils/utils'
-import { ChipContent, type IconComponent } from '../ChipContent/ChipContent'
+import { ChipContent, ChipContentProps } from '../ChipContent/ChipContent'
 import { ChipContentWrapper } from '../ChipContentWrapper'
 
 const ChipButton = styled(Button)`
@@ -34,24 +33,13 @@ export type ButtonChipVariation = 'outline' | 'shadow'
 /**
  * @public
  */
-export type ButtonChipProps = SpaceProps &
-  FontSizeProps & {
-    BridgeIcon?: IconComponent
-    bridgeLabel?: string
-    children?: React.ReactNode
-    color?: string
-    disabled?: boolean
-    expanded?: boolean
-    facet?: string
-    Icon?: IconComponent
-    id?: string
-    label?: string
-    selected?: boolean
-    showActionIcon?: boolean
-    onClick?: (e: unknown) => unknown
-    width?: string
-    variation?: ButtonChipVariation
-  }
+export type ButtonChipProps = Omit<ChipContentProps, 'action'> & {
+  expanded?: boolean
+  id?: string
+  showActionIcon?: boolean
+  onClick?: (e: unknown) => unknown
+  variation?: ButtonChipVariation
+}
 
 /**
  * @public

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -48,7 +48,7 @@ export type ButtonChipProps = SpaceProps &
     label?: string
     selected?: boolean
     showActionIcon?: boolean
-    onClick?: (unknown) => unknown
+    onClick?: (e: unknown) => unknown
     width?: string
     variation?: ButtonChipVariation
   }

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -1,9 +1,9 @@
 import { ChevronDown } from 'pcln-icons'
 import React from 'react'
 import styled from 'styled-components'
-import { Button } from '../../Button/Button'
+import { Button, type ButtonProps } from '../../Button/Button'
 import { getPaletteColor } from '../../utils/utils'
-import { ChipContent, ChipContentProps } from '../ChipContent/ChipContent'
+import { ChipContent, type ChipContentProps } from '../ChipContent/ChipContent'
 import { ChipContentWrapper } from '../ChipContentWrapper'
 
 const ChipButton = styled(Button)`
@@ -37,7 +37,7 @@ export type ButtonChipProps = Omit<ChipContentProps, 'action'> & {
   expanded?: boolean
   id?: string
   showActionIcon?: boolean
-  onClick?: (e: unknown) => unknown
+  onClick?: ButtonProps['onClick']
   variation?: ButtonChipVariation
 }
 

--- a/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
+++ b/packages/core/src/Chip/ButtonChip/ButtonChip.tsx
@@ -33,7 +33,7 @@ export type ButtonChipVariation = 'outline' | 'shadow'
 /**
  * @public
  */
-export type ButtonChipProps = Omit<ChipContentProps, 'action'> & {
+export type ButtonChipProps = Omit<ChipContentProps, 'action' | 'ref'> & {
   expanded?: boolean
   id?: string
   showActionIcon?: boolean
@@ -44,7 +44,7 @@ export type ButtonChipProps = Omit<ChipContentProps, 'action'> & {
 /**
  * @public
  */
-export const ButtonChip: React.FC<ButtonChipProps> = React.forwardRef(
+export const ButtonChip: React.FC<ButtonChipProps> = React.forwardRef<HTMLButtonElement, ButtonChipProps>(
   (
     {
       color,

--- a/packages/core/src/Chip/FilterChip/FilterChip.tsx
+++ b/packages/core/src/Chip/FilterChip/FilterChip.tsx
@@ -27,7 +27,7 @@ export type FilterChipProps = SpaceProps &
     actionTitle?: string
     value?: string | number
     color?: string
-    children?: React.ReactNode | string
+    children?: React.ReactNode
     variation?: FilterChipVariation
   }
 

--- a/packages/core/src/CloseButton/CloseButton.styled.tsx
+++ b/packages/core/src/CloseButton/CloseButton.styled.tsx
@@ -5,16 +5,13 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { ComposedStyleFns } from '../theme/theme'
 import { getPaletteColor } from '../utils/utils'
-import type { CloseButtonProps } from './CloseButton'
+import { type MotionButtonProps } from './CloseButton'
 
 /** @public */
 export const closeButtonSizes = ['sm', 'md', 'lg'] as const
 
 /** @public */
 export type CloseButtonSize = (typeof closeButtonSizes)[number] | number
-
-/** @public */
-export type MotionButtonProps = HTMLMotionProps<'button'> & CloseButtonProps
 
 export const closeButtonIconSizes: Record<CloseButtonSize, number> = {
   sm: 20,

--- a/packages/core/src/CloseButton/CloseButton.styled.tsx
+++ b/packages/core/src/CloseButton/CloseButton.styled.tsx
@@ -38,7 +38,7 @@ export const closeButtonVariants = ['filled', 'white'] as const
 /** @public */
 export type CloseButtonVariant = (typeof closeButtonVariants)[number]
 
-export const closeButtonVariantProps: Record<CloseButtonVariant, Omit<CloseButtonProps, 'variant'>> = {
+export const closeButtonVariantProps = {
   filled: { bgColor: 'background.lightest', boxShadowSize: 'sm', color: 'primary.base' },
   white: { color: 'text.lightest' },
 } as const

--- a/packages/core/src/CloseButton/CloseButton.tsx
+++ b/packages/core/src/CloseButton/CloseButton.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler, useState } from 'react'
+import { type HTMLMotionProps } from 'framer-motion'
 import { Relative } from '../Relative/Relative'
 import { type BoxShadowSize, type IStyledSystemProps, type PaletteColor } from '../theme/theme'
 import {
@@ -25,6 +26,9 @@ export type CloseButtonProps = IStyledSystemProps & {
   variant?: CloseButtonVariant
 }
 
+/** @public */
+export type MotionButtonProps = HTMLMotionProps<'button'> & CloseButtonProps
+
 /**
  * @public
  */
@@ -39,7 +43,7 @@ export const CloseButton = ({
   title = 'close',
   variant,
   ...props
-}: CloseButtonProps) => {
+}: MotionButtonProps) => {
   const [hover, setHover] = useState(false)
 
   return (

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 import themeGet from '@styled-system/theme-get'
-import { HTMLMotionProps, Transition, motion } from 'framer-motion'
+import { Transition, motion } from 'framer-motion'
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 import { overflowX, overflowY, zIndex } from 'styled-system'
@@ -35,7 +35,7 @@ const scrimStyles = {
 
 const enterTransition: Transition = { duration: 0.25, ease: 'easeOut' }
 const exitTransition: Transition = { duration: 0.15, ease: 'easeIn' }
-const animationStyles: Record<'default' | 'sheet' | 'overlay', HTMLMotionProps<'div'>> = {
+const animationStyles = {
   default: {
     initial: { opacity: 0, scale: 0.9, translateY: 64 },
     animate: { opacity: 1, scale: 1, translateY: 0, transition: enterTransition },

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -20,7 +20,7 @@ import { applyVariations } from '../utils/utils'
 /**
  * @public
  */
-export type FlexProps = BoxProps &
+export type FlexProps<T extends HTMLElement = HTMLDivElement> = BoxProps<T> &
   SpaceProps &
   WidthProps &
   AlignItemsProps &

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -20,7 +20,7 @@ import { applyVariations } from '../utils/utils'
 /**
  * @public
  */
-export type FlexProps<T extends HTMLElement = HTMLDivElement> = BoxProps<T> &
+export type FlexProps = BoxProps &
   SpaceProps &
   WidthProps &
   AlignItemsProps &

--- a/packages/core/src/Hug/Hug.tsx
+++ b/packages/core/src/Hug/Hug.tsx
@@ -10,7 +10,7 @@ export type HugProps = CardProps & {
   children?: React.ReactNode
   iconDisplay?: string[]
   icon?: React.ReactNode
-  text?: React.ReactNode | React.ReactNode[] | string
+  text?: React.ReactNode
   color?: string
   fontSize?: string | number
 }

--- a/packages/core/src/Image/Image.tsx
+++ b/packages/core/src/Image/Image.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentProps } from 'react'
 import styled from 'styled-components'
 import {
   BorderRadiusProps,
@@ -42,7 +42,7 @@ export type ImageProps = BorderRadiusProps &
   MinWidthProps &
   SpaceProps &
   WidthProps &
-  Partial<Omit<HTMLImageElement, 'width' | 'height'>> & {
+  Omit<ComponentProps<'img'>, 'width' | 'height'> & {
     borderRadiusSize?: string
     rounded?: string
     boxShadowSize?: string

--- a/packages/core/src/Image/Image.tsx
+++ b/packages/core/src/Image/Image.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps } from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled from 'styled-components'
 import {
   BorderRadiusProps,
@@ -42,7 +42,7 @@ export type ImageProps = BorderRadiusProps &
   MinWidthProps &
   SpaceProps &
   WidthProps &
-  Omit<ComponentProps<'img'>, 'width' | 'height'> & {
+  Omit<ComponentPropsWithoutRef<'img'>, 'width' | 'height'> & {
     borderRadiusSize?: string
     rounded?: string
     boxShadowSize?: string

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -80,7 +80,7 @@ export type InputProps = SpaceProps &
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> &
   React.RefAttributes<HTMLInputElement> & {
     children?: React.ReactNode
-    onChange?: (unknown) => unknown
+    onChange?: (e: unknown) => unknown
     helperText?: React.ReactElement<
       InputHelperTextProps,
       string | React.JSXElementConstructor<InputHelperTextProps>

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -80,7 +80,7 @@ export type InputProps = SpaceProps &
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> &
   React.RefAttributes<HTMLInputElement> & {
     children?: React.ReactNode
-    onChange?: (e: unknown) => unknown
+    onChange?: React.ComponentProps<'input'>['onChange']
     helperText?: React.ReactElement<
       InputHelperTextProps,
       string | React.JSXElementConstructor<InputHelperTextProps>

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, RefAttributes } from 'react'
+import React, { type ComponentPropsWithRef, ForwardRefExoticComponent, RefAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import {
   FontSizeProps,
@@ -77,10 +77,8 @@ export type InputHelperTextProps = TextProps & {
 export type InputProps = SpaceProps &
   FontSizeProps &
   ZIndexProps &
-  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> &
-  React.RefAttributes<HTMLInputElement> & {
+  Omit<ComponentPropsWithRef<'input'>, 'size'> & {
     children?: React.ReactNode
-    onChange?: React.ComponentProps<'input'>['onChange']
     helperText?: React.ReactElement<
       InputHelperTextProps,
       string | React.JSXElementConstructor<InputHelperTextProps>
@@ -101,7 +99,7 @@ export type InputWithRef = ForwardRefExoticComponent<Omit<InputProps, 'ref'> & R
 /**
  * @public
  */
-export const Input = React.forwardRef((props: InputProps, ref) => {
+export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const { helperText, color, ...restProps } = props
   return (
     <>

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -55,7 +55,7 @@ export type LabelProps = SpaceProps &
   TextStyleProps &
   WidthProps &
   Partial<Omit<HTMLLabelElement, 'children'>> & {
-    children?: React.ReactNode | string
+    children?: React.ReactNode
     color?: string
     autoHide?: boolean
     nowrap?: boolean

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { zIndex } from 'styled-system'
 import { Box } from '../Box/Box'
-import { Grid } from '../Grid/Grid'
+import { Grid, type GridProps } from '../Grid/Grid'
 import { spaceValues } from '../theme'
 
 const getWidthsForVariation = (variation: string | undefined) => {
@@ -107,7 +107,7 @@ export type LayoutVariation =
 /**
  * @public
  */
-export type LayoutProps = {
+export type LayoutProps = GridProps & {
   children: React.ReactNode
   gap?: LayoutGap
   rowGap?: LayoutGap

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -108,7 +108,7 @@ export type LayoutVariation =
  * @public
  */
 export type LayoutProps = {
-  children: React.ReactElement | React.ReactElement[]
+  children: React.ReactNode
   gap?: LayoutGap
   rowGap?: LayoutGap
   variation?: LayoutVariation

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -5,7 +5,7 @@ import { Box } from '../Box/Box'
 import { Grid } from '../Grid/Grid'
 import { spaceValues } from '../theme'
 
-const getWidthsForVariation = (variation: string) => {
+const getWidthsForVariation = (variation: string | undefined) => {
   return (
     variation &&
     variation
@@ -102,7 +102,7 @@ export type LayoutGap = (typeof ALLOWED_GAP_VALUES)[number] | Array<(typeof ALLO
  */
 export type LayoutVariation =
   | (typeof ALLOWED_LAYOUT_VALUES)[number]
-  | Array<(typeof ALLOWED_LAYOUT_VALUES)[number]>
+  | Array<(typeof ALLOWED_LAYOUT_VALUES)[number] | undefined>
 
 /**
  * @public

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -83,7 +83,7 @@ export type LinkProps = WidthProps &
   SpaceProps &
   React.AnchorHTMLAttributes<HTMLAnchorElement> &
   React.RefAttributes<unknown> & {
-    children?: React.ReactNode | string
+    children?: React.ReactNode
     color?: string
     disabled?: boolean
     href?: string

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -90,8 +90,8 @@ export type LinkProps = WidthProps &
     size?: ButtonSizes | ButtonSizes[]
     target?: string
     variation?: ButtonVariations
-    onClick?: React.MouseEventHandler<HTMLAnchorElement>
-    onFocus?: React.FocusEventHandler<HTMLAnchorElement>
+    onClick?: React.ComponentProps<'a'>['onClick']
+    onFocus?: React.ComponentProps<'a'>['onFocus']
   }
 
 /**

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled, { css } from 'styled-components'
 import { SpaceProps, WidthProps, compose, space, width } from 'styled-system'
 import { buttonStyles, type ButtonSizes, type ButtonVariations } from '../Button/Button'
@@ -81,8 +81,7 @@ const variations = {
  */
 export type LinkProps = WidthProps &
   SpaceProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
-  React.RefAttributes<unknown> & {
+  ComponentPropsWithRef<'a'> & {
     children?: React.ReactNode
     color?: string
     disabled?: boolean
@@ -90,8 +89,6 @@ export type LinkProps = WidthProps &
     size?: ButtonSizes | ButtonSizes[]
     target?: string
     variation?: ButtonVariations
-    onClick?: React.ComponentProps<'a'>['onClick']
-    onFocus?: React.ComponentProps<'a'>['onFocus']
   }
 
 /**

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -1,5 +1,5 @@
 import themeGet from '@styled-system/theme-get'
-import React from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled, { css } from 'styled-components'
 import { compose, fontSize, space, width, type FontSizeProps, type SpaceProps } from 'styled-system'
 import { type PaletteColor, type PaletteFamilyName } from '../theme/theme'
@@ -45,7 +45,7 @@ export type ListListStyle = (typeof listStyles)[number]
  */
 export type ListProps = FontSizeProps &
   SpaceProps &
-  React.HTMLAttributes<HTMLOListElement | HTMLUListElement> & {
+  ComponentPropsWithoutRef<'ul' | 'ol'> & {
     children?: React.ReactNode
     listStyle?: ListListStyle
     indentSize?: ListIndentSize

--- a/packages/core/src/PlaceholderImage/PlaceholderImage.tsx
+++ b/packages/core/src/PlaceholderImage/PlaceholderImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled from 'styled-components'
 import { Image } from '../Image/Image'
 
@@ -27,7 +27,7 @@ const determineSRC = (blur, chooseSrc, height, width) => {
 /**
  * @public
  */
-export type PlaceholderImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+export type PlaceholderImageProps = ComponentPropsWithoutRef<'img'> & {
   ariaHidden?: boolean
   blur?: boolean
   chooseSrc?: string

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -75,7 +75,7 @@ export type RadioProps = ComponentPropsWithoutRef<'input'> & {
 /**
  * @public
  */
-export const Radio: React.FC<RadioProps> = React.forwardRef<HTMLInputElement,RadioProps>((props, ref) => {
+export const Radio: React.FC<RadioProps> = React.forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const { checked, disabled, size } = props
 
   const borderAdjustedSize = size + 4

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -70,7 +70,7 @@ const RadioIcon = ({ checked, ...props }: RadioIconProps) => {
 export type RadioProps = React.InputHTMLAttributes<HTMLInputElement> & {
   size?: number
   color?: PaletteFamilyName
-  onClick?: (unknown) => unknown
+  onClick?: (e: unknown) => unknown
 }
 
 /**

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import { RadioChecked, RadioEmpty } from 'pcln-icons'
-import React from 'react'
+import React, { type ComponentPropsWithoutRef } from 'react'
 import styled from 'styled-components'
 import { type PaletteFamilyName } from '../theme/theme'
 import { applyVariations, getPaletteColor } from '../utils/utils'
@@ -67,16 +67,15 @@ const RadioIcon = ({ checked, ...props }: RadioIconProps) => {
 /**
  * @public
  */
-export type RadioProps = React.InputHTMLAttributes<HTMLInputElement> & {
+export type RadioProps = ComponentPropsWithoutRef<'input'> & {
   size?: number
   color?: PaletteFamilyName
-  onClick?: React.ComponentProps<'input'>['onClick']
 }
 
 /**
  * @public
  */
-export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => {
+export const Radio: React.FC<RadioProps> = React.forwardRef<HTMLInputElement,RadioProps>((props, ref) => {
   const { checked, disabled, size } = props
 
   const borderAdjustedSize = size + 4

--- a/packages/core/src/Radio/Radio.tsx
+++ b/packages/core/src/Radio/Radio.tsx
@@ -70,7 +70,7 @@ const RadioIcon = ({ checked, ...props }: RadioIconProps) => {
 export type RadioProps = React.InputHTMLAttributes<HTMLInputElement> & {
   size?: number
   color?: PaletteFamilyName
-  onClick?: (e: unknown) => unknown
+  onClick?: React.ComponentProps<'input'>['onClick']
 }
 
 /**

--- a/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
+++ b/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
@@ -41,7 +41,7 @@ export type TVPositions = (typeof RadioCheckToggleCardVPositions)[number]
  * @public
  */
 export type RadioCheckToggleCardProps = {
-  children?: React.ReactNode | string
+  children?: React.ReactNode
   cardType?: TCardTypes
   hPosition?: THPositions
   vPosition?: TVPositions

--- a/packages/core/src/Relative/Relative.tsx
+++ b/packages/core/src/Relative/Relative.tsx
@@ -17,7 +17,12 @@ import { Box, type BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type RelativeProps = TopProps & RightProps & BottomProps & LeftProps & ZIndexProps & BoxProps
+export type RelativeProps<T extends HTMLElement = HTMLDivElement> = TopProps &
+  RightProps &
+  BottomProps &
+  LeftProps &
+  ZIndexProps &
+  BoxProps<T>
 
 /**
  * @public

--- a/packages/core/src/Relative/Relative.tsx
+++ b/packages/core/src/Relative/Relative.tsx
@@ -17,12 +17,7 @@ import { Box, type BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type RelativeProps = TopProps &
-  RightProps &
-  BottomProps &
-  LeftProps &
-  ZIndexProps &
-  BoxProps
+export type RelativeProps = TopProps & RightProps & BottomProps & LeftProps & ZIndexProps & BoxProps
 
 /**
  * @public

--- a/packages/core/src/Relative/Relative.tsx
+++ b/packages/core/src/Relative/Relative.tsx
@@ -17,12 +17,12 @@ import { Box, type BoxProps } from '../Box/Box'
 /**
  * @public
  */
-export type RelativeProps<T extends HTMLElement = HTMLDivElement> = TopProps &
+export type RelativeProps = TopProps &
   RightProps &
   BottomProps &
   LeftProps &
   ZIndexProps &
-  BoxProps<T>
+  BoxProps
 
 /**
  * @public

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,6 +1,6 @@
 import themeGet from '@styled-system/theme-get'
 import { ChevronDown } from 'pcln-icons'
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled, { css } from 'styled-components'
 import { FontSizeProps, SpaceProps, borderRadius, compose, fontSize, space } from 'styled-system'
 import { Flex } from '../Flex/Flex'
@@ -78,12 +78,11 @@ export type SelectVariations = 'input' | 'subtle'
  */
 export type SelectProps = SpaceProps &
   FontSizeProps &
-  Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> & {
+  Omit<ComponentPropsWithRef<'select'>, 'size'> & {
     children?: React.ReactNode
     color?: PaletteColor
     borderRadius?: BorderRadius
     size?: SelectSizes
-    ref?: React.Ref<React.ForwardedRef<unknown>>
     variation?: SelectVariations
   }
 

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -14,7 +14,7 @@ import { useSlideBoxNav } from './useSlideBoxNav'
 export type SlideBoxProps = {
   children?: React.ReactNode
   visibleSlides?: Array<number> | number
-  onSlideChange?: (e: unknown) => unknown
+  onSlideChange?: (e: any) => unknown
   slideSpacing?: number
   stretchHeight?: boolean
   layout?: string

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -12,7 +12,7 @@ import { useSlideBoxNav } from './useSlideBoxNav'
  * @public
  */
 export type SlideBoxProps = {
-  children?: React.ReactNode | string
+  children?: React.ReactNode
   visibleSlides?: Array<number> | number
   onSlideChange?: (unknown) => unknown
   slideSpacing?: number

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -14,6 +14,7 @@ import { useSlideBoxNav } from './useSlideBoxNav'
 export type SlideBoxProps = {
   children?: React.ReactNode
   visibleSlides?: Array<number> | number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSlideChange?: (e: any) => unknown
   slideSpacing?: number
   stretchHeight?: boolean

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -14,7 +14,7 @@ import { useSlideBoxNav } from './useSlideBoxNav'
 export type SlideBoxProps = {
   children?: React.ReactNode
   visibleSlides?: Array<number> | number
-  onSlideChange?: (unknown) => unknown
+  onSlideChange?: (e: unknown) => unknown
   slideSpacing?: number
   stretchHeight?: boolean
   layout?: string

--- a/packages/core/src/Step/Step.tsx
+++ b/packages/core/src/Step/Step.tsx
@@ -26,7 +26,7 @@ export type StepProps = {
   active?: boolean
   completed?: boolean
   children?: React.ReactNode
-  onClick?: (unknown) => unknown
+  onClick?: (e: unknown) => unknown
 }
 
 /**

--- a/packages/core/src/Step/Step.tsx
+++ b/packages/core/src/Step/Step.tsx
@@ -25,7 +25,7 @@ export type StepProps = {
   className?: string
   active?: boolean
   completed?: boolean
-  children?: React.ReactNode | string
+  children?: React.ReactNode
   onClick?: (unknown) => unknown
 }
 

--- a/packages/core/src/Step/Step.tsx
+++ b/packages/core/src/Step/Step.tsx
@@ -1,7 +1,7 @@
 import { Check } from 'pcln-icons'
 import React from 'react'
 import styled from 'styled-components'
-import { Button } from '../Button/Button'
+import { Button, type ButtonProps } from '../Button/Button'
 import { Text } from '../Text/Text'
 import { getPaletteColor } from '../utils/utils'
 
@@ -26,7 +26,7 @@ export type StepProps = {
   active?: boolean
   completed?: boolean
   children?: React.ReactNode
-  onClick?: (e: unknown) => unknown
+  onClick?: ButtonProps['onClick']
 }
 
 /**

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import themeGet from '@styled-system/theme-get'
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled from 'styled-components'
 import { space, SpaceProps } from 'styled-system'
 import { applyVariations, borders, getPaletteColor } from '../utils/utils'
@@ -8,8 +8,7 @@ import { applyVariations, borders, getPaletteColor } from '../utils/utils'
  * @public
  */
 export type TextAreaProps = SpaceProps &
-  React.TextareaHTMLAttributes<HTMLTextAreaElement> &
-  React.RefAttributes<HTMLTextAreaElement> & { isField?: boolean }
+  ComponentPropsWithRef<'textarea'> & { isField?: boolean }
 
 /**
  * @public

--- a/packages/core/src/Toggle/Toggle.tsx
+++ b/packages/core/src/Toggle/Toggle.tsx
@@ -60,7 +60,7 @@ const WrapperBox = styled(Box)`
 export type ToggleProps = {
   isOn?: boolean
   label?: string
-  onToggle?: (unknown) => unknown
+  onToggle?: (e: unknown) => unknown
   disabled?: boolean
   width?: string
   height?: number

--- a/packages/core/src/Toggle/Toggle.tsx
+++ b/packages/core/src/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Absolute } from '../Absolute/Absolute'
-import { Box } from '../Box/Box'
+import { Box, type BoxProps } from '../Box/Box'
 import { getPaletteColor } from '../utils/utils'
 
 const alphaColor = (color: string, props) => `${getPaletteColor(color)(props)}4C`
@@ -60,7 +60,7 @@ const WrapperBox = styled(Box)`
 export type ToggleProps = {
   isOn?: boolean
   label?: string
-  onToggle?: (e: unknown) => unknown
+  onToggle?: BoxProps['onClick']
   disabled?: boolean
   width?: string
   height?: number

--- a/packages/core/src/ToggleBadge/ToggleBadge.tsx
+++ b/packages/core/src/ToggleBadge/ToggleBadge.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type ComponentPropsWithRef } from 'react'
 import styled from 'styled-components'
 import { FontSizeProps, SpaceProps, borderRadius, compose, fontSize, space } from 'styled-system'
 import { borderRadiusAttrs } from '../utils/attrs'
@@ -15,8 +15,7 @@ export type ToggleBadgeProps = {
   unSelectedBg?: string
 } & SpaceProps &
   FontSizeProps &
-  React.HTMLAttributes<HTMLInputElement> &
-  React.RefAttributes<HTMLInputElement>
+  ComponentPropsWithRef<'button'>
 
 /**
  * @public

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,7 +168,7 @@ export * from './utils'
 export { createTheme } from './utils/createTheme'
 
 export * from './theme'
-export type { PaletteColorPaletteFamily, PaletteColorPaletteFamilyOption, PaletteFamily } from './theme/theme'
+export type { PaletteFamily } from './theme/theme'
 
 // DocsUtils
 export { DoDont, type DoDontProps } from './DocsUtils/DoDont/DoDont'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,7 @@ export {
   type FilterChipProps,
   type FilterChipVariation,
 } from './Chip/FilterChip/FilterChip'
-export { CloseButton, type CloseButtonProps } from './CloseButton/CloseButton'
+export { CloseButton, type CloseButtonProps, type MotionButtonProps } from './CloseButton/CloseButton'
 export {
   closeButtonSizes,
   closeButtonVariants,

--- a/packages/core/src/theme/theme.ts
+++ b/packages/core/src/theme/theme.ts
@@ -629,21 +629,8 @@ export type PaletteFamilies = Record<PaletteFamilyName, PaletteFamily>
 /**
  * @public
  */
-export type PaletteColorPaletteFamily = Array<keyof PaletteFamilies>[number]
+export type PaletteColor = `${PaletteFamilyName}.${PaletteFamilyVariation}`
 
-/**
- * @public
- */
-export type PaletteColorPaletteFamilyOption = Array<keyof PaletteFamily>[number]
-
-/**
- * @public
- */
-export type PaletteColor = `${PaletteColorPaletteFamily}.${PaletteColorPaletteFamilyOption}`
-
-/**
- * @public
- */
 export const paletteColors = paletteFamilyNames.flatMap((family) =>
   paletteFamilyVariations.map((variation) => `${family}.${variation}`)
 )

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -250,7 +250,10 @@ export const applyVariations =
  * @public
  */
 export function getPaletteColor(
-  ...args: [PaletteColor | PaletteFamilyName | PaletteFamilyVariation | string, PaletteFamilyVariation?]
+  ...args: [
+    PaletteColor | PaletteFamilyName | PaletteFamilyVariation | string,
+    (PaletteColor | PaletteFamilyVariation)?
+  ]
 ) {
   return (props) => {
     let color = args.length === 2 ? args[0] : props.color

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import themeGet from '@styled-system/theme-get'
 import { css } from 'styled-components'
-import { mediaQueries } from '../theme'
+import { mediaQueries, type PaletteFamilyName, type PaletteColor, PaletteFamilyVariation } from '../theme'
 
 /**
  * Checks if the given color prop is a valid palette color
@@ -249,9 +249,10 @@ export const applyVariations =
  *
  * @public
  */
-export const getPaletteColor =
-  (...args) =>
-  (props) => {
+export function getPaletteColor(
+  ...args: [PaletteColor | PaletteFamilyName | PaletteFamilyVariation | string, PaletteFamilyVariation?]
+) {
+  return (props) => {
     let color = args.length === 2 ? args[0] : props.color
     let shade = args.length === 2 ? args[1] : args[0]
 
@@ -262,13 +263,12 @@ export const getPaletteColor =
       shade = colorShade[1]
     }
 
-    return (
-      themeGet(`palette.${color}.${shade}`)(props) ||
+    return (themeGet(`palette.${color}.${shade}`)(props) ||
       themeGet(`palette.${color}`)(props) ||
       themeGet(`colors.${color}`)(props) ||
-      color
-    )
+      color) as string
   }
+}
 
 /**
  * @public


### PR DESCRIPTION
### Description/Summary of changes

- Avoid unions where `ReactNode` was being used. The type `ReactNode` itself is unioin of all possible types that React can render
- Consistently type children prop with `ReactNode`
- Substitute the type `*HTMLAttributes` with `ComponentPropsWithRef` or `ComponentPropsWithoutRef`. Read [here](https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase#wrappingmirroring-a-html-element) for further info on this.
- Remove explicitly typed `ref` props and instead leverage  `ComponentPropsWithRef`. This ensures support for `ForwardRef` typing, where the impacted component are used in a `forwardRef`
- Use explicit typings for `React.forwardRef` where required
- Remove explicitly typed handlers like `onClick` and instead using `ComponentProps*`
- Strongly type handlers for composed components based on where the handler is being passed
- Updating `IconLeft` and `IconRight` typings for `Button` component
- Allow `Layout` to accept `undefined` for the `variation` prop when it receives an array
- Reuse the `BorderRadius` and `BoxShadowSize` types on `Box` and `Button`
- Enhance props of certain components based on how they pass the props to their child components
- Attempt to add typings to `getPaletteColor`