### PR TITLE
fix(UXPT-7566): support programatic control of the popover

### DIFF
--- a/common/changes/pcln-popover/fix-UXPT-7566-toggleIsOpenOnClick_2024-07-09-14-11.json
+++ b/common/changes/pcln-popover/fix-UXPT-7566-toggleIsOpenOnClick_2024-07-09-14-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "built in support for toggleIsOpenOnClick so people can programatically control the open and close without sideeffects",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/popover/src/Popover/Popover.jsx
+++ b/packages/popover/src/Popover/Popover.jsx
@@ -54,7 +54,7 @@ function Popover({
             'aria-label': ariaLabel,
             type: 'button',
             ref: reference,
-            onClick: !openOnHover && toggleIsOpenOnClick && handleToggle || function () {},
+            onClick: !openOnHover && (toggleIsOpenOnClick ? handleToggle : () => {}),
           }),
         })}
       {(isPopoverOpen || isOpen) && (

--- a/packages/popover/src/Popover/Popover.jsx
+++ b/packages/popover/src/Popover/Popover.jsx
@@ -20,6 +20,7 @@ function Popover({
   onClose,
   onBeforeOpen,
   onBeforeClose,
+  toggleIsOpenOnClick,
   ...props
 }) {
   const {
@@ -53,7 +54,7 @@ function Popover({
             'aria-label': ariaLabel,
             type: 'button',
             ref: reference,
-            onClick: !openOnHover && handleToggle,
+            onClick: !openOnHover && toggleIsOpenOnClick && handleToggle || function () {},
           }),
         })}
       {(isPopoverOpen || isOpen) && (

--- a/packages/popover/src/Popover/Popover.spec.js
+++ b/packages/popover/src/Popover/Popover.spec.js
@@ -40,6 +40,32 @@ describe('Popover', () => {
       expect(container.firstChild).toMatchSnapshot()
     })
 
+    it('does not toggle the element visibility when "toggleOpenOnClick" is false and the user clicks (controlled by isOpen only)', () => {
+      const mockOnOpen = jest.fn()
+      const mockOnClose = jest.fn()
+      const { rerender, getByText, queryByText } = render(
+        <Popover {...popoverProps} toggleIsOpenOnClick={false} onOpen={mockOnOpen} onClose={mockOnClose} isOpen={false}>
+          <button>{triggerButtonText}</button>
+        </Popover>
+      )
+      // Click the button, it should NOT open
+      const button = getByText(triggerButtonText)
+      fireEvent.click(button)
+      expect(queryByText('Click me to close button!')).toBeFalsy()
+      fireEvent.click(button)
+      expect(mockOnOpen).toHaveBeenCalledTimes(0)
+
+      // Update the isOpen prop
+      rerender(
+        <Popover {...popoverProps} toggleIsOpenOnClick={false} onOpen={mockOnOpen} onClose={mockOnClose} isOpen={true}>
+        <button>{triggerButtonText}</button>
+      </Popover>
+      )
+
+      // Now that the component has been re-rendered with isOpen set to true we should see the popover content
+      expect(queryByText('Click me to close button!')).toBeTruthy()
+    })
+
     it('toggle popover from trigger element', () => {
       const { getByText, getByLabelText, queryByText } = render(
         <Popover {...popoverProps}>

--- a/packages/popover/src/Popover/Popover.stories.jsx
+++ b/packages/popover/src/Popover/Popover.stories.jsx
@@ -407,3 +407,32 @@ export const DisableFloating = (args) => (
     </Flex>
   </Flex>
 )
+
+const ControlledTemplate = ({ isOpen, handleOpen, handleClose, ...args }) => (
+  <>
+    <div>Below is a button that you can't open by clicking. Instead you must use the controls tab at the bottom to modify the <strong>isOpen</strong> prop. If you do it, an unbelievable fact will be revealed.</div>
+    <Popover
+      {...args}
+      isOpen={isOpen}
+      renderContent={({}) => (
+        <Box p={2}>
+         {`Tardigrades can survive in the vacuum of space, endure extreme temperatures from just above absolute zero to over 300 degrees Fahrenheit, withstand high levels of radiation, and go without water for decades by entering a state called cryptobiosis. When conditions improve, they can rehydrate and return to their normal functioning state.`}
+        </Box>
+      )}
+    >
+      <Button>
+        Tee Hee
+      </Button>
+    </Popover>
+  </>
+)
+
+export const OpensAndClosesProgrammatically = {
+  name: 'Tests / Opens and closes programmatically',
+  render: ControlledTemplate.bind({}),
+  args: {
+    isOpen: false,
+    openOnHover: false,
+    toggleIsOpenOnClick: false,
+  }
+}


### PR DESCRIPTION
There is an issue for certain use-cases where we need to control the open/close state solely with prop changes. This prevents the click handler from automatically opening and closing the popover when `toggleIsOpenOnClick` is set to false. 

This logic is used to conditionally set the onClick handler based on the values of openOnHover, toggleIsOpenOnClick, and handleToggle. If the conditions are not met, it ensures that onClick is set to a no-op function (function() {}), preventing any potential errors from undefined or null references.

