### PR TITLE
feat(UXPT-6345): add a new parameter 'shouldDisableTabIndex' to Dialog component

### DIFF
--- a/common/changes/pcln-design-system/feat-UXPT-6345_2024-07-24-16-29.json
+++ b/common/changes/pcln-design-system/feat-UXPT-6345_2024-07-24-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "feat(UXPT-6345): add a new parameter 'shouldDisableTabIndex' to Dialog component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Dialog/Dialog.spec.tsx
+++ b/packages/core/src/Dialog/Dialog.spec.tsx
@@ -53,6 +53,46 @@ describe('Dialog', () => {
     })
   })
 
+  it('Add the tabIndex attribution to element as default', async () => {
+    render(
+      <Dialog triggerNode={<button>{triggerText}</button>} ariaDescription='Description' ariaTitle='Title'>
+        {contentText}
+      </Dialog>
+    )
+
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    await waitFor(() => {
+      const element = screen.getByRole('dialog', { name: 'Title' })
+      expect(element).toBeInTheDocument()
+      expect(element).toHaveAttribute('aria-describedby', 'Description')
+      expect(element).toHaveAttribute('tabindex', '-1')
+    })
+  })
+
+  it('Do not add the tabIndex attribution to element if shouldDisableTabIndex is true', async () => {
+    render(
+      <Dialog
+        triggerNode={<button>{triggerText}</button>}
+        ariaDescription='Description'
+        ariaTitle='Title'
+        shouldDisableTabIndex={true}
+      >
+        {contentText}
+      </Dialog>
+    )
+
+    const triggerNode = screen.getByText(triggerText)
+    triggerNode.click()
+
+    await waitFor(() => {
+      const element = screen.getByRole('dialog', { name: 'Title' })
+      expect(element).toBeInTheDocument()
+      expect(element).not.toHaveAttribute('tabindex')
+    })
+  })
+
   it.skip('calls onOpenChange when trigger is clicked', () => {
     const onOpenChange = jest.fn()
     render(

--- a/packages/core/src/Dialog/Dialog.stories.args.tsx
+++ b/packages/core/src/Dialog/Dialog.stories.args.tsx
@@ -24,6 +24,7 @@ export const argTypes: Partial<ArgTypes<DialogProps>> = {
   triggerNode: { control: { type: 'none' } },
   overflowX: { control: { type: 'select' }, options: overflowArgs },
   overflowY: { control: { type: 'select' }, options: overflowArgs },
+  shouldDisableTabIndex: { control: { type: 'boolean' } },
 }
 
 export const defaultArgs: Partial<DialogProps> = {
@@ -55,4 +56,5 @@ export const defaultArgs: Partial<DialogProps> = {
   triggerNode: <Button>Open Dialog</Button>,
   overflowX: 'auto',
   overflowY: 'auto',
+  shouldDisableTabIndex: undefined,
 }

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -176,7 +176,6 @@ export const DialogContent = ({
   onOpenChange,
   shouldDisableTabIndex,
 }: DialogProps) => {
-  console.log('shouldDisableTabIndex', shouldDisableTabIndex)
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
     headerIcon ? 'heading5' : 'heading4', // sm

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -174,7 +174,9 @@ export const DialogContent = ({
   size,
   zIndex,
   onOpenChange,
+  shouldDisableTabIndex,
 }: DialogProps) => {
+  console.log('shouldDisableTabIndex', shouldDisableTabIndex)
   const headerSizeArray = [
     headerIcon ? 'heading5' : 'heading4', // xs
     headerIcon ? 'heading5' : 'heading4', // sm
@@ -205,6 +207,7 @@ export const DialogContent = ({
         zIndex={zIndex}
         hasFooterContent={footerContent}
         {...(sheet ? animationStyles.sheet : animationStyles.default)}
+        {...(typeof shouldDisableTabIndex === 'boolean' && shouldDisableTabIndex && { tabIndex: undefined })}
       >
         {showCloseButton && (
           <Dialog.Close asChild>

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -35,6 +35,7 @@ export type DialogProps = Omit<OverflowProps, 'overflow'> & {
   zIndex?: ZIndex
   onOpenChange?: (open: boolean) => void
   showScrollShadow?: boolean
+  shouldDisableTabIndex?: boolean
 }
 
 /**
@@ -67,6 +68,7 @@ const PclnDialog = ({
   overflowX = 'auto',
   overflowY = 'auto',
   onOpenChange,
+  shouldDisableTabIndex,
 }: DialogProps) => {
   const [_open, setOpen] = React.useState(open ?? defaultOpen)
 
@@ -104,6 +106,7 @@ const PclnDialog = ({
               showCloseButton={showCloseButton}
               size={size}
               showScrollShadow={showScrollShadow}
+              shouldDisableTabIndex={shouldDisableTabIndex}
             >
               {children}
             </DialogContent>


### PR DESCRIPTION
**Desc:**

When I fixing a Penny chat bot accessibility issue, we couldn't swtich elemenets in chat bot modal by using 'tab' key.
After a long investigation, I found it's due to `tabindex='-1'` in `<Dialog/>` component. When I remove tabindex attribution from `<Dialog/>`, the accessibility issue is gone, we can swtich elemenets in chat bot modal by using 'tab' key. And I also found the `tabindex='-1'` in Dialog elemenet seems it's a default value. (Video recording of this issue https://app.screencastify.com/v3/watch/L7vnzLf7ZWQYuIibKmsh)

So I have two options to fix it,

Option 1 is to write a logic in penny chat bot, to get rid of tabindex from `<Dialog/>` when modal is rendered.

Option 2 is to update `<Dialog/>` component in pcln-design-system, to accept a new optional parameter, eg. shouldDisableTabIndex, if this param is `true`, then not add tabindex to element.

My personally I perfer Option 2 much more.


**Beta version:**

`6.17.1-beta-bobby-1`

**Testings screenshots:**

![image](https://github.com/user-attachments/assets/35b9780d-53bd-4221-8044-86090017ee2a)

![image](https://github.com/user-attachments/assets/4bb35f7d-fb2e-4356-b0f8-17580747d62e)

![image](https://github.com/user-attachments/assets/1e092f3a-e93f-4d4f-889d-7013415439da)

![image](https://github.com/user-attachments/assets/7ace24d4-be57-406c-a186-29b0547b4a7d)
