### PR TITLE
Slidebox key access

### DIFF
--- a/common/changes/pcln-design-system/slideboxKeyAccess_2024-07-25-19-37.json
+++ b/common/changes/pcln-design-system/slideboxKeyAccess_2024-07-25-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "remove special prop key access from slidebox",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/SlideBox/SlideBox.tsx
+++ b/packages/core/src/SlideBox/SlideBox.tsx
@@ -82,7 +82,7 @@ export function SlideBox({
       >
         {childArray.map((item: string & React.JSX.Element, index: number) => (
           <Slide
-            key={item.props.key || `slide${index}`}
+            key={`slide${index}`}
             width={layout ? getCustomWidths(layout.split('-'), index) : getVisibleSlides(visibleSlides)}
             onSlideChange={onSlideChangeWrapper}
             slideSpacing={slideSpacing}


### PR DESCRIPTION
* Slide component was trying to access key from props.
* `key` is a special prop https://react.dev/warnings/special-props  and shouldn't be read from a component.
* This pr removes the read and just keeps the map index as slide key 