### PR TITLE
feat(UXPT-7739): Leverage the CloseButton for the ChatHeader

### DIFF
--- a/common/changes/pcln-design-system/feat-UXPT-7739-replace-close-button-styling_2024-08-05-18-18.json
+++ b/common/changes/pcln-design-system/feat-UXPT-7739-replace-close-button-styling_2024-08-05-18-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Modified the chatHeader component so that it uses the CloseButton",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/ChatHeader/ChatHeader.spec.tsx
+++ b/packages/core/src/ChatHeader/ChatHeader.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen, fireEvent } from '../__test__/testing-library'
+import { ChatHeader } from './ChatHeader'
+
+describe('ChatHeader', () => {
+  test('renders children', () => {
+    render(<ChatHeader onClose={jest.fn()}>Header Content</ChatHeader>)
+
+    expect(screen.getByText('Header Content')).toBeInTheDocument()
+  })
+
+  test('calls onClose when close button is clicked', () => {
+    const onClose = jest.fn()
+    render(<ChatHeader onClose={onClose}>Header Content</ChatHeader>)
+    // Minimize button shouldn't be present if we haven't provided a function to call when clicked
+    const minimizeButton = screen.queryByTestId('chat-header-minimize-button')
+    expect(minimizeButton).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('chat-header-close-button'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test('calls onMinimize when minimize button is clicked', () => {
+    const onMinimize = jest.fn()
+    render(
+      <ChatHeader onMinimize={onMinimize} onClose={jest.fn()}>
+        Header Content
+      </ChatHeader>
+    )
+
+    fireEvent.click(screen.getByTestId('chat-header-minimize-button'))
+
+    expect(onMinimize).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/ChatHeader/ChatHeader.stories.tsx
+++ b/packages/core/src/ChatHeader/ChatHeader.stories.tsx
@@ -31,7 +31,7 @@ const Children = (
   </Flex>
 )
 
-export const _ChatHeader: ChatHeaderStory = {
+export const _ChatHeaderWithMinimize: ChatHeaderStory = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement)
 
@@ -44,4 +44,20 @@ export const _ChatHeader: ChatHeaderStory = {
     await expect(args.onClose).toHaveBeenCalled()
   },
   render: (args) => <ChatHeader {...args}>{Children}</ChatHeader>,
+}
+
+export const _ChatHeaderWithoutMinimize: ChatHeaderStory = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Penny')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getAllByRole('button')[0])
+    await expect(args.onClose).toHaveBeenCalled()
+  },
+  render: (args) => (
+    <ChatHeader {...args} onMinimize={undefined}>
+      {Children}
+    </ChatHeader>
+  ),
 }

--- a/packages/core/src/ChatHeader/ChatHeader.tsx
+++ b/packages/core/src/ChatHeader/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import { Close, Minus } from 'pcln-icons'
+import { Minus } from 'pcln-icons'
 import React from 'react'
 import styled from 'styled-components'
 import { Box } from '../Box/Box'
@@ -6,6 +6,7 @@ import { Button } from '../Button/Button'
 import { Flex } from '../Flex/Flex'
 import { Hide } from '../Hide/Hide'
 import { getPaletteColor } from '../utils/utils'
+import { CloseButton } from '../CloseButton/CloseButton'
 
 const BorderBottomFlex = styled(Flex)`
   border-bottom: 1px solid ${getPaletteColor('border.base')};
@@ -28,7 +29,7 @@ const HeaderButton = styled(Button)`
 export type ChatHeaderProps = {
   children: React.ReactNode
   onClose: () => void
-  onMinimize: () => void
+  onMinimize?: () => void
 }
 
 /**
@@ -39,10 +40,17 @@ export function ChatHeader({ children, onClose, onMinimize }: ChatHeaderProps) {
     <BorderBottomFlex alignItems='center' justifyContent='space-between' p={3}>
       <Box>{children}</Box>
       <Flex>
-        <Hide xs sm md>
-          <HeaderButton IconLeft={Minus} onClick={onMinimize} mr={2} />
-        </Hide>
-        <HeaderButton IconLeft={Close} onClick={onClose} />
+        {onMinimize && (
+          <Hide xs sm md>
+            <HeaderButton
+              IconLeft={Minus}
+              onClick={onMinimize}
+              mr={2}
+              data-testid='chat-header-minimize-button'
+            />
+          </Hide>
+        )}
+        <CloseButton onClick={onClose} data-testid='chat-header-close-button' />
       </Flex>
     </BorderBottomFlex>
   )


### PR DESCRIPTION
Minor modifications to the ChatHeader component:
1. The close button is now a CloseButton component
2. `onMinimize` is now optional and the `minimize` button will only be displayed if the `onMinimize` prop is passed.

Below is a comparison of old vs new. Old is on left, new is on right:

https://github.com/user-attachments/assets/4e8d2711-1fca-48ac-bcae-f00ab292a9f1

