### PR TITLE
fix(RC-25445): use querySelectorPortal in pcln-menu and pcln-popover only when provided as a prop

### DIFF
--- a/common/changes/pcln-design-system/fix-RC-25445-menuSSR_2024-08-12-15-53.json
+++ b/common/changes/pcln-design-system/fix-RC-25445-menuSSR_2024-08-12-15-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "use querySelectorPortal in pcln-menu only when provided to fix SSR issues",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-menu/fix-RC-25445-menuSSR_2024-08-12-15-53.json
+++ b/common/changes/pcln-menu/fix-RC-25445-menuSSR_2024-08-12-15-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-menu",
+      "comment": "use querySelectorPortal in pcln-menu only when provided to fix SSR issues",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-menu"
+}

--- a/common/changes/pcln-popover/fix-RC-25445-menuSSR_2024-08-12-16-20.json
+++ b/common/changes/pcln-popover/fix-RC-25445-menuSSR_2024-08-12-16-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/common/changes/pcln-popover/fix-RC-25445-menuSSR_2024-08-12-16-27.json
+++ b/common/changes/pcln-popover/fix-RC-25445-menuSSR_2024-08-12-16-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-popover",
+      "comment": "do not query the DOM if querySelectorPortal is falsy",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-popover"
+}

--- a/packages/menu/src/Menu/Menu.jsx
+++ b/packages/menu/src/Menu/Menu.jsx
@@ -69,7 +69,7 @@ function Menu({
         trapFocus={trapFocus}
         width={width}
         zIndex={zIndex}
-        querySelectorPortal={querySelectorPortal && `.${querySelectorPortal}`}
+        querySelectorPortal={querySelectorPortal ? `.${querySelectorPortal}` : undefined}
         {...props}
       >
         <ClickableNode />

--- a/packages/menu/src/Menu/Menu.jsx
+++ b/packages/menu/src/Menu/Menu.jsx
@@ -69,14 +69,14 @@ function Menu({
         trapFocus={trapFocus}
         width={width}
         zIndex={zIndex}
-        querySelectorPortal={`.${querySelectorPortal}`}
+        querySelectorPortal={querySelectorPortal && `.${querySelectorPortal}`}
         {...props}
       >
         <ClickableNode />
       </Popover>
-      {querySelectorPortal ? (
-        <div style={{ width: 0, display: 'inline-block' }} className={querySelectorPortal} />
-      ) : null}
+      {querySelectorPortal && (
+        <div style={{ width: 0, display: 'inline-block' }} className={querySelectorPortal} data-testid={querySelectorPortal} />
+      )}
     </>
   )
 }

--- a/packages/menu/src/Menu/Menu.spec.js
+++ b/packages/menu/src/Menu/Menu.spec.js
@@ -121,4 +121,26 @@ describe('Menu', () => {
     const dialog = await screen.findByRole('dialog')
     expect(dialog).toHaveAttribute('data-placement', 'bottom')
   })
+
+  it('renders a div with querySelectorPortal className when querySelectorPortal is provided', async () => {
+    const { getByTestId } = render(
+      <Menu id='menu' idx='1' buttonText='Click Me' placement='bottom' querySelectorPortal='popover-portal'>
+        <MenuItem>Item One</MenuItem>
+        <MenuItem>Item Two</MenuItem>
+      </Menu>
+    )
+
+    expect(getByTestId('popover-portal')).toBeInTheDocument()
+  })
+
+  it('does not render a div with querySelectorPortal className when querySelectorPortal is not provided', async () => {
+    const { queryByTestId } = render(
+      <Menu id='menu' idx='1' buttonText='Click Me' placement='bottom'>
+        <MenuItem>Item One</MenuItem>
+        <MenuItem>Item Two</MenuItem>
+      </Menu>
+    )
+
+    expect(queryByTestId('popover-portal')).toBeFalsy()
+  })
 })

--- a/packages/menu/src/Menu/Menu.spec.js
+++ b/packages/menu/src/Menu/Menu.spec.js
@@ -123,24 +123,24 @@ describe('Menu', () => {
   })
 
   it('renders a div with querySelectorPortal className when querySelectorPortal is provided', async () => {
-    const { getByTestId } = render(
+    render(
       <Menu id='menu' idx='1' buttonText='Click Me' placement='bottom' querySelectorPortal='popover-portal'>
         <MenuItem>Item One</MenuItem>
         <MenuItem>Item Two</MenuItem>
       </Menu>
     )
 
-    expect(getByTestId('popover-portal')).toBeInTheDocument()
+    expect(screen.getByTestId('popover-portal')).toBeInTheDocument()
   })
 
   it('does not render a div with querySelectorPortal className when querySelectorPortal is not provided', async () => {
-    const { queryByTestId } = render(
+    render(
       <Menu id='menu' idx='1' buttonText='Click Me' placement='bottom'>
         <MenuItem>Item One</MenuItem>
         <MenuItem>Item Two</MenuItem>
       </Menu>
     )
 
-    expect(queryByTestId('popover-portal')).toBeFalsy()
+    expect(screen.queryByTestId('popover-portal')).toBeFalsy()
   })
 })

--- a/packages/popover/src/PopoverContent/PopoverContent.jsx
+++ b/packages/popover/src/PopoverContent/PopoverContent.jsx
@@ -69,7 +69,7 @@ function PopoverContent({
 
   // Fallback when cannot find an element
   useLayoutEffect(() => {
-    if (document.querySelector(querySelectorPortal)) {
+    if (querySelectorPortal && document.querySelector(querySelectorPortal)) {
       setPortalSelector(querySelectorPortal)
     } else {
       setPortalSelector('body')

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -84,4 +84,18 @@ describe('PopoverContent', () => {
     const bodyContainer = document.querySelector('body > [role="dialog"]')
     expect(bodyContainer).toBeInTheDocument()
   })
+
+  it('not using portal fallback to a body', () => {
+    const Wrapper = () => (
+      <>
+        <PopoverContent renderContent={() => 'Content'} />
+        <div className='wrapper'></div>
+      </>
+    )
+    render(<Wrapper />)
+    const container = document.querySelector('.wrapper > [role="dialog"]')
+    expect(container).not.toBeInTheDocument()
+    const bodyContainer = document.querySelector('body > [role="dialog"]')
+    expect(bodyContainer).toBeInTheDocument()
+  })
 })

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -89,12 +89,9 @@ describe('PopoverContent', () => {
     const Wrapper = () => (
       <>
         <PopoverContent renderContent={() => 'Content'} />
-        <div className='wrapper'></div>
       </>
     )
     render(<Wrapper />)
-    const container = document.querySelector('.wrapper > [role="dialog"]')
-    expect(container).not.toBeInTheDocument()
     const bodyContainer = document.querySelector('body > [role="dialog"]')
     expect(bodyContainer).toBeInTheDocument()
   })

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -71,7 +71,7 @@ describe('PopoverContent', () => {
     expect(container).toBeInTheDocument()
   })
 
-  it('Using different portal fallback to a body', () => {
+  it('falls back to use body as a selector when receiving a mismatched portal selector', () => {
     const Wrapper = () => (
       <>
         <PopoverContent renderContent={() => 'Content'} querySelectorPortal='.wrong-wrapper' />
@@ -85,10 +85,11 @@ describe('PopoverContent', () => {
     expect(bodyContainer).toBeInTheDocument()
   })
 
-  it('not using portal fallback to a body', () => {
+  it('falls back to use body as a selector when not receivinga portal selector', () => {
     const Wrapper = () => (
       <>
         <PopoverContent renderContent={() => 'Content'} />
+        <div className='wrapper'></div>
       </>
     )
     render(<Wrapper />)

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -89,7 +89,6 @@ describe('PopoverContent', () => {
     const Wrapper = () => (
       <>
         <PopoverContent renderContent={() => 'Content'} />
-        <div className='wrapper'></div>
       </>
     )
     render(<Wrapper />)

--- a/packages/popover/src/PopoverContent/PopoverContent.spec.js
+++ b/packages/popover/src/PopoverContent/PopoverContent.spec.js
@@ -85,7 +85,7 @@ describe('PopoverContent', () => {
     expect(bodyContainer).toBeInTheDocument()
   })
 
-  it('falls back to use body as a selector when not receivinga portal selector', () => {
+  it('falls back to use body as a selector when not receiving a portal selector', () => {
     const Wrapper = () => (
       <>
         <PopoverContent renderContent={() => 'Content'} />


### PR DESCRIPTION
Update (9/4): This PR doesn't fix the original hydration issue but it resolves other potential bugs.
Apparently there is a [known issue](https://github.com/remix-run/remix/issues/4822) with React 18 where browser extensions will cause hydration issues. This makes sense because when we are developing alt-landing app locally we are using the Modheader chrome extension. Bumping to React 18 canary version/React 19 will solve browser extensions+hydration issue. 

I noticed a hydration issue with `CurrencySelector` in `@pcln/selectors` while trying to migrate alt-landing app (which is only used for Airport Rental Cars landing page) to use DS6+React 18. `@pcln/selectors > CurrencySelector` is used in `@pcln/white-label-components` > `Header`.

@sdalonzo pointed out there was a bug with pcln-menu and pcln-popover (thank you!). In this PR I am making updates and adding test cases so that `querySelectorPortal` is only used in `pcln-menu` and `pcln-popover` only when provided as a prop.