### PR TITLE
feat(PB-3722): update Carousel to allow custom vertical slide padding

### DIFF
--- a/common/changes/pcln-carousel/pb-3722-make-y-spacing-optional_2024-11-04-19-46.json
+++ b/common/changes/pcln-carousel/pb-3722-make-y-spacing-optional_2024-11-04-19-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-carousel",
+      "comment": "add slidePaddingY prop for custom vertical padding on slides",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-carousel"
+}

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -52,7 +52,7 @@ export const Carousel = ({
   visibleSlides = 1,
   arrowsPosition = 'side',
   slideSpacing = 2,
-  onlySpaceSlideX = false,
+  slidePaddingY = slideSpacing,
   onSlideChange,
   sideButtonMargin = '-30px',
   sidePositionArrowButton,
@@ -181,11 +181,7 @@ export const Carousel = ({
                     onSlideChange={onSlideChange}
                     displayArrowsMobile={displayArrowsMobile}
                   >
-                    <Box
-                      p={!onlySpaceSlideX && slideSpacing}
-                      px={onlySpaceSlideX && slideSpacing}
-                      height='100%'
-                    >
+                    <Box p={slideSpacing} py={slidePaddingY} height='100%'>
                       {!layout && stretchSlideHeight
                         ? React.cloneElement(item, { style: { 'min-height': '100%' } })
                         : item}
@@ -289,8 +285,8 @@ Carousel.propTypes = {
   arrowsPosition: PropTypes.oneOf(['side', 'top', 'bottom', 'hide']),
   /** Padding around the slides */
   slideSpacing: PropTypes.number,
-  /** Only apply horizontal padding around the slides */
-  onlySpaceSlideX: PropTypes.bool,
+  /** Vertical padding for the slides */
+  slidePaddingY: PropTypes.number,
   /** Custom arrow button margin for side position/horizontal orientation */
   sideButtonMargin: PropTypes.string,
   /** Called each time the current slide changes, passed the new currentSlide (zero-indexed) */

--- a/packages/carousel/src/Carousel.jsx
+++ b/packages/carousel/src/Carousel.jsx
@@ -52,6 +52,7 @@ export const Carousel = ({
   visibleSlides = 1,
   arrowsPosition = 'side',
   slideSpacing = 2,
+  onlySpaceSlideX = false,
   onSlideChange,
   sideButtonMargin = '-30px',
   sidePositionArrowButton,
@@ -180,7 +181,11 @@ export const Carousel = ({
                     onSlideChange={onSlideChange}
                     displayArrowsMobile={displayArrowsMobile}
                   >
-                    <Box p={slideSpacing} height='100%'>
+                    <Box
+                      p={!onlySpaceSlideX && slideSpacing}
+                      px={onlySpaceSlideX && slideSpacing}
+                      height='100%'
+                    >
                       {!layout && stretchSlideHeight
                         ? React.cloneElement(item, { style: { 'min-height': '100%' } })
                         : item}
@@ -284,6 +289,8 @@ Carousel.propTypes = {
   arrowsPosition: PropTypes.oneOf(['side', 'top', 'bottom', 'hide']),
   /** Padding around the slides */
   slideSpacing: PropTypes.number,
+  /** Only apply horizontal padding around the slides */
+  onlySpaceSlideX: PropTypes.bool,
   /** Custom arrow button margin for side position/horizontal orientation */
   sideButtonMargin: PropTypes.string,
   /** Called each time the current slide changes, passed the new currentSlide (zero-indexed) */


### PR DESCRIPTION
Changes:
- added `slidePaddingY` prop to allow for custom vertical slide padding (defaults to `slideSpacing` to be backwards compatible) 