### PR TITLE
Task/htl 111365 fix props override for collapse and close

### DIFF
--- a/common/changes/pcln-design-system/task-HTL-111365-fix-props-override-for-collapse-and-close_2024-11-08-16-49.json
+++ b/common/changes/pcln-design-system/task-HTL-111365-fix-props-override-for-collapse-and-close_2024-11-08-16-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Fix storybook buttons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -21,9 +21,9 @@ function DrawerStory(props) {
         heading='Header'
         isOpen={isOpen}
         isCollapsed={isCollapsed}
+        {...props}
         onClose={includeCloseButton ? () => setIsOpen(false) : undefined}
         onCollapse={includeCollapseButton ? () => setIsCollapsed((isCollapsed) => !isCollapsed) : undefined}
-        {...props}
       >
         {props.children}
       </Drawer>

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -79,8 +79,8 @@ export const Drawer: React.FC<DrawerProps> = ({
           maxHeight={isMobile ? ['290px', '400px', '480px', 'calc(100vh - 64px)'] : props.height ?? '100%'}
           maxWidth={isMobile ? '100%' : ['400px', '600px', '800px', '100%']}
           width={isMobile ? '100%' : props.width}
-          height={!isCollapsed && props.height ? props.height : 'fit-content'}
           {...props}
+          height={!isCollapsed && props.height ? props.height : 'fit-content'}
         >
           <DrawerRoot
             data-testid='drawer'


### PR DESCRIPTION
Previously this was frozen due to prop override, fixed now.
<img width="656" alt="Screenshot 2024-11-08 at 11 50 25 AM" src="https://github.com/user-attachments/assets/b1cbed87-4fc9-4a3b-b252-c9a9011a0ddd">
