### PR TITLE
add z-index to icon button in password input in order to make it clickable

### DIFF
--- a/common/changes/pcln-design-system/bugfix-password-input_2024-11-13-19-16.json
+++ b/common/changes/pcln-design-system/bugfix-password-input_2024-11-13-19-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add zindex to IconButton in PasswordInput",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-icons/bugfix-password-input_2024-11-13-19-16.json
+++ b/common/changes/pcln-icons/bugfix-password-input_2024-11-13-19-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-icons"
+}

--- a/packages/core/src/PasswordInput/PasswordInput.tsx
+++ b/packages/core/src/PasswordInput/PasswordInput.tsx
@@ -15,6 +15,10 @@ const NoWrapText = styled(Text)`
   white-space: nowrap;
 `
 
+const ClickableIconButton = styled(IconButton)`
+  z-index: 1;
+`
+
 const maxProgressBarLength = 4
 
 /**
@@ -96,7 +100,7 @@ export function PasswordInput({
           autoComplete={autoComplete}
         />
         {showCheckIcon && <Check color='secondary' data-testid='check-mark-icon' />}
-        <IconButton
+        <ClickableIconButton
           title='visibility-button'
           icon={<VisibilityIcon color='text.light' />}
           onClick={changeVisibility}


### PR DESCRIPTION
* visibility icon displaying password input is currently not working because the icon is not clickable
* verified fix in storybook

Main branch storybook with issue: https://main--5a85e56213417800200978ab.chromatic.com/?path=/docs/passwordinput--docs

Bugfix branch storybook: https://5a85e56213417800200978ab-fdhpatpceq.chromatic.com/?path=/docs/passwordinput--docs