### PR TITLE
Task/htl 111885 Drawer enhancements

### DIFF
--- a/common/changes/pcln-design-system/task-HTL-111885-scrolling-and-snapping-mechanism_2024-11-21-19-51.json
+++ b/common/changes/pcln-design-system/task-HTL-111885-scrolling-and-snapping-mechanism_2024-11-21-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add snap and prop to disable enter animation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Drawer/Drawer.spec.tsx
+++ b/packages/core/src/Drawer/Drawer.spec.tsx
@@ -68,4 +68,26 @@ describe('Drawer', () => {
     const boxShadow = style?.boxShadow
     expect(boxShadow).toBeFalsy()
   })
+
+  test('Renders snappable container when snapHeights and snapDimensions are present', () => {
+    const { getByTestId } = render(
+      <Drawer
+        isOpen={true}
+        placement='right'
+        onClose={jest.fn}
+        onCollapse={jest.fn}
+        snapHeights={['0%', '20%', '50%']}
+        snapDimensions={{ width: '100%', height: '800px' }}
+        heading={<div>Custom Heading</div>}
+        showDivider={false} // Default true
+      >
+        Content
+      </Drawer>
+    )
+
+    const element = getByTestId('snap-container')
+    const style = window.getComputedStyle(element)
+    const boxShadow = style?.boxShadow
+    expect(boxShadow).toBeFalsy()
+  })
 })

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -8,6 +8,7 @@ import { Stamp } from '../Stamp/Stamp'
 import { ChatMessageContainer } from '../ChatMessageContainer/ChatMessageContainer'
 import { DrawerHandle } from './Drawer.styled'
 import { Button } from '../Button/Button'
+import styled from 'styled-components'
 
 function DrawerStory(props) {
   const [isOpen, setIsOpen] = useState(true)
@@ -211,4 +212,37 @@ export const WithContentOverflow = (args) => (
   <DrawerStory {...args} height='50vh' placement='right'>
     {CustomPennyContent}
   </DrawerStory>
+)
+
+/**
+ * Use case for Snap behavior
+ */
+const StyledContainer = styled(Box)`
+  position: relative;
+`
+
+function DrawerScrollable(props) {
+  return (
+    <StyledContainer
+      height='100vh'
+      style={{ backgroundColor: 'grey', height: '100vh', position: 'relative' }}
+    >
+      <Drawer heading='Header' isOpen={true} {...props}>
+        {props.children}
+      </Drawer>
+    </StyledContainer>
+  )
+}
+
+export const DrawerDragToSnap = () => (
+  <DrawerScrollable
+    snapHeights={['20%', '-50%', '-67%']}
+    snapDimensions={{ width: '100%', height: '800px' }}
+    disableEnterAnimation
+    isMobile
+    isFloating={false}
+    heading={NeighborhoodsHeader}
+  >
+    {CustomPennyContent}
+  </DrawerScrollable>
 )

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -236,7 +236,7 @@ function DrawerScrollable(props) {
 
 export const DrawerDragToSnap = () => (
   <DrawerScrollable
-    snapHeights={['20%', '-50%', '-67%']}
+    snapHeights={['0%', '-30%', '-70%']}
     snapDimensions={{ width: '100%', height: '800px' }}
     disableEnterAnimation
     isMobile

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -28,9 +28,6 @@ export type DrawerProps = SpaceProps &
     placement?: PlacementOptions
     position?: string
 
-    /**
-     * Neighborhoods-related props
-     */
     // top, middle, bottom - 3 snap points required
     snapHeights?: [string, string, string]
 

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -7,10 +7,12 @@ import { ChevronDown, Close } from 'pcln-icons'
 import { AnimatePresence, motion } from 'framer-motion'
 import { SpaceProps, LayoutProps } from 'styled-system'
 import { useScrollWithShadow } from '../useScrollWithShadows/useScrollWithShadow'
-import { MotionVariants } from '../Animate/Animate'
 import { theme } from '../theme'
+import { useSnap } from './hooks/useSnap'
+import { getDragToDismissAnimation, getDividerStyle, getEnterAnimation } from './helpers'
 
 export type PlacementOptions = 'top' | 'bottom' | 'right' | 'left'
+
 export type DrawerProps = SpaceProps &
   LayoutProps & {
     children?: React.ReactNode
@@ -24,36 +26,17 @@ export type DrawerProps = SpaceProps &
     onClose?: () => void
     onCollapse?: () => void
     placement?: PlacementOptions
+
+    // neighborhood-related props:
+    snapHeights?: Array<string>
+    snapDimensions?: {
+      // When snap enabled, lock-in drawer dimensions
+      width?: string
+      height?: string
+    }
+    disableEnterAnimation?: false
     position?: string
   }
-
-const enterAnimation = {
-  top: { ...MotionVariants.slideInTop },
-  bottom: { ...MotionVariants.slideInBottom },
-  right: { ...MotionVariants.slideInRight },
-  left: { ...MotionVariants.slideInLeft },
-}
-
-const dragToDismissAnimation = (onDragEnd) => {
-  return {
-    drag: 'y',
-    dragConstraints: { top: 0, bottom: 0 },
-    dragElastic: { top: 0, bottom: 0.3 },
-    transition: { duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] },
-    onDragEnd: (event, info) => {
-      if (info.offset.y > 200) {
-        onDragEnd()
-      }
-    },
-  }
-}
-
-const getDividerStyle = ({ showDivider, boxShadow }) =>
-  showDivider
-    ? {
-        boxShadow,
-      }
-    : {}
 
 export const Drawer: React.FC<DrawerProps> = ({
   children,
@@ -67,108 +50,135 @@ export const Drawer: React.FC<DrawerProps> = ({
   onClose,
   onCollapse,
   placement = 'right',
+
+  // neighborhood-related props:
+  snapHeights,
+  snapDimensions,
+  disableEnterAnimation,
   ...props
 }) => {
   const { boxShadow, onScrollHandler } = useScrollWithShadow()
+  const { snapPosition, handleSnap } = useSnap(snapHeights)
+  const SnapContainer = snapHeights ? motion.div : React.Fragment
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <DrawerWrapper
-          placement={isMobile ? 'bottom' : placement}
-          padding={isFloating ? 3 : 0}
-          maxHeight={isMobile ? ['290px', '400px', '480px', 'calc(100vh - 64px)'] : props.height ?? '100%'}
-          maxWidth={isMobile ? '100%' : ['400px', '600px', '800px', '100%']}
-          width={isMobile ? '100%' : props.width}
-          {...props}
-          height={!isCollapsed && props.height ? props.height : 'fit-content'}
-        >
-          <DrawerRoot
-            data-testid='drawer'
-            isCollapsed={isCollapsed}
-            isFloating={isFloating}
-            key='drawer'
+    <SnapContainer
+      className='box'
+      style={
+        // Note: Somehow declaring a variable for the style triggers type errors related to motion.div intrinsic types
+        snapHeights && snapDimensions
+          ? {
+              position: 'absolute',
+              bottom: snapPosition,
+              width: snapDimensions.width,
+              height: snapDimensions.height,
+            }
+          : {}
+      }
+      transition={{ type: 'spring', bounce: 0 }}
+      drag='y'
+      dragConstraints={{ top: 0, bottom: 0 }}
+      onDragEnd={handleSnap}
+    >
+      <AnimatePresence>
+        {isOpen && (
+          <DrawerWrapper
             placement={isMobile ? 'bottom' : placement}
-            {...enterAnimation[isMobile ? 'bottom' : placement]}
-            {...(isDraggable ? dragToDismissAnimation(onCollapse) : {})}
-            height='100%'
-            width='100%'
-            overflow='hidden'
+            padding={isFloating ? 3 : 0}
+            maxHeight={isMobile ? ['290px', '400px', '480px', 'calc(100vh - 64px)'] : props.height ?? '100%'}
+            maxWidth={isMobile ? '100%' : ['400px', '600px', '800px', '100%']}
+            width={isMobile ? '100%' : props.width}
+            {...props}
+            height={!isCollapsed && props.height ? props.height : 'fit-content'}
           >
-            <Flex flexDirection='column'>
-              {(heading || onClose || onCollapse) && (
-                <Flex flexDirection='column'>
-                  <Flex flexDirection='row' p={3}>
-                    {typeof heading === 'string' ? (
-                      <Text width='100%' textStyle='heading4'>
-                        {heading}
-                      </Text>
-                    ) : (
-                      heading
-                    )}
-                    {onClose || onCollapse ? (
-                      <Flex flexDirection='row' ml='auto' style={{ columnGap: theme.space[2] }}>
-                        {onCollapse && (
-                          <motion.div
-                            animate={{
-                              rotate: isCollapsed ? 180 : 0,
-                              transition: { duration: 0.25 },
-                            }}
-                          >
+            <DrawerRoot
+              data-testid='drawer'
+              isCollapsed={isCollapsed}
+              isFloating={isFloating}
+              key='drawer'
+              placement={isMobile ? 'bottom' : placement}
+              {...getEnterAnimation({ disableEnterAnimation, isMobile, placement })}
+              {...getDragToDismissAnimation({ isDraggable, snapHeights, onCollapse })}
+              height='100%'
+              width='100%'
+              overflow='hidden'
+            >
+              <Flex flexDirection='column'>
+                {(heading || onClose || onCollapse) && (
+                  <Flex flexDirection='column'>
+                    <Flex flexDirection='row' p={3}>
+                      {typeof heading === 'string' ? (
+                        <Text width='100%' textStyle='heading4'>
+                          {heading}
+                        </Text>
+                      ) : (
+                        heading
+                      )}
+                      {onClose || onCollapse ? (
+                        <Flex flexDirection='row' ml='auto' style={{ columnGap: theme.space[2] }}>
+                          {onCollapse && (
+                            <motion.div
+                              animate={{
+                                rotate: isCollapsed ? 180 : 0,
+                                transition: { duration: 0.25 },
+                              }}
+                            >
+                              <HeaderButton
+                                data-testid='drawerCollapse'
+                                onClick={onCollapse}
+                                icon={<ChevronDown title='Dismiss' />}
+                              />
+                            </motion.div>
+                          )}
+                          {onClose && (
                             <HeaderButton
-                              data-testid='drawerCollapse'
-                              onClick={onCollapse}
-                              icon={<ChevronDown title='Dismiss' />}
+                              data-testid='drawerClose'
+                              onClick={onClose}
+                              icon={<Close title='Close' />}
                             />
-                          </motion.div>
-                        )}
-                        {onClose && (
-                          <HeaderButton
-                            data-testid='drawerClose'
-                            onClick={onClose}
-                            icon={<Close title='Close' />}
-                          />
-                        )}
-                      </Flex>
-                    ) : null}
+                          )}
+                        </Flex>
+                      ) : null}
+                    </Flex>
                   </Flex>
-                </Flex>
-              )}
-              <AnimatePresence initial={false}>
-                {!isCollapsed && (
-                  <motion.div
-                    key='content'
-                    {...{
-                      exit: { scaleY: 0, height: 0 },
-                      animate: { scaleY: 1, height: 'auto' },
-                      initial: { scaleY: 1, height: 'auto' },
-                    }}
-                  >
-                    {heading ? (
-                      <Box
-                        height='100%'
-                        maxHeight={`calc(${props.height ?? '100vh'} - 100px)`}
-                        overflow='scroll'
-                        onScroll={onScrollHandler}
-                        data-testid='drawer-divider'
-                        style={getDividerStyle({ showDivider, boxShadow })}
-                      >
+                )}
+                <AnimatePresence initial={false}>
+                  {!isCollapsed && (
+                    <motion.div
+                      key='content'
+                      {...{
+                        exit: { scaleY: 0, height: 0 },
+                        animate: { scaleY: 1, height: 'auto' },
+                        initial: { scaleY: 1, height: 'auto' },
+                      }}
+                    >
+                      {heading ? (
+                        <Box
+                          height='100%'
+                          maxHeight={`calc(${props.height ?? '100vh'} - 100px)`}
+                          overflow='scroll'
+                          onScroll={onScrollHandler}
+                          data-testid='drawer-divider'
+                          style={getDividerStyle({ showDivider, boxShadow })}
+                        >
+                          <Box py={2} px={3} height='100%'>
+                            {children}
+                          </Box>
+                        </Box>
+                      ) : (
                         <Box py={2} px={3} height='100%'>
                           {children}
                         </Box>
-                      </Box>
-                    ) : (
-                      <Box py={2} px={3} height='100%'>
-                        {children}
-                      </Box>
-                    )}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </Flex>
-          </DrawerRoot>
-        </DrawerWrapper>
-      )}
-    </AnimatePresence>
+                      )}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </Flex>
+            </DrawerRoot>
+          </DrawerWrapper>
+        )}
+      </AnimatePresence>
+    </SnapContainer>
   )
 }
 

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -26,16 +26,22 @@ export type DrawerProps = SpaceProps &
     onClose?: () => void
     onCollapse?: () => void
     placement?: PlacementOptions
+    position?: string
 
-    // neighborhood-related props
-    snapHeights?: [string, string, string] // top, middle, bottom - 3 snap points required
+    /**
+     * Neighborhoods-related props
+     */
+    // top, middle, bottom - 3 snap points required
+    snapHeights?: [string, string, string]
+
+    // When snap enabled, lock-in drawer dimensions
     snapDimensions?: {
-      // When snap enabled, lock-in drawer dimensions
       width?: string
       height?: string
     }
+
+    // Disable enter animation to eliminate side effects on viewport change
     disableEnterAnimation?: false
-    position?: string
   }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -65,7 +71,7 @@ export const Drawer: React.FC<DrawerProps> = ({
     <SnapContainer
       className='box'
       style={
-        // Note: Somehow declaring a variable for the style triggers type errors related to motion.div intrinsic types
+        // Note: Declaring a variable for the style triggers type errors related to motion.div intrinsic types
         snapHeights && snapDimensions
           ? {
               position: 'absolute',

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -85,6 +85,7 @@ export const Drawer: React.FC<DrawerProps> = ({
       drag='y'
       dragConstraints={{ top: 0, bottom: 0 }}
       onDragEnd={handleSnap}
+      data-testid='snap-container'
     >
       <AnimatePresence>
         {isOpen && (

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -27,8 +27,8 @@ export type DrawerProps = SpaceProps &
     onCollapse?: () => void
     placement?: PlacementOptions
 
-    // neighborhood-related props:
-    snapHeights?: Array<string>
+    // neighborhood-related props
+    snapHeights?: [string, string, string] // top, middle, bottom - 3 snap points required
     snapDimensions?: {
       // When snap enabled, lock-in drawer dimensions
       width?: string

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -53,7 +53,6 @@ export const Drawer: React.FC<DrawerProps> = ({
   onClose,
   onCollapse,
   placement = 'right',
-
   snapHeights,
   snapDimensions,
   disableEnterAnimation,

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -69,7 +69,6 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   return (
     <SnapContainer
-      className='box'
       style={
         // Note: Declaring a variable for the style triggers type errors related to motion.div intrinsic types
         snapHeights && snapDimensions

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -54,7 +54,6 @@ export const Drawer: React.FC<DrawerProps> = ({
   onCollapse,
   placement = 'right',
 
-  // neighborhood-related props:
   snapHeights,
   snapDimensions,
   disableEnterAnimation,

--- a/packages/core/src/Drawer/helpers/getDividerStyle.spec.ts
+++ b/packages/core/src/Drawer/helpers/getDividerStyle.spec.ts
@@ -1,0 +1,19 @@
+import { getDividerStyle } from './getDividerStyle'
+
+describe('Drawer divider toggle helper unit test', () => {
+  test('If showDivider, return boxShadow', () => {
+    const boxShadow = {
+      'box-shadow': '10px 10px',
+    }
+    const res = getDividerStyle({ showDivider: true, boxShadow })
+    expect(res).toBe(boxShadow)
+  })
+
+  test('If !showDivider, return {}', () => {
+    const boxShadow = {
+      'box-shadow': '10px 10px',
+    }
+    const res = getDividerStyle({ showDivider: false, boxShadow })
+    expect(res).toBe({})
+  })
+})

--- a/packages/core/src/Drawer/helpers/getDividerStyle.spec.ts
+++ b/packages/core/src/Drawer/helpers/getDividerStyle.spec.ts
@@ -6,7 +6,7 @@ describe('Drawer divider toggle helper unit test', () => {
       'box-shadow': '10px 10px',
     }
     const res = getDividerStyle({ showDivider: true, boxShadow })
-    expect(res).toBe(boxShadow)
+    expect(res).toEqual({ boxShadow })
   })
 
   test('If !showDivider, return {}', () => {
@@ -14,6 +14,6 @@ describe('Drawer divider toggle helper unit test', () => {
       'box-shadow': '10px 10px',
     }
     const res = getDividerStyle({ showDivider: false, boxShadow })
-    expect(res).toBe({})
+    expect(res).toEqual({})
   })
 })

--- a/packages/core/src/Drawer/helpers/getDividerStyle.ts
+++ b/packages/core/src/Drawer/helpers/getDividerStyle.ts
@@ -1,0 +1,9 @@
+/**
+ * Toggle divider visibility
+ */
+export const getDividerStyle = ({ showDivider, boxShadow }) =>
+  showDivider
+    ? {
+        boxShadow,
+      }
+    : {}

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.spec.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.spec.ts
@@ -3,12 +3,12 @@ import { dragToDismissAnimation, getDragToDismissAnimation } from './getDragToDi
 describe('Drawer header drag helper function unit test', () => {
   const onCollapse = () => {}
   test('Disable header drag animation when snappeable', () => {
-    let res = getDragToDismissAnimation({ isDraggable: true, snapHeights: [1, 2, 3], onCollapse })
-    expect(res).toBe({})
+    const res = getDragToDismissAnimation({ isDraggable: true, snapHeights: [1, 2, 3], onCollapse })
+    expect(res).toEqual({})
   })
 
   test('Enable header drag animation when non-snappeable', () => {
-    let res = getDragToDismissAnimation({ isDraggable: true, snapHeights: null, onCollapse })
-    expect(res).toBe(dragToDismissAnimation(onCollapse))
+    const res = getDragToDismissAnimation({ isDraggable: true, snapHeights: null, onCollapse })
+    expect(JSON.stringify(res)).toStrictEqual(JSON.stringify(dragToDismissAnimation(onCollapse)))
   })
 })

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.spec.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.spec.ts
@@ -1,0 +1,14 @@
+import { dragToDismissAnimation, getDragToDismissAnimation } from './getDragToDismissAnimation'
+
+describe('Drawer header drag helper function unit test', () => {
+  const onCollapse = () => {}
+  test('Disable header drag animation when snappeable', () => {
+    let res = getDragToDismissAnimation({ isDraggable: true, snapHeights: [1, 2, 3], onCollapse })
+    expect(res).toBe({})
+  })
+
+  test('Enable header drag animation when non-snappeable', () => {
+    let res = getDragToDismissAnimation({ isDraggable: true, snapHeights: null, onCollapse })
+    expect(res).toBe(dragToDismissAnimation(onCollapse))
+  })
+})

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
@@ -1,0 +1,20 @@
+/**
+ * Handles header collapse animation behavior on side button click
+ */
+
+export const dragToDismissAnimation = (onDragEnd) => {
+  return {
+    drag: 'y',
+    dragConstraints: { top: 0, bottom: 0 },
+    dragElastic: { top: 0, bottom: 0.3 },
+    transition: { duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] },
+    onDragEnd: (event, info) => {
+      if (info.offset.y > 200) {
+        onDragEnd()
+      }
+    },
+  }
+}
+
+export const getDragToDismissAnimation = ({ isDraggable, snapHeights, onCollapse }) =>
+  isDraggable && !snapHeights ? dragToDismissAnimation(onCollapse) : {}

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
@@ -1,5 +1,5 @@
 /**
- * Handles header collapse animation behavior on side button click
+ * Handles header collapse/expand behavior on button click
  */
 
 export const dragToDismissAnimation = (onDragEnd) => {

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
@@ -8,6 +8,8 @@ export const dragToDismissAnimation = (onDragEnd) => {
     dragConstraints: { top: 0, bottom: 0 },
     dragElastic: { top: 0, bottom: 0.3 },
     transition: { duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] },
+
+    /* istanbul ignore next */
     onDragEnd: (event, info) => {
       if (info.offset.y > 200) {
         onDragEnd()

--- a/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getDragToDismissAnimation.ts
@@ -9,8 +9,8 @@ export const dragToDismissAnimation = (onDragEnd) => {
     dragElastic: { top: 0, bottom: 0.3 },
     transition: { duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] },
 
-    /* istanbul ignore next */
     onDragEnd: (event, info) => {
+      /* c8 ignore next */
       if (info.offset.y > 200) {
         onDragEnd()
       }

--- a/packages/core/src/Drawer/helpers/getEnterAnimation.spec.ts
+++ b/packages/core/src/Drawer/helpers/getEnterAnimation.spec.ts
@@ -1,13 +1,13 @@
 import { getEnterAnimation } from './getEnterAnimation'
 
 describe('Entrance animation unit test', () => {
-  test('Return no animation if disabled', () => {
-    let res = getEnterAnimation({ disableEnterAnimation: true, isMobile: true, placement: 'top' })
+  test('Hide animation if ebaled', () => {
+    const res = getEnterAnimation({ disableEnterAnimation: true, isMobile: true, placement: 'top' })
     expect(res).toBeFalsy()
   })
 
-  test('Return animation if enabled', () => {
-    let res = getEnterAnimation({ disableEnterAnimation: true, isMobile: true, placement: 'top' })
+  test('Return animation if disabled', () => {
+    const res = getEnterAnimation({ disableEnterAnimation: false, isMobile: true, placement: 'top' })
     expect(res).toBeTruthy()
   })
 })

--- a/packages/core/src/Drawer/helpers/getEnterAnimation.spec.ts
+++ b/packages/core/src/Drawer/helpers/getEnterAnimation.spec.ts
@@ -1,0 +1,13 @@
+import { getEnterAnimation } from './getEnterAnimation'
+
+describe('Entrance animation unit test', () => {
+  test('Return no animation if disabled', () => {
+    let res = getEnterAnimation({ disableEnterAnimation: true, isMobile: true, placement: 'top' })
+    expect(res).toBeFalsy()
+  })
+
+  test('Return animation if enabled', () => {
+    let res = getEnterAnimation({ disableEnterAnimation: true, isMobile: true, placement: 'top' })
+    expect(res).toBeTruthy()
+  })
+})

--- a/packages/core/src/Drawer/helpers/getEnterAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getEnterAnimation.ts
@@ -1,0 +1,11 @@
+import { MotionVariants } from '../../Animate/Animate'
+
+const enterAnimation = {
+  top: { ...MotionVariants.slideInTop },
+  bottom: { ...MotionVariants.slideInBottom },
+  right: { ...MotionVariants.slideInRight },
+  left: { ...MotionVariants.slideInLeft },
+}
+
+export const getEnterAnimation = ({ disableEnterAnimation, isMobile, placement }) =>
+  !disableEnterAnimation && enterAnimation[isMobile ? 'bottom' : placement]

--- a/packages/core/src/Drawer/helpers/getEnterAnimation.ts
+++ b/packages/core/src/Drawer/helpers/getEnterAnimation.ts
@@ -1,5 +1,8 @@
 import { MotionVariants } from '../../Animate/Animate'
 
+/**
+ * Handles enter animation based on drawer placement
+ */
 const enterAnimation = {
   top: { ...MotionVariants.slideInTop },
   bottom: { ...MotionVariants.slideInBottom },

--- a/packages/core/src/Drawer/helpers/index.ts
+++ b/packages/core/src/Drawer/helpers/index.ts
@@ -1,0 +1,5 @@
+import { getDragToDismissAnimation } from './getDragToDismissAnimation'
+import { getDividerStyle } from './getDividerStyle'
+import { getEnterAnimation } from './getEnterAnimation'
+
+export { getDragToDismissAnimation, getDividerStyle, getEnterAnimation }

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -1,0 +1,8 @@
+import { useSnap } from './useSnap'
+
+describe('Drawer snap hook unit test', () => {
+  test('Snap position initialized correctly', () => {
+    const { snapPosition } = useSnap(['0%', '20%', '30%'])
+    expect(snapPosition).toEqual('0%')
+  })
+})

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -1,8 +1,9 @@
 import { useSnap } from './useSnap'
+import { renderHook } from '@testing-library/react'
 
 describe('Drawer snap hook unit test', () => {
   test('Snap position initialized correctly', () => {
-    const { snapPosition } = useSnap(['0%', '20%', '30%'])
-    expect(snapPosition).toEqual('0%')
+    const { result } = renderHook(() => useSnap(['0%', '20%', '30%']))
+    expect(result.current.snapPosition).toEqual('0%')
   })
 })

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -4,6 +4,9 @@ import { renderHook } from '@testing-library/react'
 describe('Drawer snap hook unit test', () => {
   test('Snap position initialized correctly', () => {
     const { result } = renderHook(() => useSnap(['0%', '20%', '30%']))
-    expect(result.current.snapPosition).toEqual('0%')
+    const { snapPosition, handleSnap } = result.current
+    expect(snapPosition).toBe('0%')
+    handleSnap('', { offset: { y: 99 } })
+    expect(snapPosition).toBe('0%')
   })
 })

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -6,7 +6,20 @@ describe('Drawer snap hook unit test', () => {
     const { result } = renderHook(() => useSnap(['0%', '20%', '30%']))
     const { snapPosition, handleSnap } = result.current
     expect(snapPosition).toBe('0%')
-    handleSnap('', { offset: { y: 99 } })
+
+    // Scroll all the way up, and back down should return to original position
+    // To middle
+    handleSnap('', { offset: { y: 0 } })
+    handleSnap('', { offset: { y: 101 } })
+
+    // To top
+    handleSnap('', { offset: { y: 101 } })
+
+    // Back to middle
+    handleSnap('', { offset: { y: -101 } })
+
+    // Back to bottom
+    handleSnap('', { offset: { y: -101 } })
     expect(snapPosition).toBe('0%')
   })
 })

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -11,7 +11,7 @@ import { useState } from 'react'
 export function useSnap(snapHeights) {
   const [TOP, MIDDLE, BOTTOM] = snapHeights || []
   const SCROLL_THRESHOLD = 100
-  const [snapPosition, setSnapPosition] = useState<string>(TOP)
+  const [snapPosition, setSnapPosition] = useState(TOP)
 
   const handleSnap = (...args) => {
     const info = args?.[1]

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -14,8 +14,8 @@ export function useSnap(snapHeights) {
   const [snapPosition, setSnapPosition] = useState<string>(TOP)
 
   const handleSnap = (...args) => {
-    let info = args?.[1]
-    let scrollOffset = info.offset.y
+    const info = args?.[1]
+    const scrollOffset = info.offset.y
 
     const SCROLL_DOWN = scrollOffset > SCROLL_THRESHOLD
     const SCROLL_UP = scrollOffset < -SCROLL_THRESHOLD

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -2,10 +2,11 @@ import { useState } from 'react'
 
 /**
  * Custom hook that returns:
- * 1. The snap position of the drawer container
- * 2. The snap handler which dictates the snapping position depending on current position
  *
- * Designed to support 3 snap points so far.
+ * 1. Snap position of the drawer container
+ * 2. Snap drag handler which determins the future snapping position based on current
+ *
+ * Designed to support 3 snap points.
  */
 export function useSnap(snapHeights) {
   const [TOP, MIDDLE, BOTTOM] = snapHeights || []

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+/**
+ * Custom hook that returns:
+ * 1. The snap position of the drawer container
+ * 2. The snap handler which dictates the snapping position depending on current position
+ *
+ * Designed to support 3 snap points so far.
+ */
+export function useSnap(snapHeights) {
+  const [TOP, MIDDLE, BOTTOM] = snapHeights || []
+  const SCROLL_THRESHOLD = 100
+  const [snapPosition, setSnapPosition] = useState<string>(TOP)
+
+  const handleSnap = (...args) => {
+    let info = args?.[1]
+    let scrollOffset = info.offset.y
+
+    const SCROLL_DOWN = scrollOffset > SCROLL_THRESHOLD
+    const SCROLL_UP = scrollOffset < -SCROLL_THRESHOLD
+
+    // Scroll down logic
+    if (SCROLL_DOWN) {
+      if (snapPosition === TOP) setSnapPosition(MIDDLE)
+      if (snapPosition === MIDDLE) setSnapPosition(BOTTOM)
+    }
+
+    // Scroll up logic
+    else if (SCROLL_UP) {
+      if (snapPosition === BOTTOM) setSnapPosition(MIDDLE)
+      if (snapPosition === MIDDLE) setSnapPosition(TOP)
+    }
+  }
+
+  return { snapPosition, handleSnap }
+}


### PR DESCRIPTION
Changelog:

### **1. Added Snap functionality**

- The snap functionality works by changing the absolute positioning of a motion.div within a relative parent container. 
- On each drag action we update the position of the motion.div based on the percentage values we pass in as `snapHeights`. This prop accepts an array of 3 exact values `[top: string, middle: string, bottom: string]` as snap points.
- The extent of scroll and rigidity can be adjusted via `snapDimensions`, which controls the dimensions of the motion.div container.

Video 1: POC with div
https://github.com/user-attachments/assets/e4aa562a-3721-4d25-a833-f74e2d752fd5

Video 2: With Drawer
https://github.com/user-attachments/assets/e15739c8-6e37-4f0c-bb5b-de7c23a5095b




### **2. Added prop to toggle enter animation**

When resizing the viewport, it can trigger an enter animation based on a position change. Sometimes it'll push the component outside the screen. Adding `disableEnterAnimation` disables enter animation and prevents this side-effect, effectively fixating the component to a certain position.



### **3. Refactoring + Added directories for helper function and custom hooks**

Here we will implement a custom hook for the snap use-case to prevent the Drawer.tsx from becoming too verbose.
This way it's modular enough to move between codebases. 
The animation configs and helper functions were also moved into a new directory for better organization.

