### PR TITLE
task(): Change fragement to div drawer

### DIFF
--- a/common/changes/pcln-design-system/task-change-fragment-to-div-drawer_2024-11-27-20-07.json
+++ b/common/changes/pcln-design-system/task-change-fragment-to-div-drawer_2024-11-27-20-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Change fragment to div to bypass type errors",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -60,7 +60,7 @@ export const Drawer: React.FC<DrawerProps> = ({
 }) => {
   const { boxShadow, onScrollHandler } = useScrollWithShadow()
   const { snapPosition, handleSnap } = useSnap(snapHeights)
-  const SnapContainer = snapHeights ? motion.div : React.Fragment
+  const SnapContainer = snapHeights ? motion.div : 'div'
 
   return (
     <SnapContainer


### PR DESCRIPTION
`React.Fragment` throws type errors when invalid props are using it, changing to div fixes it.