### PR TITLE
Task/htl 112172 additional drawer work

### DIFF
--- a/common/changes/pcln-design-system/task-htl-112172-additional-drawer-work_2024-12-17-15-22.json
+++ b/common/changes/pcln-design-system/task-htl-112172-additional-drawer-work_2024-12-17-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add prop to disable max height, add z-index to outer container, add error handling to snap hook",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -214,6 +214,18 @@ export const WithContentOverflow = (args) => (
   </DrawerStory>
 )
 
+export const WithNoMaxHeightConstraint = (args) => (
+  <DrawerStory {...args} height='50vh' disableMaxHeight isMobile isFloating={false}>
+    {CustomPennyContent}
+  </DrawerStory>
+)
+
+export const WithMaxHeightConstraint = (args) => (
+  <DrawerStory {...args} height='50vh' isMobile isFloating={false}>
+    {CustomPennyContent}
+  </DrawerStory>
+)
+
 /**
  * Use case for Snap behavior
  */

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -215,7 +215,7 @@ export const WithContentOverflow = (args) => (
 )
 
 export const CustomMaxHeight = (args) => (
-  <DrawerStory {...args} height='800px' maxHeight={'100px'} isMobile isFloating={false}>
+  <DrawerStory {...args} height='800px' maxHeight='100px' isMobile isFloating={false}>
     {CustomPennyContent}
   </DrawerStory>
 )

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -214,14 +214,8 @@ export const WithContentOverflow = (args) => (
   </DrawerStory>
 )
 
-export const WithNoMaxHeightConstraint = (args) => (
-  <DrawerStory {...args} height='50vh' disableMaxHeight isMobile isFloating={false}>
-    {CustomPennyContent}
-  </DrawerStory>
-)
-
-export const WithMaxHeightConstraint = (args) => (
-  <DrawerStory {...args} height='50vh' isMobile isFloating={false}>
+export const CustomMaxHeight = (args) => (
+  <DrawerStory {...args} height='800px' maxHeight={'100px'} isMobile isFloating={false}>
     {CustomPennyContent}
   </DrawerStory>
 )
@@ -248,7 +242,7 @@ function DrawerScrollable(props) {
 
 export const DrawerDragToSnap = () => (
   <DrawerScrollable
-    snapHeights={['0%', '-30%', '-70%']}
+    snapHeights={['20%', '0%', '-20%']}
     snapDimensions={{ width: '100%', height: '400px' }}
     disableEnterAnimation
     isMobile

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -249,11 +249,12 @@ function DrawerScrollable(props) {
 export const DrawerDragToSnap = () => (
   <DrawerScrollable
     snapHeights={['0%', '-30%', '-70%']}
-    snapDimensions={{ width: '100%', height: '800px' }}
+    snapDimensions={{ width: '100%', height: '400px' }}
     disableEnterAnimation
     isMobile
     isFloating={false}
     heading={NeighborhoodsHeader}
+    height='400px'
   >
     {CustomPennyContent}
   </DrawerScrollable>

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -29,7 +29,7 @@ export type DrawerProps = SpaceProps &
     position?: string
     zIndex?: number
 
-    // 3 snap points relative to the bottom of the viewport
+    // top, middle (initial position), bottom snap points relative to viewport
     snapHeights?: [string, string, string]
 
     // When snap enabled, lock-in drawer dimensions

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -40,9 +40,6 @@ export type DrawerProps = SpaceProps &
 
     // Disable enter animation to eliminate side effects on viewport change
     disableEnterAnimation?: boolean
-
-    // Disable vertical length limit constraint to show variable height on smaller devices
-    disableMaxHeight?: boolean
   }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -61,7 +58,6 @@ export const Drawer: React.FC<DrawerProps> = ({
   snapHeights,
   snapDimensions,
   disableEnterAnimation,
-  disableMaxHeight,
   ...props
 }) => {
   const { boxShadow, onScrollHandler } = useScrollWithShadow()
@@ -95,7 +91,9 @@ export const Drawer: React.FC<DrawerProps> = ({
             placement={isMobile ? 'bottom' : placement}
             padding={isFloating ? 3 : 0}
             maxHeight={
-              isMobile && !disableMaxHeight
+              props?.maxHeight
+                ? props.maxHeight
+                : isMobile
                 ? ['290px', '400px', '480px', 'calc(100vh - 64px)']
                 : props.height ?? '100%'
             }

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -78,6 +78,7 @@ export const Drawer: React.FC<DrawerProps> = ({
               bottom: snapPosition,
               width: snapDimensions.width,
               height: snapDimensions.height,
+              zIndex: zIndex,
             }
           : {}
       }
@@ -85,8 +86,8 @@ export const Drawer: React.FC<DrawerProps> = ({
       drag='y'
       dragConstraints={{ top: 0, bottom: 0 }}
       onDragEnd={handleSnap}
+      {...(snapHeights ? { onDragEnd: handleSnap } : {})}
       data-testid='snap-container'
-      z-index={zIndex}
     >
       <AnimatePresence>
         {isOpen && (

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -27,8 +27,9 @@ export type DrawerProps = SpaceProps &
     onCollapse?: () => void
     placement?: PlacementOptions
     position?: string
+    zIndex?: number
 
-    // top, middle, bottom - 3 snap points required
+    // 3 snap points relative to the bottom of the viewport
     snapHeights?: [string, string, string]
 
     // When snap enabled, lock-in drawer dimensions
@@ -38,7 +39,10 @@ export type DrawerProps = SpaceProps &
     }
 
     // Disable enter animation to eliminate side effects on viewport change
-    disableEnterAnimation?: false
+    disableEnterAnimation?: boolean
+
+    // Disable vertical length limit constraint to show variable height on smaller devices
+    disableMaxHeight?: boolean
   }
 
 export const Drawer: React.FC<DrawerProps> = ({
@@ -53,13 +57,15 @@ export const Drawer: React.FC<DrawerProps> = ({
   onClose,
   onCollapse,
   placement = 'right',
+  zIndex = 1,
   snapHeights,
   snapDimensions,
   disableEnterAnimation,
+  disableMaxHeight,
   ...props
 }) => {
   const { boxShadow, onScrollHandler } = useScrollWithShadow()
-  const { snapPosition, handleSnap } = useSnap(snapHeights)
+  const { snapPosition, handleSnap } = useSnap(snapHeights, snapDimensions)
   const SnapContainer = snapHeights ? motion.div : 'div'
 
   return (
@@ -80,13 +86,18 @@ export const Drawer: React.FC<DrawerProps> = ({
       dragConstraints={{ top: 0, bottom: 0 }}
       onDragEnd={handleSnap}
       data-testid='snap-container'
+      z-index={zIndex}
     >
       <AnimatePresence>
         {isOpen && (
           <DrawerWrapper
             placement={isMobile ? 'bottom' : placement}
             padding={isFloating ? 3 : 0}
-            maxHeight={isMobile ? ['290px', '400px', '480px', 'calc(100vh - 64px)'] : props.height ?? '100%'}
+            maxHeight={
+              isMobile && !disableMaxHeight
+                ? ['290px', '400px', '480px', 'calc(100vh - 64px)']
+                : props.height ?? '100%'
+            }
             maxWidth={isMobile ? '100%' : ['400px', '600px', '800px', '100%']}
             width={isMobile ? '100%' : props.width}
             {...props}

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -5,21 +5,14 @@ describe('Drawer snap hook unit test', () => {
   test('Snap position initialized correctly', () => {
     const { result } = renderHook(() => useSnap(['0%', '20%', '30%'], ['100%', '100%', '100%']))
     const { snapPosition, handleSnap } = result.current
-    expect(snapPosition).toBe('0%')
+    expect(snapPosition).toBe('20%')
 
-    // Scroll all the way up, and back down should return to original position
-    // To middle
-    handleSnap('', { offset: { y: 0 } })
+    // Start middle, scroll up and scroll down should be back to initial position
+    // Scroll to top
     handleSnap('', { offset: { y: 101 } })
-
-    // To top
-    handleSnap('', { offset: { y: 101 } })
-
-    // Back to middle
+    // Scroll back to middle
     handleSnap('', { offset: { y: -101 } })
 
-    // Back to bottom
-    handleSnap('', { offset: { y: -101 } })
-    expect(snapPosition).toBe('0%')
+    expect(snapPosition).toBe('20%')
   })
 })

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react'
 
 describe('Drawer snap hook unit test', () => {
   test('Snap position initialized correctly', () => {
-    const { result } = renderHook(() => useSnap(['0%', '20%', '30%']))
+    const { result } = renderHook(() => useSnap(['0%', '20%', '30%'], ['100%', '100%', '100%']))
     const { snapPosition, handleSnap } = result.current
     expect(snapPosition).toBe('0%')
 

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -16,7 +16,7 @@ export function useSnap(snapHeights, snapDimensions) {
   const [TOP, MIDDLE, BOTTOM] = snapHeights
 
   const SCROLL_THRESHOLD = 100
-  const [snapPosition, setSnapPosition] = useState(MIDDLE) // Changed this line
+  const [snapPosition, setSnapPosition] = useState(MIDDLE)
 
   const handleSnap = (...args) => {
     const info = args?.[1]
@@ -27,7 +27,7 @@ export function useSnap(snapHeights, snapDimensions) {
 
     // Scroll down logic
     if (SCROLL_DOWN) {
-      if (snapPosition === TOP) setSnapPosition(MIDDLE) // Changed this line
+      if (snapPosition === TOP) setSnapPosition(MIDDLE)
       if (snapPosition === MIDDLE) setSnapPosition(BOTTOM)
     }
 
@@ -35,7 +35,6 @@ export function useSnap(snapHeights, snapDimensions) {
     else if (SCROLL_UP) {
       if (snapPosition === BOTTOM) setSnapPosition(MIDDLE)
       if (snapPosition === MIDDLE) setSnapPosition(TOP)
-      // Changed this line
     }
   }
 

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -14,8 +14,9 @@ export function useSnap(snapHeights, snapDimensions) {
   }
 
   const [TOP, MIDDLE, BOTTOM] = snapHeights
+
   const SCROLL_THRESHOLD = 100
-  const [snapPosition, setSnapPosition] = useState(TOP)
+  const [snapPosition, setSnapPosition] = useState(MIDDLE) // Changed this line
 
   const handleSnap = (...args) => {
     const info = args?.[1]
@@ -26,7 +27,7 @@ export function useSnap(snapHeights, snapDimensions) {
 
     // Scroll down logic
     if (SCROLL_DOWN) {
-      if (snapPosition === TOP) setSnapPosition(MIDDLE)
+      if (snapPosition === TOP) setSnapPosition(MIDDLE) // Changed this line
       if (snapPosition === MIDDLE) setSnapPosition(BOTTOM)
     }
 
@@ -34,6 +35,7 @@ export function useSnap(snapHeights, snapDimensions) {
     else if (SCROLL_UP) {
       if (snapPosition === BOTTOM) setSnapPosition(MIDDLE)
       if (snapPosition === MIDDLE) setSnapPosition(TOP)
+      // Changed this line
     }
   }
 

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -8,8 +8,12 @@ import { useState } from 'react'
  *
  * Designed to support 3 snap points.
  */
-export function useSnap(snapHeights) {
-  const [TOP, MIDDLE, BOTTOM] = snapHeights || []
+export function useSnap(snapHeights, snapDimensions) {
+  if (!snapHeights || !snapDimensions) {
+    return { snapPosition: null, handleSnap: () => {} }
+  }
+
+  const [TOP, MIDDLE, BOTTOM] = snapHeights
   const SCROLL_THRESHOLD = 100
   const [snapPosition, setSnapPosition] = useState(TOP)
 


### PR DESCRIPTION
**Changelog**

1. Fixed a few type declaration bugs + added null checks to remove TS warnings.

2. On first render, assign the starting drag position to be the initial height. This way it enables user to drag bidirectionally (up/down), rather than just up.
https://github.com/user-attachments/assets/f125fa70-14e0-4fd0-9617-862996104e11

3. Propogating maxHeight from container




