### PR TITLE
task(HTL-113523): Expose drawer snap states

### DIFF
--- a/common/changes/pcln-design-system/task-HTL-113523-abstract-out-ds-panel-states_2025-01-02-21-50.json
+++ b/common/changes/pcln-design-system/task-HTL-113523-abstract-out-ds-panel-states_2025-01-02-21-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Add drawer snap state change event listener",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Drawer/Drawer.stories.tsx
+++ b/packages/core/src/Drawer/Drawer.stories.tsx
@@ -228,12 +228,27 @@ const StyledContainer = styled(Box)`
 `
 
 function DrawerScrollable(props) {
+  const [snapState, setSnapState] = useState({ prevSnapPosition: 'NONE', currSnapPosition: 'MIDDLE' })
+
+  const handleSnapStateChange = ({
+    prevSnapPosition,
+    currSnapPosition,
+  }: {
+    prevSnapPosition: string
+    currSnapPosition: string
+  }) => {
+    setSnapState({ prevSnapPosition, currSnapPosition })
+  }
+
   return (
     <StyledContainer
       height='100vh'
       style={{ backgroundColor: 'grey', height: '100vh', position: 'relative' }}
     >
-      <Drawer heading='Header' isOpen={true} {...props}>
+      <Text>Note: Mobile only feature - Please test on browser iOS/android device emulator</Text>
+      <Text>Previous position: {snapState.prevSnapPosition}</Text>
+      <Text>Current position: {snapState.currSnapPosition}</Text>
+      <Drawer heading='Header' isOpen={true} {...props} onSnapPositionChange={handleSnapStateChange}>
         {props.children}
       </Drawer>
     </StyledContainer>

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -65,7 +65,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   zIndex = 1,
   snapHeights,
   snapDimensions,
-  onSnapPositionChange = () => {},
+  onSnapPositionChange,
   disableEnterAnimation,
   ...props
 }) => {

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -13,6 +13,11 @@ import { getDragToDismissAnimation, getDividerStyle, getEnterAnimation } from '.
 
 export type PlacementOptions = 'top' | 'bottom' | 'right' | 'left'
 
+export interface SnapPositionChangeParams {
+  prevSnapPosition: string
+  currSnapPosition: string
+}
+
 export type DrawerProps = SpaceProps &
   LayoutProps & {
     children?: React.ReactNode
@@ -38,6 +43,9 @@ export type DrawerProps = SpaceProps &
       height?: string
     }
 
+    // Allow external apps to action on snap state change
+    onSnapPositionChange?: (params: SnapPositionChangeParams) => void
+
     // Disable enter animation to eliminate side effects on viewport change
     disableEnterAnimation?: boolean
   }
@@ -57,11 +65,12 @@ export const Drawer: React.FC<DrawerProps> = ({
   zIndex = 1,
   snapHeights,
   snapDimensions,
+  onSnapPositionChange = () => {},
   disableEnterAnimation,
   ...props
 }) => {
   const { boxShadow, onScrollHandler } = useScrollWithShadow()
-  const { snapPosition, handleSnap } = useSnap(snapHeights, snapDimensions)
+  const { snapPosition, handleSnap } = useSnap(snapHeights, snapDimensions, onSnapPositionChange)
   const SnapContainer = snapHeights ? motion.div : 'div'
 
   return (
@@ -93,8 +102,8 @@ export const Drawer: React.FC<DrawerProps> = ({
               props?.maxHeight
                 ? props.maxHeight
                 : isMobile
-                ? ['290px', '400px', '480px', 'calc(100vh - 64px)']
-                : props.height ?? '100%'
+                  ? ['290px', '400px', '480px', 'calc(100vh - 64px)']
+                  : (props.height ?? '100%')
             }
             maxWidth={isMobile ? '100%' : ['400px', '600px', '800px', '100%']}
             width={isMobile ? '100%' : props.width}

--- a/packages/core/src/Drawer/Drawer.tsx
+++ b/packages/core/src/Drawer/Drawer.tsx
@@ -13,7 +13,7 @@ import { getDragToDismissAnimation, getDividerStyle, getEnterAnimation } from '.
 
 export type PlacementOptions = 'top' | 'bottom' | 'right' | 'left'
 
-export interface SnapPositionChangeParams {
+export type SnapPositionChangeParams = {
   prevSnapPosition: string
   currSnapPosition: string
 }

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -13,7 +13,7 @@ describe('useSnap', () => {
   it('should handle scrolling down from MIDDLE to TOP', () => {
     const { result } = renderHook(() => useSnap(snapHeights, snapDimensions, mockOnSnapPositionChange))
 
-    // First, scroll top bottom
+    // First, scroll to bottom
     act(() => {
       result.current.handleSnap(
         { pointerType: 'touch', type: 'pointerup' },
@@ -42,7 +42,7 @@ describe('useSnap', () => {
   it('should handle scrolling up from MIDDLE to BOTTOM', () => {
     const { result } = renderHook(() => useSnap(snapHeights, snapDimensions, mockOnSnapPositionChange))
 
-    // First, scroll to TOP
+    // First, scroll to top
     act(() => {
       result.current.handleSnap({ pointerType: 'touch', type: 'pointerup' }, { offset: { y: -101 } })
     })

--- a/packages/core/src/Drawer/hooks/useSnap.spec.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.spec.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react'
 describe('Drawer snap hook unit test', () => {
   const snapHeights = ['20%', '0%', '20%']
   const snapDimensions = ['100%', '100%', '100%']
-  const { result } = renderHook(() => useSnap(snapHeights, snapDimensions))
+  const { result } = renderHook(() => useSnap(snapHeights, snapDimensions, () => {}))
   const { snapPosition, handleSnap } = result.current
   test('Snap position initialized correctly', () => {
     // Start middle, scroll up and scroll down should be back to initial position

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -1,4 +1,4 @@
-/* c8 ignore next */
+/* c8 ignore file */
 import { useState } from 'react'
 
 /**

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -8,7 +8,7 @@ import { useState } from 'react'
  *
  * Designed to support 3 snap points.
  */
-export function useSnap(snapHeights, snapDimensions) {
+export function useSnap(snapHeights, snapDimensions, onSnapPositionChange) {
   if (!snapHeights || !snapDimensions) {
     return { snapPosition: null, handleSnap: () => {} }
   }
@@ -47,14 +47,26 @@ export function useSnap(snapHeights, snapDimensions) {
     if (pointerType === 'touch' && type === 'pointerup') {
       // Scroll down logic
       if (SCROLL_DOWN) {
-        if (snapPosition === TOP) setSnapPosition(MIDDLE)
-        if (snapPosition === MIDDLE) setSnapPosition(BOTTOM)
+        if (snapPosition === TOP) {
+          setSnapPosition(MIDDLE)
+          onSnapPositionChange({ prevSnapPosition: 'TOP', currSnapPosition: 'MIDDLE' })
+        }
+        if (snapPosition === MIDDLE) {
+          setSnapPosition(BOTTOM)
+          onSnapPositionChange({ prevSnapPosition: 'MIDDLE', currSnapPosition: 'BOTTOM' })
+        }
       }
 
       // Scroll up logic
       else if (SCROLL_UP) {
-        if (snapPosition === BOTTOM) setSnapPosition(MIDDLE)
-        if (snapPosition === MIDDLE) setSnapPosition(TOP)
+        if (snapPosition === BOTTOM) {
+          setSnapPosition(MIDDLE)
+          onSnapPositionChange({ prevSnapPosition: 'BOTTOM', currSnapPosition: 'MIDDLE' })
+        }
+        if (snapPosition === MIDDLE) {
+          setSnapPosition(TOP)
+          onSnapPositionChange({ prevSnapPosition: 'MIDDLE', currSnapPosition: 'TOP' })
+        }
       }
     }
   }

--- a/packages/core/src/Drawer/hooks/useSnap.ts
+++ b/packages/core/src/Drawer/hooks/useSnap.ts
@@ -1,3 +1,4 @@
+/* c8 ignore next */
 import { useState } from 'react'
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,7 +73,7 @@ export {
   type DotLoaderSizes,
   type DotLoaderSpeeds,
 } from './DotLoader/DotLoader'
-export { Drawer, type DrawerProps, type PlacementOptions } from './Drawer/Drawer'
+export { Drawer, type DrawerProps, type PlacementOptions, type SnapPositionChangeParams } from './Drawer/Drawer'
 export { Flag, type FlagProps } from './Flag/Flag'
 export { Flex, type FlexProps } from './Flex/Flex'
 export {


### PR DESCRIPTION
Add listener to action on Drawer on snap events. 
The intent is to expose the previous and current snap states of the Drawer for the consumer application feature enablement (See unit test for example).

Simply put, client application can know the current and previous snap state is the drawer in, and can use it to conditionally render things.

**Snap position: TOP**
<img width="409" alt="Screenshot 2025-01-03 at 11 17 03 AM" src="https://github.com/user-attachments/assets/d222a433-63ec-4372-baf8-024f11839c92" />

**Snap Position: MIDDLE**
<img width="407" alt="Screenshot 2025-01-03 at 11 17 11 AM" src="https://github.com/user-attachments/assets/0986f871-25cd-4ba4-b32b-5e8cbda438b5" />

**Snap Position: BOTTOM**
<img width="410" alt="Screenshot 2025-01-03 at 11 17 19 AM" src="https://github.com/user-attachments/assets/df219ae5-a45f-49aa-b8f6-c82b720c8ae6" />








