### PR TITLE
chore(UXPT-9083): Remove Shimmer Component DefaultProps

### DIFF
--- a/common/changes/pcln-design-system/chore-UXPT-9083-Remove-Shimmer-DefaultProps_2025-02-03-14-15.json
+++ b/common/changes/pcln-design-system/chore-UXPT-9083-Remove-Shimmer-DefaultProps_2025-02-03-14-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Remove DefaultProps from the Shimmer Component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/packages/core/src/Shimmer/Shimmer.tsx
+++ b/packages/core/src/Shimmer/Shimmer.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { Box, type BoxProps } from '../Box/Box'
 import {
+  ShimmerVariationType,
   VARIATION_BACKGROUND_COLORS,
   VARIATION_GLARE_GRADIENTS,
-  ShimmerVariationType,
   type ShimmerVariation,
 } from './constants'
 
@@ -58,20 +58,19 @@ export type ShimmerProps = BoxProps & {
 /**
  * @public
  */
-export function Shimmer({ animationWidth, disable, ...props }: ShimmerProps): JSX.Element {
+export function Shimmer({
+  animationWidth = 100,
+  disable = false,
+  variation = ShimmerVariationType.Base,
+  ...props
+}: ShimmerProps): JSX.Element {
   return (
-    <Wrapper {...props} data-testid='Shimmer__Wrapper'>
+    <Wrapper {...props} data-testid='Shimmer__Wrapper' variation={variation}>
       {!disable && (
-        <Glare animationWidth={animationWidth + 200} data-testid='Shimmer__Glare' variation={props.variation}>
+        <Glare animationWidth={animationWidth + 200} data-testid='Shimmer__Glare' variation={variation}>
           &zwnj;
         </Glare>
       )}
     </Wrapper>
   )
-}
-
-Shimmer.defaultProps = {
-  animationWidth: 100,
-  disable: false,
-  variation: ShimmerVariationType.Base,
 }


### PR DESCRIPTION
# Context

Use of `DefaultProps` throws a warning in React 18.3, and an error in React 19. 

# Description of Changes

Removes the Shimmer component's DefaultProps