### PR TITLE
feat(HTL-114826): add toggleText prop for accordion

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -315,6 +315,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "tommyliang-dev",
+      "name": "Tommy Liang",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84786278?v=4",
+      "profile": "https://github.com/tommyliang-dev",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/common/changes/pcln-design-system/HTL-114826-accordion-dtls-rate-grid_2025-02-20-15-12.json
+++ b/common/changes/pcln-design-system/HTL-114826-accordion-dtls-rate-grid_2025-02-20-15-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "add useTextToggle prop to accordion",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-modal/HTL-114826-accordion-dtls-rate-grid_2025-02-20-15-12.json
+++ b/common/changes/pcln-modal/HTL-114826-accordion-dtls-rate-grid_2025-02-20-15-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "pcln-modal"
+}

--- a/packages/core/src/Accordion/Accordion.spec.tsx
+++ b/packages/core/src/Accordion/Accordion.spec.tsx
@@ -41,6 +41,24 @@ describe('Accordion', () => {
     expect(onToggle).toHaveBeenCalled()
   })
 
+  it('toggles items with text toggle', () => {
+    const onToggle = jest.fn()
+    const items = testItems[0]
+    render(<Accordion items={[items]} onToggle={onToggle} useTextToggle />)
+    const header1 = screen.getByText('Header 1')
+    const moreTextTriggers = screen.getByText(/more/i)
+    const lessTextTriggers = screen.getByText(/less/i)
+
+    expect(moreTextTriggers).toHaveStyle('display: none')
+    expect(lessTextTriggers).toHaveStyle('display: inline')
+
+    fireEvent.click(header1)
+
+    expect(onToggle).toHaveBeenCalled()
+    expect(moreTextTriggers).toHaveStyle('display: inline')
+    expect(lessTextTriggers).toHaveStyle('display: none')
+  })
+
   it('toggles items isExternallyControlled', () => {
     const onToggle = jest.fn()
     render(<Accordion items={testItems} onToggle={onToggle} isExternallyControlled />)

--- a/packages/core/src/Accordion/Accordion.stories.tsx
+++ b/packages/core/src/Accordion/Accordion.stories.tsx
@@ -141,6 +141,9 @@ export const ChevronClose = {
   render: (args) => <Accordion {...args} isAnimatedChevron items={items} />,
 }
 
+export const UseTextToggle = {
+  render: (args) => <Accordion {...args} items={items} useTextToggle itemsState={['item-1', 'item-2']} />,
+}
 export const TrackStateMultiple = {
   render: (args) => {
     const [itemsState, setItemsState] = useState(['item-1', 'item-3'])

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -53,9 +53,14 @@ export const StyledContent = styled(Accordion.Content)`
 `
 
 export const StyledTrigger = styled(Accordion.Trigger).attrs(borderRadiusAttrs)`
+  .moreText,
+  .lessText {
+    padding-left: 8px;
+  }
   all: unset;
   box-sizing: border-box;
   display: flex;
+  align-items: center;
   justify-content: space-between;
   width: 100%;
   color: ${(props) => (props.variation === 'hug' ? getPaletteColor('text.lightest')(props) : '')};
@@ -63,8 +68,22 @@ export const StyledTrigger = styled(Accordion.Trigger).attrs(borderRadiusAttrs)`
     transform: rotate(180deg);
   }
   &[data-state='closed'] {
+    .lessText {
+      display: none;
+    }
+    .moreText {
+      display: inline;
+    }
     ${(props) =>
       props.variation === 'flatCard' ? `background-color: ${getPaletteColor('background.light')(props)}` : ''}
+  }
+  &[data-state='open'] {
+    .lessText {
+      display: inline;
+    }
+    .moreText {
+      display: none;
+    }
   }
   ${(props) =>
     props.variation === 'ladder'

--- a/packages/core/src/Accordion/Accordion.tsx
+++ b/packages/core/src/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { SpaceProps } from 'styled-system'
 import { Box } from '../Box/Box'
 import { Flex } from '../Flex/Flex'
+import { Text } from '../Text/Text'
 import {
   IconContainer,
   StyledAccordionRoot,
@@ -23,6 +24,7 @@ export type AccordionProps = SpaceProps & {
   variation?: string
   isExternallyControlled?: boolean
   headerDividerColor?: string
+  useTextToggle?: boolean
 }
 
 /**
@@ -50,6 +52,7 @@ export function Accordion({
   variation = 'default',
   p = '12px',
   headerDividerColor,
+  useTextToggle = false,
   ...props
 }: AccordionProps): React.ReactElement {
   return items ? (
@@ -66,35 +69,48 @@ export function Accordion({
         isolation: 'isolate',
       }}
     >
-      {items.map((child: AccordionItemProps, index) => (
-        <RadixAccordion.Item key={child.value} asChild value={child.value}>
-          <StyledItem
-            variation={variation}
-            overflow='hidden'
-            borderRadius='12px'
-            marginBottom='12px'
-            headerBg={child.headerBg}
-            hoverBg={child.hoverBg}
-            data-testid={`styled-item-${child.value}`}
-            headerDividerColor={index > 0 && headerDividerColor}
-          >
-            <StyledTrigger {...props} p={p} variation={variation}>
-              <Flex width='100%' justifyContent='space-between' alignItems='center'>
-                {child.headerLabel}
-                {child.headerActions ? (
-                  <Box onClick={(e) => e.preventDefault()}>{child.headerActions}</Box>
-                ) : null}
-              </Flex>
-              <IconContainer margin='auto' height='25px'>
-                <StyledChevron className='chevron' variation={variation} />
-              </IconContainer>
-            </StyledTrigger>
-            <StyledContent {...props} p={p} variation={variation} contentBg={child.contentBg}>
-              {child.content}
-            </StyledContent>
-          </StyledItem>
-        </RadixAccordion.Item>
-      ))}
+      {items.map((child: AccordionItemProps, index) => {
+        return (
+          <RadixAccordion.Item key={child.value} asChild value={child.value}>
+            <StyledItem
+              variation={variation}
+              overflow='hidden'
+              borderRadius='12px'
+              marginBottom='12px'
+              headerBg={child.headerBg}
+              hoverBg={child.hoverBg}
+              data-testid={`styled-item-${child.value}`}
+              headerDividerColor={index > 0 && headerDividerColor}
+            >
+              <StyledTrigger {...props} p={p} variation={variation} hoverBg={child.hoverBg}>
+                <Flex width='100%' justifyContent='space-between' alignItems='center'>
+                  {child.headerLabel}
+                  {child.headerActions ? (
+                    <Box onClick={(e) => e.preventDefault()}>{child.headerActions}</Box>
+                  ) : null}
+                </Flex>
+                {useTextToggle ? (
+                  <>
+                    <Text.span textStyle='captionBold' color='primary.base' className='lessText'>
+                      Less
+                    </Text.span>
+                    <Text.span textStyle='captionBold' color='primary.base' className='moreText'>
+                      More
+                    </Text.span>
+                  </>
+                ) : (
+                  <IconContainer margin='auto' height='25px'>
+                    <StyledChevron className='chevron' variation={variation} />
+                  </IconContainer>
+                )}
+              </StyledTrigger>
+              <StyledContent {...props} p={p} variation={variation} contentBg={child.contentBg}>
+                {child.content}
+              </StyledContent>
+            </StyledItem>
+          </RadixAccordion.Item>
+        )
+      })}
     </StyledAccordionRoot>
   ) : null
 }

--- a/packages/modal/src/__snapshots__/Headers.spec.js.snap
+++ b/packages/modal/src/__snapshots__/Headers.spec.js.snap
@@ -24,6 +24,12 @@ exports[`ModalHeader render 1`] = `
   align-items: center;
 }
 
+.c3 {
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 16px;
+}
+
 .c10 {
   -webkit-flex: none;
   -ms-flex: none;
@@ -34,12 +40,6 @@ exports[`ModalHeader render 1`] = `
 
 .c11 {
   outline: none;
-}
-
-.c3 {
-  font-weight: 700;
-  font-size: 14px;
-  line-height: 16px;
 }
 
 .c6 {


### PR DESCRIPTION
Bringing a previously approved PR back to life: https://github.com/priceline/design-system/pull/1537

- **Accordion**: Added useToggleText prop to allow customization of the toggle element. When set to true, the default arrow will be replaced with "More" and "Less" text

![image](https://github.com/user-attachments/assets/8244e4bc-c4ea-482d-b8f5-803afb1ea936)
![image](https://github.com/user-attachments/assets/52627a6a-343c-4878-a5c4-f0d734ef932b)
