### PR TITLE
Chore/uxpt 10092 pass ref to transition

### DIFF
--- a/common/changes/pcln-design-system/fix-UXPT-9366-revert-attrs-changes_2025-04-07-20-25.json
+++ b/common/changes/pcln-design-system/fix-UXPT-9366-revert-attrs-changes_2025-04-07-20-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "revert removal of defaultProps due to bad interaction with attrs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-slider/fix-UXPT-9366-revert-attrs-changes_2025-04-07-20-25.json
+++ b/common/changes/pcln-slider/fix-UXPT-9366-revert-attrs-changes_2025-04-07-20-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-slider",
+      "comment": "revert removal of defaultProps due to bad interaction with attrs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-slider"
+}

--- a/packages/core/src/BackgroundImage/BackgroundImage.tsx
+++ b/packages/core/src/BackgroundImage/BackgroundImage.tsx
@@ -9,8 +9,8 @@ import {
   height,
   width,
 } from 'styled-system'
+import { applyVariations, getPaletteColor } from '../utils'
 import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
-import { applyVariations, getPaletteColor } from '../utils/utils'
 
 const variations = {
   parallax: css`
@@ -41,23 +41,22 @@ export type BackgroundImageProps = WidthProps &
     backgroundPosition?: (typeof backgroundPositionList)[number]
   }
 
-const _BackgroundImage: React.FC<BackgroundImageProps> = styled.div.attrs(borderRadiusAttrs)`
+/**
+ * @public
+ */
+export const BackgroundImage: React.FC<BackgroundImageProps> = styled.div.attrs(borderRadiusAttrs)`
   background-position: ${(props) => props.backgroundPosition};
   background-size: cover;
   background-repeat: no-repeat;
   background-color: ${getPaletteColor('border.light')};
   ${applyVariations('BackgroundImage', variations)}
   ${image} 
-
   ${(props) => compose(height, width, borderRadius)(props)}
 `
-/**
- * @public
- */
-export const BackgroundImage: React.FC<BackgroundImageProps> = ({
-  variation = 'static',
-  backgroundPosition = 'center',
-  ...props
-}) => <_BackgroundImage variation={variation} backgroundPosition={backgroundPosition} {...props} />
+
+BackgroundImage.defaultProps = {
+  variation: 'static',
+  backgroundPosition: 'center',
+}
 
 BackgroundImage.displayName = 'BackgroundImage'

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -86,28 +86,27 @@ export type BadgeProps = SpaceProps &
     textTransform?: string
   }
 
-const _Badge: React.FC<BadgeProps> = styled.div.attrs(borderRadiusAttrs)`
+/**
+ * @public
+ */
+export const Badge: React.FC<BadgeProps> = styled.div.attrs(borderRadiusAttrs)`
   display: inline-block;
   ${({ theme }) => applySizes(sizes, undefined, theme.mediaQueries)};
   ${applyVariations('Badge')};
   ${type}
   ${color}
-${colorScheme}
-${textTransform}
-${letterSpacing}
+  ${colorScheme}
+  ${textTransform}
+  ${letterSpacing}
 
-${(props) => compose(space, borderRadius)(props)}
+  ${(props) => compose(space, borderRadius)(props)}
 `
 
-/**
- * @public
- */
-export const Badge: React.FC<BadgeProps> = ({
-  borderRadius = 'full',
-  px = 2,
-  size = 'medium',
-  textTransform = 'uppercase',
-  ...props
-}) => <_Badge borderRadius={borderRadius} px={px} size={size} textTransform={textTransform} {...props} />
+Badge.defaultProps = {
+  size: 'medium',
+  px: 2,
+  borderRadius: 'full',
+  textTransform: 'uppercase',
+}
 
 Badge.displayName = 'Badge'

--- a/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/core/src/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -19,9 +19,9 @@ exports[`Badge bg blue sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -49,9 +49,9 @@ exports[`Badge bg green sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -79,9 +79,9 @@ exports[`Badge bg lightBlue sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -109,9 +109,9 @@ exports[`Badge bg lightGreen sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -139,9 +139,9 @@ exports[`Badge bg lightRed sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -169,9 +169,9 @@ exports[`Badge bg orange sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -199,9 +199,9 @@ exports[`Badge bg red sets background-color and color 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -228,9 +228,9 @@ exports[`Badge can escape preset: bg lightBlue sets background-color and color t
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -258,9 +258,9 @@ exports[`Badge non-preset: bg text sets background-color and color white sets co
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -288,9 +288,9 @@ exports[`Badge renders 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div
@@ -317,9 +317,9 @@ exports[`Badge renders small 1`] = `
   -moz-letter-spacing: 0.025em;
   -ms-letter-spacing: 0.025em;
   letter-spacing: 0.025em;
-  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
+  border-radius: 9999px;
 }
 
 <div

--- a/packages/core/src/BlockLink/__snapshots__/BlockLink.spec.tsx.snap
+++ b/packages/core/src/BlockLink/__snapshots__/BlockLink.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`BlockLink renders 1`] = `
 }
 
 <a
-  className="c0 c1 sc-dcJsrY c1"
+  className="c0 c1"
   color="primary"
   rel={null}
   size="medium"

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -31,8 +31,8 @@ exports[`FormField disabled state renders input with icon - disabled 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
   padding-left: 40px;
 }
 
@@ -303,9 +303,9 @@ exports[`FormField disabled state renders select with icon - disabled 1`] = `
   width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
+  padding-left: 40px;
   font-size: 16px;
   margin: 0px;
-  padding-left: 40px;
 }
 
 .c10::-ms-expand {
@@ -460,8 +460,8 @@ exports[`FormField renders 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
 }
 
 .c3::-webkit-input-placeholder {
@@ -624,8 +624,8 @@ exports[`FormField renders with Icon 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
   padding-left: 40px;
 }
 
@@ -821,8 +821,8 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
   padding-left: 40px;
 }
 
@@ -1271,9 +1271,9 @@ exports[`FormField renders with Select and Icon 1`] = `
   width: 100%;
   padding: 14px 32px 14px 12px;
   border-color: #c0cad5;
+  padding-left: 40px;
   font-size: 16px;
   margin: 0px;
-  padding-left: 40px;
 }
 
 .c8::-ms-expand {

--- a/packages/core/src/Image/Image.tsx
+++ b/packages/core/src/Image/Image.tsx
@@ -51,7 +51,10 @@ export type ImageProps = BorderRadiusProps &
     objectPosition?: ObjectPosition
   }
 
-const _Image: React.FC<ImageProps> = styled.img.attrs((props) => ({
+/**
+ * @public
+ */
+export const Image: React.FC<ImageProps> = styled.img.attrs((props) => ({
   ...borderRadiusAttrs(props),
   ...boxShadowAttrs(props),
 }))`
@@ -63,11 +66,9 @@ const _Image: React.FC<ImageProps> = styled.img.attrs((props) => ({
     compose(width, height, maxHeight, maxWidth, minHeight, minWidth, space, borderRadius, boxShadow)(props)}
 `
 
-/**
- * @public
- */
-export const Image: React.FC<ImageProps> = ({ boxShadowColor = 'border', maxWidth = '100%', ...props }) => (
-  <_Image boxShadowColor={boxShadowColor} maxWidth={maxWidth} {...props} />
-)
-
 Image.displayName = 'Image'
+
+Image.defaultProps = {
+  boxShadowColor: 'border',
+  maxWidth: '100%',
+}

--- a/packages/core/src/Input/Input.tsx
+++ b/packages/core/src/Input/Input.tsx
@@ -96,7 +96,10 @@ export type InputWithRef = ForwardRefExoticComponent<Omit<InputProps, 'ref'> & R
   HelperText: React.FC<InputHelperTextProps>
 }
 
-const _Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+/**
+ * @public
+ */
+export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const { helperText, color, ...restProps } = props
   return (
     <>
@@ -109,15 +112,6 @@ const _Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   )
 }) as InputWithRef
 
-/**
- * @public
- */
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ fontSize = [2, null, 1], borderRadius = 'lg', size = 'lg', ...props }, ref) => (
-    <_Input borderRadius={borderRadius} fontSize={fontSize} size={size} ref={ref} {...props} />
-  )
-) as InputWithRef
-
 const HelperText: React.FC<InputHelperTextProps> = styled(Text).attrs(() => ({
   mt: 2,
   fontSize: 1,
@@ -129,3 +123,8 @@ Input.HelperText.displayName = INPUT_ERROR_TEXT
 
 Input.displayName = 'Input'
 Input.isField = true
+Input.defaultProps = {
+  fontSize: [2, null, 1],
+  borderRadius: 'lg',
+  size: 'lg',
+}

--- a/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/core/src/Input/__snapshots__/Input.spec.tsx.snap
@@ -16,8 +16,8 @@ exports[`Input it renders 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
 }
 
 .c0::-webkit-input-placeholder {
@@ -92,10 +92,10 @@ exports[`Input it renders an input element with a really large padding and margi
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
-  font-size: 16px;
   padding: 32px;
   margin: 32px;
+  font-size: 16px;
+  border-radius: 12px;
 }
 
 .c0::-webkit-input-placeholder {
@@ -170,8 +170,8 @@ exports[`Input it renders an input element with a red border with a color prop i
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c00;
-  border-radius: 12px;
   font-size: 16px;
+  border-radius: 12px;
 }
 
 .c0::-webkit-input-placeholder {
@@ -247,8 +247,8 @@ exports[`Input it renders an input element with large text 1`] = `
   margin: 0;
   padding: 14px 12px 14px 12px;
   border-color: #c0cad5;
-  border-radius: 12px;
   font-size: 24px;
+  border-radius: 12px;
 }
 
 .c0::-webkit-input-placeholder {

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -14,7 +14,10 @@ export type InputGroupProps = SpaceProps & {
   children?: React.ReactNode
 }
 
-const _InputGroup: React.FC<InputGroupProps> = styled.div`
+/**
+ * @public
+ */
+export const InputGroup: React.FC<InputGroupProps> = styled.div`
   display: flex;
   align-items: center;
   border-radius: ${themeGet('borderRadii.xl')};
@@ -35,9 +38,6 @@ const _InputGroup: React.FC<InputGroupProps> = styled.div`
   ${space}
 `
 
-/**
- * @public
- */
-export const InputGroup: React.FC<InputGroupProps> = ({ borderColor = 'border', ...props }) => (
-  <_InputGroup borderColor={borderColor} {...props} />
-)
+InputGroup.defaultProps = {
+  borderColor: 'border',
+}

--- a/packages/core/src/Label/Label.tsx
+++ b/packages/core/src/Label/Label.tsx
@@ -65,7 +65,10 @@ export type LabelProps = SpaceProps &
     onClick?: (evt: unknown) => void
   }
 
-const _Label: React.FC<LabelProps> & { isLabel?: boolean } = styled.label.attrs((props) => ({
+/**
+ * @public
+ */
+export const Label: React.FC<LabelProps> & { isLabel?: boolean } = styled.label.attrs((props) => ({
   ...typographyAttrs(props),
   ...props,
 }))`
@@ -86,14 +89,10 @@ const _Label: React.FC<LabelProps> & { isLabel?: boolean } = styled.label.attrs(
   ${(props) => compose(fontSize, fontWeight, lineHeight, letterSpacing, space, textStyle, width)(props)}
 `
 
-/**
- * @public
- */
-export const Label: React.FC<LabelProps> & { isLabel?: boolean } = ({
-  color = 'text.light',
-  textStyle = 'label',
-  ...props
-}) => <_Label color={color} textStyle={textStyle} {...props} />
+Label.defaultProps = {
+  color: 'text.light',
+  textStyle: 'label',
+}
 
 Label.displayName = 'Label'
 Label.isLabel = true

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -91,15 +91,20 @@ export type LinkProps = WidthProps &
     variation?: ButtonVariations
   }
 
-const _Link: React.FC<LinkProps> = styled.a.attrs(({ color, disabled, href, target, onClick, ...props }) => ({
-  color: disabled ? 'text.light' : color,
-  disabled,
-  href: !disabled ? href : undefined,
-  rel: target === '_blank' ? 'noopener' : null,
-  target,
-  onClick: !disabled ? onClick : () => {},
-  ...props,
-}))`
+/**
+ * @public
+ */
+export const Link: React.FC<LinkProps> = styled.a.attrs(
+  ({ color, disabled, href, target, onClick, ...props }) => ({
+    color: disabled ? 'text.light' : color,
+    disabled,
+    href: !disabled ? href : undefined,
+    rel: target === '_blank' ? 'noopener' : null,
+    target,
+    onClick: !disabled ? onClick : () => {},
+    ...props,
+  })
+)`
   ${applyVariations('Link', variations)}
 
   ${(props) =>
@@ -115,14 +120,10 @@ const _Link: React.FC<LinkProps> = styled.a.attrs(({ color, disabled, href, targ
   ${(props) => compose(space, width)(props)}
 `
 
-/**
- * @public
- */
-export const Link: React.FC<LinkProps> = ({
-  color = 'primary',
-  variation = 'link',
-  size = 'medium',
-  ...props
-}) => <_Link color={color} variation={variation} size={size} {...props} />
-
 Link.displayName = 'Link'
+
+Link.defaultProps = {
+  color: 'primary',
+  variation: 'link',
+  size: 'medium',
+}

--- a/packages/core/src/RatingBadge/RatingBadge.tsx
+++ b/packages/core/src/RatingBadge/RatingBadge.tsx
@@ -4,6 +4,14 @@ import { borderRadius, compose, fontWeight } from 'styled-system'
 import { Box, type BoxProps } from '../Box/Box'
 import { borderRadiusAttrs } from '../utils/attrs/borderRadiusAttrs'
 
+const defaultProps = {
+  fontWeight: 'bold',
+  px: 2,
+  color: 'alert',
+  borderRadius: 'md',
+  bg: 'alert',
+}
+
 /**
  * @public
  */
@@ -32,7 +40,10 @@ function getBgAndColorProps({ color, bg }) {
   }
 }
 
-const _RatingBadge: React.FC<RatingBadgeProps> = styled(Box).attrs((props) => ({
+/**
+ * @public
+ */
+export const RatingBadge: React.FC<RatingBadgeProps> = styled(Box).attrs((props) => ({
   ...getBgAndColorProps(props),
   ...borderRadiusAttrs(props),
 }))`
@@ -41,25 +52,4 @@ const _RatingBadge: React.FC<RatingBadgeProps> = styled(Box).attrs((props) => ({
   ${(props) => compose(fontWeight, borderRadius)(props)}
 `
 
-/**
- * @public
- */
-export const RatingBadge: React.FC<RatingBadgeProps> = ({
-  fontWeight = 'bold',
-  px = 2,
-  color = 'alert',
-  borderRadius = 'md',
-  bg = 'alert',
-  ...props
-}) => {
-  return (
-    <_RatingBadge
-      fontWeight={fontWeight}
-      px={px}
-      color={color}
-      borderRadius={borderRadius}
-      bg={bg}
-      {...props}
-    />
-  )
-}
+RatingBadge.defaultProps = defaultProps

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -86,7 +86,7 @@ export type SelectProps = SpaceProps &
     variation?: SelectVariations
   }
 
-const _SelectBase: React.FC<SelectProps> = styled.select.attrs(borderRadiusAttrs)`
+const SelectBase: React.FC<SelectProps> = styled.select.attrs(borderRadiusAttrs)`
   appearance: none;
   background-color: transparent;
   border-style: solid;
@@ -125,9 +125,11 @@ const _SelectBase: React.FC<SelectProps> = styled.select.attrs(borderRadiusAttrs
   ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
-const SelectBase: React.FC<SelectProps> = ({ fontSize = [2, null, 1], m = 0, size = 'lg', ...props }) => (
-  <_SelectBase fontSize={fontSize} m={m} size={size} {...props} />
-)
+SelectBase.defaultProps = {
+  fontSize: [2, null, 1],
+  m: 0,
+  size: 'lg',
+}
 
 /**
  * @public

--- a/packages/core/src/Stamp/Stamp.tsx
+++ b/packages/core/src/Stamp/Stamp.tsx
@@ -69,7 +69,10 @@ export type StampProps = SpaceProps &
     colorScheme?: ColorSchemeName
   }
 
-const _Stamp: React.FC<StampProps> = styled.div.attrs(borderRadiusAttrs)`
+/**
+ * @public
+ */
+export const Stamp: React.FC<StampProps> = styled.div.attrs(borderRadiusAttrs)`
   display: inline-flex;
   align-items: center;
   vertical-align: top;
@@ -88,31 +91,15 @@ const _Stamp: React.FC<StampProps> = styled.div.attrs(borderRadiusAttrs)`
   ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
-/**
- * @public
- */
-export const Stamp: React.FC<StampProps> = ({
-  bg = 'background.light',
-  borderColor = 'border.base',
-  borderRadius = 'md',
-  color = 'border.light',
-  px = 1,
-  py = 0,
-  size = 'medium',
-  variation = 'outline',
-  ...props
-}) => (
-  <_Stamp
-    bg={bg}
-    borderColor={borderColor}
-    borderRadius={borderRadius}
-    color={color}
-    px={px}
-    py={py}
-    size={size}
-    variation={variation}
-    {...props}
-  />
-)
-
 Stamp.displayName = 'Stamp'
+
+Stamp.defaultProps = {
+  px: 1,
+  py: 0,
+  color: 'border.light',
+  bg: 'background.light',
+  borderColor: 'border.base',
+  borderRadius: 'md',
+  size: 'medium',
+  variation: 'outline',
+}

--- a/packages/core/src/Stamp/__snapshots__/Stamp.spec.tsx.snap
+++ b/packages/core/src/Stamp/__snapshots__/Stamp.spec.tsx.snap
@@ -34,11 +34,11 @@ exports[`Stamp bg blue sets background color 1`] = `
   color: #eceff2;
   border-color: #c0cad5;
   background-color: #0068ef;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -87,11 +87,11 @@ exports[`Stamp borderColor green sets border color 1`] = `
   color: #eceff2;
   border-color: #0a0;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -140,11 +140,11 @@ exports[`Stamp color blue sets text and icon color 1`] = `
   color: #0068ef;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -193,11 +193,11 @@ exports[`Stamp color gray sets text and icon color 1`] = `
   color: #4f6f8f;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -246,11 +246,11 @@ exports[`Stamp color green sets text and icon color 1`] = `
   color: #0a0;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -299,11 +299,11 @@ exports[`Stamp color orange sets text and icon color 1`] = `
   color: #f06f20;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -352,11 +352,11 @@ exports[`Stamp color purple sets text and icon color 1`] = `
   color: #70b;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -405,11 +405,11 @@ exports[`Stamp color red sets text and icon color 1`] = `
   color: #c00;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -458,11 +458,11 @@ exports[`Stamp has default borderGray border color 1`] = `
   color: #eceff2;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -511,11 +511,11 @@ exports[`Stamp renders 1`] = `
   color: #eceff2;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -564,11 +564,11 @@ exports[`Stamp renders medium fill 1`] = `
   color: #001833;
   background-color: #eceff2;
   border-color: #eceff2;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -612,11 +612,11 @@ exports[`Stamp renders small fill 1`] = `
   color: #001833;
   background-color: #eceff2;
   border-color: #eceff2;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {
@@ -660,11 +660,11 @@ exports[`Stamp renders small size 1`] = `
   color: #eceff2;
   border-color: #c0cad5;
   background-color: #f4f6f8;
-  border-radius: 8px;
   padding-left: 4px;
   padding-right: 4px;
   padding-top: 0px;
   padding-bottom: 0px;
+  border-radius: 8px;
 }
 
 .c0 > svg {

--- a/packages/core/src/ToggleBadge/ToggleBadge.tsx
+++ b/packages/core/src/ToggleBadge/ToggleBadge.tsx
@@ -17,7 +17,10 @@ export type ToggleBadgeProps = {
   FontSizeProps &
   ComponentPropsWithRef<'button'>
 
-const _ToggleBadge: React.FC<ToggleBadgeProps> = styled.button.attrs(borderRadiusAttrs)`
+/**
+ * @public
+ */
+export const ToggleBadge: React.FC<ToggleBadgeProps> = styled.button.attrs(borderRadiusAttrs)`
   border-radius: ${(props) => props.theme.radius};
   border: 0;
   display: inline-block;
@@ -35,35 +38,16 @@ const _ToggleBadge: React.FC<ToggleBadgeProps> = styled.button.attrs(borderRadiu
   ${(props) => compose(space, fontSize, borderRadius)(props)}
 `
 
-/**
- * @public
- */
-export const ToggleBadge: React.FC<ToggleBadgeProps> = ({
-  borderRadius = 'full',
-  color = 'primary',
-  fontSize = 0,
-  mx = 1,
-  my = 1,
-  px = 2,
-  py = 1,
-  selected = false,
-  unSelectedBg = 'transparent',
-  ...props
-}) => {
-  return (
-    <_ToggleBadge
-      borderRadius={borderRadius}
-      color={color}
-      fontSize={fontSize}
-      mx={mx}
-      my={my}
-      px={px}
-      py={py}
-      selected={selected}
-      unSelectedBg={unSelectedBg}
-      {...props}
-    />
-  )
-}
-
 ToggleBadge.displayName = 'ToggleBadge'
+
+ToggleBadge.defaultProps = {
+  borderRadius: 'full',
+  selected: false,
+  px: 2,
+  py: 1,
+  mx: 1,
+  my: 1,
+  fontSize: 0,
+  color: 'primary',
+  unSelectedBg: 'transparent',
+}

--- a/packages/core/src/ToggleBadge/__snapshots__/ToggleBadge.spec.tsx.snap
+++ b/packages/core/src/ToggleBadge/__snapshots__/ToggleBadge.spec.tsx.snap
@@ -11,15 +11,15 @@ exports[`ToggleBadge selected ToggleBadge renders with default props 1`] = `
   background-color: #e8f2ff;
   color: #0068ef;
   border-radius: 9999px;
-  font-size: 12px;
-  margin-left: 4px;
-  margin-right: 4px;
-  margin-top: 4px;
-  margin-bottom: 4px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  font-size: 12px;
 }
 
 .c0:hover {
@@ -44,16 +44,16 @@ exports[`ToggleBadge selected one with background-color and text color passed as
   cursor: pointer;
   background-color: #ecf7ec;
   color: #c00;
-  border-radius: 9999px;
   font-size: 14px;
-  margin-left: 4px;
-  margin-right: 4px;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  border-radius: 9999px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .c0:hover {
@@ -79,15 +79,15 @@ exports[`ToggleBadge unselected ToggleBadge renders with default props 1`] = `
   background-color: transparent;
   color: #0068ef;
   border-radius: 9999px;
-  font-size: 12px;
-  margin-left: 4px;
-  margin-right: 4px;
-  margin-top: 4px;
-  margin-bottom: 4px;
   padding-left: 8px;
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
+  margin-left: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  font-size: 12px;
 }
 
 .c0:hover {

--- a/packages/modal/src/Modal.jsx
+++ b/packages/modal/src/Modal.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
@@ -157,6 +157,8 @@ const Modal = ({
   width,
   zIndex,
 }) => {
+  const overlayRef = useRef(null)
+
   let dialogHeight = height
 
   if (enableOverflow) {
@@ -166,9 +168,10 @@ const Modal = ({
   }
 
   return (
-    <Transition in={isOpen} unmountOnExit timeout={timeout}>
+    <Transition nodeRef={overlayRef} in={isOpen} unmountOnExit timeout={timeout}>
       {(state) => (
         <Overlay
+          ref={overlayRef}
           onDismiss={onClose}
           zindex={zIndex}
           transitionstate={state}

--- a/packages/slider/src/RangeSlider.tsx
+++ b/packages/slider/src/RangeSlider.tsx
@@ -7,8 +7,14 @@ import styleSlider from './styleSlider'
 
 const _RangeSlider = styleSlider(Range)
 
-const RangeSlider = ({ allowCross = false, color = 'primary', range = true, ...props }) => {
-  return <_RangeSlider allowCross={allowCross} color={color} range={range} {...props} />
+const RangeSlider = (props) => {
+  return <_RangeSlider {...props} />
+}
+
+RangeSlider.defaultProps = {
+  allowCross: false,
+  color: 'primary',
+  range: true,
 }
 
 RangeSlider.propTypes = {

--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -1,16 +1,17 @@
 import propTypes from '@styled-system/prop-types'
 import PropTypes from 'prop-types'
 import RcSlider from 'rc-slider'
-import React from 'react'
 import styleSlider from './styleSlider'
 
-const _Slider = styleSlider(RcSlider)
-
-const Slider = ({ color = 'primary', ...props }) => <_Slider color={color} {...props} />
+const Slider = styleSlider(RcSlider)
 
 Slider.propTypes = {
   ...propTypes.space,
   color: PropTypes.string,
+}
+
+Slider.defaultProps = {
+  color: 'primary',
 }
 
 export default Slider


### PR DESCRIPTION
# Background

The `Transition` component from `react-transition-group` fallbacks on React's deprecated `findDomNode` API if the `nodeRef` prop is not passed in. This breaks in `React 19` as it finally removed the API. The only component using Transition is in `@pcln/modal`.

![image](https://github.com/user-attachments/assets/1e69b4cb-5c55-4070-8cab-21e71c328e7d)

# Description of Changes
- Added a `useRef` hook instance in `@pcln/modal` which is set to it's `Overlay` child component

# Test Plan

- I was able to verify in Storybook that the modal animation functions **exactly** the same.