### PR TITLE
chore(UXPT-10092): Update @pcln/modal to support React 19

### DIFF
--- a/common/changes/pcln-modal/chore-UXPT-10092-Transition-Ref_2025-05-16-17-14.json
+++ b/common/changes/pcln-modal/chore-UXPT-10092-Transition-Ref_2025-05-16-17-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "pass a ref to the Transition component in @pcln/modal",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-modal"
+}

--- a/packages/modal/src/Modal.jsx
+++ b/packages/modal/src/Modal.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
@@ -157,6 +157,8 @@ const Modal = ({
   width,
   zIndex,
 }) => {
+  const overlayRef = useRef(null)
+
   let dialogHeight = height
 
   if (enableOverflow) {
@@ -166,9 +168,10 @@ const Modal = ({
   }
 
   return (
-    <Transition in={isOpen} unmountOnExit timeout={timeout}>
+    <Transition nodeRef={overlayRef} in={isOpen} unmountOnExit timeout={timeout}>
       {(state) => (
         <Overlay
+          ref={overlayRef}
           onDismiss={onClose}
           zindex={zIndex}
           transitionstate={state}


### PR DESCRIPTION
# Background

The `Transition` component from `react-transition-group` fallbacks on React's deprecated `findDomNode` API if the `nodeRef` prop is not passed in. This breaks in `React 19` as it finally removed the API. The only component using Transition is in `@pcln/modal`.

![image](https://github.com/user-attachments/assets/1e69b4cb-5c55-4070-8cab-21e71c328e7d)

# Description of Changes
- Added a `useRef` hook instance in `@pcln/modal` which is set to it's `Overlay` child component

# Test Plan

- I was able to verify in Storybook that the modal animation functions **exactly** the same.