### PR TITLE
feat(AIR-70749): banner style change and updating snapshots

### DIFF
--- a/common/changes/pcln-design-system/feat-AIR-70749_2025-05-19-17-08.json
+++ b/common/changes/pcln-design-system/feat-AIR-70749_2025-05-19-17-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "changed banner text color",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-modal/feat-AIR-70749_2025-05-19-17-20.json
+++ b/common/changes/pcln-modal/feat-AIR-70749_2025-05-19-17-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-modal",
+      "comment": "snapshot update",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-modal"
+}

--- a/packages/core/src/Banner/Banner.spec.tsx
+++ b/packages/core/src/Banner/Banner.spec.tsx
@@ -75,7 +75,7 @@ describe('Banner', () => {
     const json = rendererCreateWithTheme(<Banner bg='lightGreen' />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightGreen)
-    expect(json).toHaveStyleRule('color', theme.colors.darkGreen)
+    expect(json).toHaveStyleRule('color', theme.colors.text)
   })
 
   test('renders with lightRed bg', () => {

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -29,7 +29,7 @@ const bannerColors: Record<string, BannerColor> = {
   },
   lightGreen: {
     backgroundColor: 'secondary.light',
-    color: 'secondary.dark',
+    color: 'text.base',
     icon: <SuccessIcon />,
   },
   red: {

--- a/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -584,7 +584,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
 
 .c0 {
   background-color: #ecf7ec;
-  color: #060;
+  color: #001833;
   text-align: left;
 }
 
@@ -614,7 +614,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
 
 <div
   className="c0 "
-  color="secondary.dark"
+  color="text.base"
 >
   <div
     className="c1"


### PR DESCRIPTION
### PR Summary 📝

- **Description:**

Fixed incorrect text color for Banner
Updated snapshots


| Before       | After       |
| ---------- | ----------- |
| <img width="887" alt="Screenshot 2025-05-19 at 12 26 44 PM" src="https://github.com/user-attachments/assets/5fa02c18-89ba-4f2b-81ea-55f379ff0080" /> | <img width="890" alt="Screenshot 2025-05-19 at 12 24 35 PM" src="https://github.com/user-attachments/assets/b0ae94e7-5a0d-48db-8988-c4b23580e70b" /> |
