### PR TITLE
fix(UXPT-8374): replace defaultProps in svgr template file

### DIFF
--- a/common/changes/pcln-icons/fix-UXPT-8374-svgs-r19_2025-05-28-02-46.json
+++ b/common/changes/pcln-icons/fix-UXPT-8374-svgs-r19_2025-05-28-02-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "replace defaultProps usage in svgr template file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-icons"
+}

--- a/packages/icons/svgr.config.js
+++ b/packages/icons/svgr.config.js
@@ -20,6 +20,7 @@ const BaseComponent = ({
   tabIndex = -1,
   focusable = false,
   role = 'img',
+  'aria-hidden': ariaHidden = true,
   ...props
 }) => {
   let ariaLabelledBy = titleId ? titleId : ''
@@ -56,7 +57,7 @@ module.exports = {
     desc: '{desc}',
     descId: '{descId}',
     'aria-labelledby': '{ariaLabelledBy}',
-    'aria-hidden': '{!ariaLabelledBy}',
+    'aria-hidden': '{ariaHidden}',
     fill: 'currentcolor',
     role: '{role}',
     tabIndex: '{tabIndex}',

--- a/packages/icons/svgr.config.js
+++ b/packages/icons/svgr.config.js
@@ -19,7 +19,6 @@ const BaseComponent = ({
   descId,
   tabIndex = -1,
   focusable = false,
-  'aria-hidden': ariaHidden = true,
   role = 'img',
   ...props
 }) => {
@@ -59,6 +58,9 @@ module.exports = {
     'aria-labelledby': '{ariaLabelledBy}',
     'aria-hidden': '{!ariaLabelledBy}',
     fill: 'currentcolor',
+    role: '{role}',
+    tabIndex: '{tabIndex}',
+    focusable: '{focusable}',
   },
   svgoConfig: {
     plugins: {

--- a/packages/icons/svgr.config.js
+++ b/packages/icons/svgr.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-irregular-whitespace */
 const dynamicTitlePlugin = require('./plugins/svg-dynamic-title-plugin')
 
 const replaceSvgPlugin = require('./plugins/svg-replace-plugin')
@@ -10,14 +9,18 @@ const template = (
   { imports, componentName, props, jsx, exports }
 ) => template.ast`import React from 'react'
 import Svg from './Svg'
-import styled from 'styled-components'
+import styled from 'styled-components'
 
-const BaseComponent = ({
-  size,
+const BaseComponent = ({
+  size = 24,
   title,
   desc,
   titleId,
   descId,
+  tabIndex = -1,
+  focusable = false,
+  'aria-hidden': ariaHidden = true,
+  role = 'img',
   ...props
 }) => {
   let ariaLabelledBy = titleId ? titleId : ''
@@ -34,14 +37,6 @@ const ${componentName} = styled(BaseComponent)\`
 \`
 
 ${componentName}.isIcon = true
-
-${componentName}.defaultProps = {
-  size: 24,
-  tabIndex: -1,
-  focusable: false,
-  'aria-hidden': true,
-  role: 'img'
-}
 
 export default ${componentName}`
 


### PR DESCRIPTION
Unfortunately missed this the first round. A lot of our shared components rely on the individual svg components' default props.

# Background

Working in our first React 19 application, I noticed some of the SVGs are missing defaults

# Description of Changes

- Replaced some of the old deprecated React defaultProps for the generated SVG components