### PR TITLE
chore(): update pcln-icons to use styled-system v5 and use Node 20 for builds

### DIFF
--- a/.github/workflows/chromatic-ci.yaml
+++ b/.github/workflows/chromatic-ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: PNPM cache via actions/cache@v3
         id: pnpm-cache

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish-beta.yaml
+++ b/.github/workflows/npm-publish-beta.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: PNPM cache via actions/cache@v3
         id: pnpm-cache

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: PNPM cache via actions/cache@v3
         id: pnpm-cache

--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: PNPM cache via actions/cache@v3
         id: pnpm-cache

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -24,9 +24,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: PNPM cache via actions/cache@v3
         id: pnpm-cache

--- a/common/changes/pcln-design-system/chore-update-icons_2025-06-03-02-20.json
+++ b/common/changes/pcln-design-system/chore-update-icons_2025-06-03-02-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-design-system",
+      "comment": "Update snapshots",
+      "type": "patch"
+    }
+  ],
+  "packageName": "pcln-design-system"
+}

--- a/common/changes/pcln-icons/chore-update-icons_2025-06-03-00-10.json
+++ b/common/changes/pcln-icons/chore-update-icons_2025-06-03-00-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "pcln-icons",
+      "comment": "Update to styled-system v5 on pcln-icons, move to dev dependency and peer dependency. Use Node v20 for the build process.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "pcln-icons"
+}

--- a/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/core/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -57,9 +57,9 @@ exports[`Banner renders content from children props 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -141,9 +141,9 @@ exports[`Banner renders with an icon 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -222,9 +222,9 @@ exports[`Banner renders with blue bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -303,9 +303,9 @@ exports[`Banner renders with green bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -385,9 +385,9 @@ exports[`Banner renders with header node 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c4 {
@@ -492,9 +492,9 @@ exports[`Banner renders with lightBlue bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -573,9 +573,9 @@ exports[`Banner renders with lightGreen bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -654,9 +654,9 @@ exports[`Banner renders with lightRed bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -735,9 +735,9 @@ exports[`Banner renders with no props other than theme 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -816,9 +816,9 @@ exports[`Banner renders with orange bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -897,9 +897,9 @@ exports[`Banner renders with red bg 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -978,9 +978,9 @@ exports[`Banner renders with text node 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c3 {
@@ -1077,9 +1077,9 @@ exports[`Banner renders with text string 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c4 {

--- a/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
+++ b/packages/core/src/Breadcrumbs/__snapshots__/Breadcrumbs.spec.tsx.snap
@@ -114,8 +114,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
   flex: none;
   line-height: 1;
   color: #4f6f8f;
-  margin-right: 8px;
   width: 16px;
+  margin-right: 8px;
 }
 
 .c7 {
@@ -124,8 +124,8 @@ exports[`Breadcrumbs renders with icons 1`] = `
   flex: none;
   line-height: 1;
   color: #001023;
-  margin-right: 8px;
   width: 16px;
+  margin-right: 8px;
 }
 
 .c6 {

--- a/packages/core/src/FloatingActionButton/__snapshots__/FloatingActionButton.spec.tsx.snap
+++ b/packages/core/src/FloatingActionButton/__snapshots__/FloatingActionButton.spec.tsx.snap
@@ -7,8 +7,8 @@ exports[`FloatingActionButton it renders 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-right: 0px;
   width: 24px;
+  margin-right: 0px;
 }
 
 .c6 {

--- a/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
+++ b/packages/core/src/FormField/__snapshots__/FormField.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`FormField disabled state renders input with icon - disabled 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  width: 24px;
   margin-left: 8px;
   margin-right: 8px;
-  width: 24px;
 }
 
 .c8 {
@@ -210,9 +210,9 @@ exports[`FormField disabled state renders select with icon - disabled 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  width: 24px;
   margin-left: 8px;
   margin-right: 8px;
-  width: 24px;
 }
 
 .c11 {
@@ -221,8 +221,8 @@ exports[`FormField disabled state renders select with icon - disabled 1`] = `
   flex: none;
   line-height: 1;
   color: #4f6f8f;
-  margin-left: -32px;
   width: 24px;
+  margin-left: -32px;
 }
 
 .c12 {
@@ -600,9 +600,9 @@ exports[`FormField renders with Icon 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  width: 24px;
   margin-left: 8px;
   margin-right: 8px;
-  width: 24px;
 }
 
 .c6 {
@@ -797,9 +797,9 @@ exports[`FormField renders with Label autoHide prop 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  width: 24px;
   margin-left: 8px;
   margin-right: 8px;
-  width: 24px;
 }
 
 .c6 {
@@ -995,8 +995,8 @@ exports[`FormField renders with Select  1`] = `
   flex: none;
   line-height: 1;
   color: #4f6f8f;
-  margin-left: -32px;
   width: 24px;
+  margin-left: -32px;
 }
 
 .c6 {
@@ -1178,9 +1178,9 @@ exports[`FormField renders with Select and Icon 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
+  width: 24px;
   margin-left: 8px;
   margin-right: 8px;
-  width: 24px;
 }
 
 .c9 {
@@ -1189,8 +1189,8 @@ exports[`FormField renders with Select and Icon 1`] = `
   flex: none;
   line-height: 1;
   color: #4f6f8f;
-  margin-left: -32px;
   width: 24px;
+  margin-left: -32px;
 }
 
 .c10 {

--- a/packages/core/src/GenericBanner/__snapshots__/GenericBanner.spec.tsx.snap
+++ b/packages/core/src/GenericBanner/__snapshots__/GenericBanner.spec.tsx.snap
@@ -6,9 +6,9 @@ exports[`GenericBanner renders 1`] = `
   -ms-flex: none;
   flex: none;
   line-height: 1;
-  margin-top: -2px;
-  margin-right: 8px;
   width: 24px;
+  margin-right: 8px;
+  margin-top: -2px;
 }
 
 .c5 {

--- a/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/Select.spec.tsx.snap
@@ -7,8 +7,8 @@ exports[`Select renders 1`] = `
   flex: none;
   line-height: 1;
   color: #4f6f8f;
-  margin-left: -32px;
   width: 24px;
+  margin-left: -32px;
 }
 
 .c4 {

--- a/packages/core/src/Step/__snapshots__/Step.spec.tsx.snap
+++ b/packages/core/src/Step/__snapshots__/Step.spec.tsx.snap
@@ -129,8 +129,8 @@ exports[`Step should render a completed step correctly 1`] = `
   flex: none;
   line-height: 1;
   color: #0068ef;
-  margin-right: 4px;
   width: 16px;
+  margin-right: 4px;
 }
 
 .c5 {
@@ -271,8 +271,8 @@ exports[`Step should render a step that is "active" and "completed" correctly 1`
   flex: none;
   line-height: 1;
   color: #0068ef;
-  margin-right: 4px;
   width: 16px;
+  margin-right: 4px;
 }
 
 .c5 {

--- a/packages/core/src/Stepper/__snapshots__/Stepper.spec.tsx.snap
+++ b/packages/core/src/Stepper/__snapshots__/Stepper.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`Stepper renders with children 1`] = `
   flex: none;
   line-height: 1;
   color: #0068ef;
-  margin-right: 4px;
   width: 16px;
+  margin-right: 4px;
 }
 
 .c6 {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -29,8 +29,7 @@
     "core-js": "^3.37.1",
     "@styled-system/theme-get": "^5.1.2",
     "lodash.upperfirst": "^4.3.1",
-    "prop-types": "^15.8.1",
-    "styled-system": "^4.2.4"
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.15",
@@ -56,12 +55,14 @@
     "react-is": "^18.3.1",
     "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.2",
-    "styled-components": "^5.3.11"
+    "styled-components": "^5.3.11",
+    "styled-system": "^5.1.5"
   },
   "peerDependencies": {
     "pcln-design-system": "^6.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "styled-components": ">=5.3.7 <6"
+    "styled-components": ">=5.3.7 <6",
+    "styled-system": "^5.0.0"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -21,7 +21,7 @@
    * Specify a SemVer range to ensure developers use a Node.js version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=16",
+  "nodeSupportedVersionRange": ">=20",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases


### PR DESCRIPTION
### Description

- Update `styled-system` in `pcln-icons` to v5, to be in sync with all other `pcln-*` packages
- Move `styled-system` dependency as a dev and peer dep to `pcln-icons`. This is also in sync with all `pcln-*` packages
- Use Node.js v20 to build the packages
- Use the latest version of `actions/setup-node` GHA
- Update snapshots