### PR TITLE
Consolidate styled-system onto @soroush.tech/styled-system rewrite via typescript

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: ^7.6.2
         version: 7.6.2(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
     devDependencies:
       '@babel/cli':
         specifier: ^7.23.4
@@ -201,9 +201,6 @@ importers:
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(@types/jest@28.1.3)(jest@29.7.0)
@@ -264,9 +261,6 @@ importers:
 
   ../../packages/carousel:
     dependencies:
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -282,6 +276,9 @@ importers:
       react-intersection-observer:
         specifier: ^9.5.3
         version: 9.5.3(react@18.3.1)
+      styled-system:
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -410,8 +407,8 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.23.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
     devDependencies:
       '@babel/cli':
         specifier: ^7.22.15
@@ -482,9 +479,6 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1)(react@18.3.1)
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       '@types/styled-system':
         specifier: ^5.1.22
         version: 5.1.22
@@ -507,8 +501,8 @@ importers:
         specifier: ^9.5.3
         version: 9.5.3(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
     devDependencies:
       '@babel/cli':
         specifier: ^7.22.15
@@ -642,9 +636,6 @@ importers:
 
   ../../packages/icons:
     dependencies:
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       core-js:
         specifier: ^3.37.1
         version: 3.37.1
@@ -728,14 +719,11 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.23.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
 
   ../../packages/menu:
     dependencies:
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -819,17 +807,14 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.23.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
 
   ../../packages/modal:
     dependencies:
       '@reach/dialog':
         specifier: ^0.16.2
         version: 0.16.2(react-dom@18.3.1)(react@18.3.1)
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.3.1)(react@18.3.1)
@@ -907,17 +892,14 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.23.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
 
   ../../packages/popover:
     dependencies:
       '@floating-ui/react-dom-interactions':
         specifier: ^0.13.3
         version: 0.13.3(react-dom@18.3.1)(react@18.3.1)
-      '@styled-system/theme-get':
-        specifier: ^5.1.2
-        version: 5.1.2
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -1013,8 +995,8 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.23.5)(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
 
   ../../packages/slider:
     dependencies:
@@ -1031,8 +1013,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       styled-system:
-        specifier: ^5.1.5
-        version: 5.1.5
+        specifier: npm:@soroush.tech/styled-system@^5.6.0
+        version: /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1)
       warning:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1061,9 +1043,6 @@ importers:
       '@rushstack/heft':
         specifier: ^0.66.3
         version: 0.66.3(@types/node@20.12.7)
-      '@styled-system/prop-types':
-        specifier: ^5.1.5
-        version: 5.1.5(styled-system@5.1.5)
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.1.5(@types/jest@29.5.11)
@@ -1610,7 +1589,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -1620,7 +1599,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.23.5
       '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -6040,6 +6019,20 @@ packages:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
+  /@soroush.tech/styled-system@5.6.0(prop-types@15.8.1):
+    resolution: {integrity: sha512-Ybgo3+y2sVzJ4XHiaLOlcpKwipko5mJfwziWFx08n9XeNXD2hEqRMnt1TH6+Glt4k6pAVeU/XBjVQSfGNhuZpQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': ^1.4.0
+      prop-types: ^15.8.1
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      prop-types:
+        optional: true
+    dependencies:
+      csstype: 3.1.3
+      prop-types: 15.8.1
+
   /@storybook/addon-a11y@8.3.0(storybook@8.3.0):
     resolution: {integrity: sha512-ub/O4tkeQFE3bXEg8VsH3HU9MmqD+CSwGN5QVJmnkCOzpwjnhaVtWFNVZ+3C2AsT0b3sW9llDaK4UgivglV8+A==}
     peerDependencies:
@@ -6529,84 +6522,6 @@ packages:
     dependencies:
       storybook: 8.3.0
     dev: true
-
-  /@styled-system/background@5.1.2:
-    resolution: {integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/border@5.1.5:
-    resolution: {integrity: sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/color@5.1.2:
-    resolution: {integrity: sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/core@5.1.2:
-    resolution: {integrity: sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==}
-    dependencies:
-      object-assign: 4.1.1
-
-  /@styled-system/css@5.1.5:
-    resolution: {integrity: sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==}
-
-  /@styled-system/flexbox@5.1.2:
-    resolution: {integrity: sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/grid@5.1.2:
-    resolution: {integrity: sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/layout@5.1.2:
-    resolution: {integrity: sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/position@5.1.2:
-    resolution: {integrity: sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/prop-types@5.1.5(styled-system@5.1.5):
-    resolution: {integrity: sha512-D/0d0ltp8QGhwrRifivQeIdoKkQDpFIGi98DXdpRXOaJStYXLx6aBSfS/YYIijbF1nZs1hWlAgXxYvDhCxHLSA==}
-    peerDependencies:
-      styled-system: ^5.0.0-8
-    dependencies:
-      prop-types: 15.8.1
-      styled-system: 5.1.5
-    dev: true
-
-  /@styled-system/shadow@5.1.2:
-    resolution: {integrity: sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/space@5.1.2:
-    resolution: {integrity: sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/theme-get@5.1.2:
-    resolution: {integrity: sha512-afAYdRqrKfNIbVgmn/2Qet1HabxmpRnzhFwttbGr6F/mJ4RDS/Cmn+KHwHvNXangQsWw/5TfjpWV+rgcqqIcJQ==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/typography@5.1.2:
-    resolution: {integrity: sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  /@styled-system/variant@5.1.5:
-    resolution: {integrity: sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==}
-    dependencies:
-      '@styled-system/core': 5.1.2
-      '@styled-system/css': 5.1.5
 
   /@svgr/babel-plugin-add-jsx-attribute@5.4.0:
     resolution: {integrity: sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==}
@@ -8530,8 +8445,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001791
+      browserslist: 4.28.4
+      caniuse-lite: 1.0.30001800
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -8733,8 +8648,8 @@ packages:
       pascalcase: 0.1.1
     dev: false
 
-  /baseline-browser-mapping@2.10.27:
-    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+  /baseline-browser-mapping@2.10.41:
+    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -8840,16 +8755,16 @@ packages:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
     dev: true
 
-  /browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  /browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      baseline-browser-mapping: 2.10.27
-      caniuse-lite: 1.0.30001791
-      electron-to-chromium: 1.5.350
-      node-releases: 2.0.38
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.10.41
+      caniuse-lite: 1.0.30001800
+      electron-to-chromium: 1.5.385
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -8971,13 +8886,13 @@ packages:
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001791
+      browserslist: 4.28.4
+      caniuse-lite: 1.0.30001800
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  /caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  /caniuse-lite@1.0.30001800:
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
   /cat-names@3.1.0:
     resolution: {integrity: sha512-cW5oH6EdBF8g/XovpPyM/5CHne6tsX63IBqGVpeZxDcHrIUpqmbXhRkptsMwHXiwSyDd+/bEndsib3kn4Q1qtQ==}
@@ -9327,7 +9242,7 @@ packages:
   /core-js-compat@3.34.0:
     resolution: {integrity: sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==}
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
 
   /core-js@3.34.0:
     resolution: {integrity: sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==}
@@ -9963,8 +9878,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /electron-to-chromium@1.5.350:
-    resolution: {integrity: sha512-/KWD4qK8nMqIoJh35Rpc37fiVyOe80mcUQKpfje0Dp9uot2ROuipsh+EriCdfInxjleD5v1S4OlIn41I0LXP0g==}
+  /electron-to-chromium@1.5.385:
+    resolution: {integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==}
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -13712,8 +13627,9 @@ packages:
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  /node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+  /node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -14184,7 +14100,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.32
@@ -14196,7 +14112,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
 
@@ -14261,7 +14177,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.4.32)
       postcss: 8.4.32
@@ -14293,7 +14209,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       cssnano-utils: 3.1.0(postcss@8.4.32)
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
@@ -14456,7 +14372,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.4.32
       postcss-value-parser: 4.2.0
 
@@ -14495,7 +14411,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       caniuse-api: 3.0.0
       postcss: 8.4.32
 
@@ -16178,30 +16094,13 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
 
-  /styled-system@5.1.5:
-    resolution: {integrity: sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==}
-    dependencies:
-      '@styled-system/background': 5.1.2
-      '@styled-system/border': 5.1.5
-      '@styled-system/color': 5.1.2
-      '@styled-system/core': 5.1.2
-      '@styled-system/flexbox': 5.1.2
-      '@styled-system/grid': 5.1.2
-      '@styled-system/layout': 5.1.2
-      '@styled-system/position': 5.1.2
-      '@styled-system/shadow': 5.1.2
-      '@styled-system/space': 5.1.2
-      '@styled-system/typography': 5.1.2
-      '@styled-system/variant': 5.1.5
-      object-assign: 4.1.1
-
   /stylehacks@5.1.1(postcss@8.4.32):
     resolution: {integrity: sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       postcss: 8.4.32
       postcss-selector-parser: 6.0.13
 
@@ -16829,13 +16728,13 @@ packages:
       isobject: 3.0.1
     dev: false
 
-  /update-browserslist-db@1.2.3(browserslist@4.28.2):
+  /update-browserslist-db@1.2.3(browserslist@4.28.4):
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: latest
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -17224,7 +17123,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.11.2
       acorn-import-assertions: 1.9.0(acorn@8.11.2)
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
       es-module-lexer: 1.4.1

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "downshift": "^7.6.2",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.4",
@@ -35,7 +35,6 @@
     "@rushstack/eslint-patch": "^1.6.0",
     "@storybook/jest": "^0.2.3",
     "@storybook/testing-library": "^0.2.2",
-    "@styled-system/theme-get": "^5.1.2",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "cat-names": "^3.1.0",

--- a/packages/autocomplete/src/Autocomplete.jsx
+++ b/packages/autocomplete/src/Autocomplete.jsx
@@ -9,7 +9,7 @@ import {
   getPaletteColor,
   deprecatedColorValue,
 } from 'pcln-design-system'
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 
 export const AutocompleteContext = React.createContext()
 

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -37,7 +37,7 @@
     "test:snapshots": "jest --runInBand --updateSnapshot"
   },
   "dependencies": {
-    "@styled-system/theme-get": "^5.1.2",
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0",
     "lodash.debounce": "^4.0.8",
     "moize": "^6.1.6",
     "prop-types": "^15.8.1",

--- a/packages/carousel/src/ArrowButton/ArrowButton.styles.js
+++ b/packages/carousel/src/ArrowButton/ArrowButton.styles.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { getPaletteColor, Box } from 'pcln-design-system'
 import { CarouselWrapper } from '../Carousel.styles'
 

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -32,7 +32,7 @@
     "pcln-design-system": "workspace:*",
     "prop-types": "^15.8.1",
     "styled-components": "^5.3.11",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,6 @@
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-visually-hidden": "^1.0.3",
-    "@styled-system/theme-get": "^5.1.2",
     "@types/styled-system": "^5.1.22",
     "deepmerge": "^4.3.1",
     "hoist-non-react-statics": "^3.3.2",
@@ -85,7 +84,7 @@
     "motion": "^12.16.0",
     "react-element-to-jsx-string": "^15.0.0",
     "react-intersection-observer": "^9.5.3",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.15",

--- a/packages/core/src/Accordion/Accordion.styled.tsx
+++ b/packages/core/src/Accordion/Accordion.styled.tsx
@@ -1,5 +1,5 @@
 import * as Accordion from '@radix-ui/react-accordion'
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { ChevronDown } from 'pcln-icons'
 import styled, { keyframes } from 'styled-components'
 import { space } from 'styled-system'

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { SpaceProps, borderRadius, compose, space } from 'styled-system'

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import React, { type ComponentPropsWithRef } from 'react'
 import styled, { css } from 'styled-components'
 import {

--- a/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
+++ b/packages/core/src/ChatActionContainer/ChatActionContainer.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { Button } from '../Button/Button'

--- a/packages/core/src/ChatMessage/ChatMessage.tsx
+++ b/packages/core/src/ChatMessage/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import { PricelineSparkle } from 'pcln-icons'
 import React from 'react'
 import styled, { css } from 'styled-components'

--- a/packages/core/src/Chip/ChipContentWrapper.tsx
+++ b/packages/core/src/Chip/ChipContentWrapper.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import styled, { css } from 'styled-components'
 import { compose, fontSize, space } from 'styled-system'
 import { Box, type BoxProps } from '../Box/Box'

--- a/packages/core/src/CloseButton/CloseButton.styled.tsx
+++ b/packages/core/src/CloseButton/CloseButton.styled.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import { ForwardRefComponent, HTMLMotionProps, motion } from 'motion/react'
 import { Close } from 'pcln-icons'
 import React from 'react'

--- a/packages/core/src/Dialog/Dialog.styled.tsx
+++ b/packages/core/src/Dialog/Dialog.styled.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import { Transition, motion } from 'motion/react'
 import React, { ReactElement } from 'react'
 import styled from 'styled-components'

--- a/packages/core/src/DocsUtils/DocTable/DocTable.tsx
+++ b/packages/core/src/DocsUtils/DocTable/DocTable.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import React from 'react'
 import styled from 'styled-components'
 import { Box } from '../../Box/Box'

--- a/packages/core/src/DotLoader/DotLoader.tsx
+++ b/packages/core/src/DotLoader/DotLoader.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import { Box } from '../Box/Box'

--- a/packages/core/src/Flag/Flag.tsx
+++ b/packages/core/src/Flag/Flag.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React from 'react'
 import styled from 'styled-components'
 import { SpaceProps, WidthProps } from 'styled-system'

--- a/packages/core/src/FloatingActionButton/FloatingActionButton.styled.tsx
+++ b/packages/core/src/FloatingActionButton/FloatingActionButton.styled.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import styled from 'styled-components'
 import { Box } from '../Box/Box'
 import { Button } from '../Button/Button'

--- a/packages/core/src/Hug/Hug.styled.ts
+++ b/packages/core/src/Hug/Hug.styled.ts
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import styled from 'styled-components'
 import { Box } from '../Box/Box'
 import { Card } from '../Card/Card'

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import React from 'react'
 import styled from 'styled-components'
 import { space, SpaceProps } from 'styled-system'

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React, { type ComponentPropsWithoutRef } from 'react'
 import styled, { css } from 'styled-components'
 import { compose, fontSize, space, width, type FontSizeProps, type SpaceProps } from 'styled-system'

--- a/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
+++ b/packages/core/src/RadioCheckToggleCard/RadioCheckToggleCard.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { BoxChecked, BoxEmpty, Check, RadioChecked, RadioEmpty } from 'pcln-icons'
 import React from 'react'
 import styled from 'styled-components'

--- a/packages/core/src/Select/Select.tsx
+++ b/packages/core/src/Select/Select.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import { ChevronDown } from 'pcln-icons'
 import React, { type ComponentPropsWithRef } from 'react'
 import styled, { css } from 'styled-components'

--- a/packages/core/src/Stamp/Stamp.tsx
+++ b/packages/core/src/Stamp/Stamp.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React from 'react'
 import styled, { css } from 'styled-components'
 import {

--- a/packages/core/src/Stepper/Stepper.tsx
+++ b/packages/core/src/Stepper/Stepper.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React from 'react'
 import styled from 'styled-components'
 import { Flex } from '../Flex/Flex'

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import React, { type ComponentPropsWithRef } from 'react'
 import styled from 'styled-components'
 import { space, SpaceProps } from 'styled-system'
@@ -7,8 +7,7 @@ import { applyVariations, borders, getPaletteColor } from '../utils/utils'
 /**
  * @public
  */
-export type TextAreaProps = SpaceProps &
-  ComponentPropsWithRef<'textarea'> & { isField?: boolean }
+export type TextAreaProps = SpaceProps & ComponentPropsWithRef<'textarea'> & { isField?: boolean }
 
 /**
  * @public

--- a/packages/core/src/Toast/Toast.styled.tsx
+++ b/packages/core/src/Toast/Toast.styled.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import styled, { css } from 'styled-components'
 import { Flex, type FlexProps } from '../Flex/Flex'
 import { IconButton } from '../IconButton/IconButton'

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import React from 'react'
 import styled, { withTheme } from 'styled-components'
 import { Box, BoxProps } from '../Box/Box'

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 import { css } from 'styled-components'
 import { mediaQueries, type PaletteFamilyName, type PaletteColor, PaletteFamilyVariation } from '../theme'
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "core-js": "^3.37.1",
-    "@styled-system/theme-get": "^5.1.2",
     "lodash.upperfirst": "^4.3.1",
     "prop-types": "^15.8.1"
   },
@@ -56,7 +55,7 @@
     "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.11",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "peerDependencies": {
     "pcln-design-system": "^6.2.0",

--- a/packages/icons/src/Svg.js
+++ b/packages/icons/src/Svg.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 import { space, width, compose } from 'styled-system'
-import themeGet from '@styled-system/theme-get'
+import themeGet from 'styled-system/theme-get'
 
 /**
  * Gets the color of a palette shade, using props.color as
@@ -15,24 +15,26 @@ import themeGet from '@styled-system/theme-get'
  * @example getPaletteColor('primary.base')(props) => theme.palette.primary.base
  * @example getPaletteColor('primary', 'base')(props) => theme.palette.primary.base
  */
-const getPaletteColor = (...args) => (props) => {
-  let color = args.length === 2 ? args[0] : props.color
-  let shade = args.length === 2 ? args[1] : args[0]
+const getPaletteColor =
+  (...args) =>
+  (props) => {
+    let color = args.length === 2 ? args[0] : props.color
+    let shade = args.length === 2 ? args[1] : args[0]
 
-  const colorShade = shade.match(/^([a-z]+)\.([a-z]+)$/)
+    const colorShade = shade.match(/^([a-z]+)\.([a-z]+)$/)
 
-  if (colorShade) {
-    color = colorShade[0]
-    shade = colorShade[1]
+    if (colorShade) {
+      color = colorShade[0]
+      shade = colorShade[1]
+    }
+
+    return (
+      themeGet(`palette.${color}.${shade}`)(props) ||
+      themeGet(`palette.${color}`)(props) ||
+      themeGet(`colors.${color}`)(props) ||
+      color
+    )
   }
-
-  return (
-    themeGet(`palette.${color}.${shade}`)(props) ||
-    themeGet(`palette.${color}`)(props) ||
-    themeGet(`colors.${color}`)(props) ||
-    color
-  )
-}
 
 const color = (props) => {
   if (props.color) {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -22,7 +22,6 @@
     "test:snapshots": "jest --runInBand --updateSnapshot"
   },
   "dependencies": {
-    "@styled-system/theme-get": "^5.1.2",
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
@@ -52,7 +51,7 @@
     "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.11",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "peerDependencies": {
     "pcln-design-system": "^6.29.0",

--- a/packages/menu/src/MenuList/MenuList.jsx
+++ b/packages/menu/src/MenuList/MenuList.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { Flex, applySizes } from 'pcln-design-system'
 
 const sizes = {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@reach/dialog": "^0.16.2",
-    "@styled-system/theme-get": "^5.1.2",
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
@@ -49,7 +48,7 @@
     "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.11",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "peerDependencies": {
     "pcln-design-system": "^6.29.0",

--- a/packages/modal/src/Modal.jsx
+++ b/packages/modal/src/Modal.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
 import { color, width, height, compose } from 'styled-system'
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { DialogOverlay, DialogContent } from '@reach/dialog'
 import { Box, CloseButton, deprecatedColorValue, Flex } from 'pcln-design-system'
 

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@floating-ui/react-dom-interactions": "^0.13.3",
-    "@styled-system/theme-get": "^5.1.2",
     "prop-types": "^15.8.1",
     "react-focus-lock": "^2.9.6"
   },
@@ -58,7 +57,7 @@
     "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.11",
-    "styled-system": "^5.1.5"
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0"
   },
   "peerDependencies": {
     "pcln-design-system": "^6.29.0",

--- a/packages/popover/src/PopoverContent/PopoverContent.jsx
+++ b/packages/popover/src/PopoverContent/PopoverContent.jsx
@@ -1,4 +1,4 @@
-import { themeGet } from '@styled-system/theme-get'
+import { themeGet } from 'styled-system/theme-get'
 import { Box, ThemeProvider, borderRadiusAttrs } from 'pcln-design-system'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react'

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.8.1",
     "rc-slider": "^10.2.0",
     "shallowequal": "^1.1.0",
-    "styled-system": "^5.1.5",
+    "styled-system": "npm:@soroush.tech/styled-system@^5.6.0",
     "warning": "^4.0.3"
   },
   "devDependencies": {
@@ -42,7 +42,6 @@
     "@rushstack/eslint-config": "^3.5.0",
     "@rushstack/eslint-patch": "^1.6.0",
     "@rushstack/heft": "^0.66.3",
-    "@styled-system/prop-types": "^5.1.5",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.11",

--- a/packages/slider/src/RangeSlider.tsx
+++ b/packages/slider/src/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import propTypes from '@styled-system/prop-types'
+import propTypes from 'styled-system/prop-types'
 import PropTypes from 'prop-types'
 import React from 'react'
 

--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -1,4 +1,4 @@
-import propTypes from '@styled-system/prop-types'
+import propTypes from 'styled-system/prop-types'
 import PropTypes from 'prop-types'
 import RcSlider from 'rc-slider'
 import styleSlider from './styleSlider'


### PR DESCRIPTION
# Migrate `styled-system` to the maintained, TypeScript-native `@soroush.tech/styled-system` 

## Motivation

The design-system is built on [`styled-system`](https://www.npmjs.com/package/styled-system), which is **no longer maintained** — the last release is `5.1.5` and the project has been inactive for years. Consequences we carry today:

- **No type ownership.** `styled-system` ships no types of its own; we rely on the community‑maintained `@types/styled-system` (equally stale), plus separate `@styled-system/theme-get` and `@styled-system/prop-types` packages. Types and runtime drift independently.
- **No fixes, no performance work.** Bugs and perf are frozen at the 2020 state.
- **Fragmented dependency surface.** Three separate `@styled-system/*` packages to keep in lockstep.

**`@soroush.tech/styled-system`** is a drop-in fork that addresses this:

- **TypeScript‑native** — the library *is* the source of its types (first‑class `.d.cts`/`.d.mts` shipped via `exports`), so types and runtime never drift. No `@types/*` companion needed.
- **Actively maintained** and API‑compatible with `styled-system@5`.
- **Single package** — `theme-get`, `prop-types`, and every category parser are exposed as subpaths of one package instead of three.
- **Faster** on our hot path (see [Benchmark](#benchmark)).

This PR swaps the design-system onto the fork with **zero behavioural change** to components — only the styling engine underneath changes.

## What changed

**Dependencies (9 `package.json` files)**
- Every package now declares **one** styled‑system dependency: `"styled-system": "npm:@soroush.tech/styled-system@^5.6.0"`.
- Removed the separate `@styled-system/theme-get` and `@styled-system/prop-types` dependencies — they're now subpaths of the single fork package.
- Fixed a latent misclassification: `@styled-system/theme-get` (autocomplete) and `@styled-system/prop-types` (slider) were declared as **devDependencies** despite being imported in *shipped* source. They only resolved in production by luck of monorepo hoisting + the peer `pcln-design-system` carrying them. They're now provided by the single runtime `styled-system` dependency.

**Source imports (33 files)**
- `@styled-system/theme-get` → `styled-system/theme-get`
- `@styled-system/prop-types` → `styled-system/prop-types`
- Bare `import … from 'styled-system'` (Box, Flex, Text, …) is unchanged — it already resolves to the fork via the alias.

**No config changes required**
- **No `declare module` shims** and **no `moduleResolution` change.** The fork ships a `typesVersions` map, so its subpath types resolve under the heft rig's classic `node` module resolution as‑is.
- **No consumer type changes.** The fork's public `themeGet`/`Props` signatures match upstream's permissive shapes, so existing call sites (e.g. `themeGet('colorSchemes.x')(props).foreground`, components passing `MotionButtonProps`) type‑check unchanged.

**Lockfile**
- `common/config/rush/pnpm-lock.yaml` regenerated.

_Diff: 41 files, +124 / −231 (net simplification — three deps collapse to one)._

### Verification

`tsc --noEmit` on the two TypeScript‑compiled packages, with the fork installed from npm and no `declare` / no `moduleResolution` change:

| Package | Type errors |
| --- | --- |
| `pcln-design-system` (core) | **0** |
| `pcln-slider` | **0** |

Pre‑commit `rush lint:fix` passes across all projects; `rush prettier` clean.

## Benchmark

### Why and how

The only thing that differs between the old and new design-system builds is the styled‑system engine, so the meaningful comparison is the **styling work the library performs on every render**. `<Box>` is the base primitive nearly every component builds on; on each render it composes **13 styled‑system parsers** and applies them to props:

```
compose(width, display, height, maxHeight, maxWidth, minHeight, minWidth,
        size, space, textAlign, borderRadius, boxShadow, overflow)(props)
```

The benchmark reproduces that exact composition and feeds it a heavy, **fully‑responsive** `<Box>` props object using the design-system's **real theme scales** (5 breakpoints `[32,40,48,64,80]em`, `radii [0,2,6]`, space/sizes/shadows). Array values force each parser to emit per‑breakpoint media queries — the heaviest realistic call the library makes.

- **Tool:** [`@soroush.tech/bench`](https://www.npmjs.com/package/@soroush.tech/bench) (mitata‑based), run from npm.
- **Isolation:** CPU/RAM‑pinned Docker sandbox — 1 CPU (`--cpus 1 --cpuset-cpus 0`), 512 MB with swap off — so numbers are low‑noise and reproducible on the same host.
- **Method:** GC before every iteration, 1000‑iteration warmup, **median of 3 rounds**.
- **Both sides from npm** (installed side‑by‑side under aliases): original `styled-system@5.1.5` vs ours `@soroush.tech/styled-system@5.6.0`.

### Result

| case | avg | p75 | gc/iter | vs fastest |
| :--- | ---: | ---: | ---: | ---: |
| ours — @soroush.tech/styled-system@5.6.0 | 722 µs | 1.54 ms | 5.25 ms | fastest |
| orig — styled-system@5.1.5 (jxnblk) | 851 µs | 1.55 ms | 5.68 ms | +17.9% |

- **~15% faster** on the design-system's styling hot path — the original engine is **+17.9% slower** per parse. Consistent across settled rounds (round 2: 1007 vs 1210 µs; round 3: 722 vs 851 µs).
- **Tail latency tied** — p75 is 1.54 vs 1.55 ms; the win is in the typical case, not just the average.
- **Slightly more memory** — the fork allocates **+5.3%** heap per iteration (60.6 vs 57.5 KB); GC time is marginally lower, so it nets out.

**Net:** meaningfully faster per‑render styling with equal tail latency, at the cost of ~5% more transient allocation per parse.

_Caveats: this measures the styled‑system parsing that dominates render cost (not a full React SSR render), which is the only thing differing between the two builds — so it isolates the real delta. Absolute µs figures are host‑specific; the **ratio** is the portable result._

## Risk

Low. Runtime API is compatible with `styled-system@5`, components are unchanged, and both TypeScript packages type‑check to zero errors with no config workarounds. Rollback is a one‑line revert of the dependency alias.

# Bench source
```js

  // pcln-design-system <Box> styling hot path — ORIGINAL styled-system vs OUR fork.                                                                                                                                                             
  //                                                                                                                                                                                                                                             
  // Box is the base primitive nearly every design-system component builds on. On                                                                                                                                                                
  // every render it composes these 13 styled-system parsers and applies them to                                                                                                                                                                 
  // props. This measures that exact work under the original engine                                                                                                                                                                              
  // (styled-system@5.1.5, jxnblk) vs ours (@soroush.tech/styled-system@5.6.0),                                                                                                                                                                  
  // using pcln-design-system's real theme scales and responsive Box props (array                                                                                                                                                                
  // values force per-breakpoint media-query emission across the DS's 5 breakpoints).                                                                                                                                                            
  //                                                                                                                                                                                                                                             
  //   npx '@soroush.tech/bench' ./design-system-box.bench.ts --md                                                                                                                                                                               
                                                                                                                                                                                                                                                 
  // pcln-design-system theme scales (breakpoints [32,40,48,64,80]em, radii [0,2,6]).                                                                                                                                                            
  const theme = {                                                                                                                                                                                                                                
    breakpoints: ['32em', '40em', '48em', '64em', '80em'],                                                                                                                                                                                       
    space: [0, 4, 8, 16, 32, 64, 128, 256].map((n) => n + 'px'),                                                                                                                                                                                 
    sizes: [16, 32, 64, 128, 256, 512],                                                                                                                                                                                                          
    radii: [0, 2, 6],                                                                                                                                                                                                                            
    shadows: { sm: '0 1px 2px rgba(0,0,0,.2)', lg: '0 8px 24px rgba(0,0,0,.3)' },                                                                                                                                                                
  }                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                 
  // A heavy but realistic <Box>: most props responsive so each parser emits                                                                                                                                                                     
  // media queries at every breakpoint.                                                                                                                                                                                                          
  const props = {                                                                                                                                                                                                                                
    theme,                                                                                                                                                                                                                                       
    width: [1, 1 / 2, 1 / 3, 1 / 4],                                                                                                                                                                                                             
    m: [1, 2, 3, 4],                                                                                                                                                                                                                             
    mt: [0, 1, 2],                                                                                                                                                                                                                               
    p: [4, 3, 2],                                                                                                                                                                                                                                
    px: [2, 3],                                                                                                                                                                                                                                  
    display: ['block', 'flex', 'inline-block'],                                                                                                                                                                                                  
    height: [64, 128, 256],                                                                                                                                                                                                                      
    minHeight: [32, 64],                                                                                                                                                                                                                         
    maxHeight: [128, 256],                                                                                                                                                                                                                       
    minWidth: [16, 32],                                                                                                                                                                                                                          
    maxWidth: [256, 512],                                                                                                                                                                                                                        
    size: [32, 64],                                                                                                                                                                                                                              
    textAlign: ['left', 'center', 'right'],                                                                                                                                                                                                      
    borderRadius: [1, 2],                                                                                                                                                                                                                        
    boxShadow: ['sm', 'lg'],                                                                                                                                                                                                                     
    overflow: ['hidden', 'auto'],                                                                                                                                                                                                                
  }                                                                                                                                                                                                                                              
                                       // Box's exact composition (packages/core/src/Box/Box.tsx).                                                                                                                                                                                    
  const BOX_PARSERS = [                                                                                                                                                                                                                          
    'width',                                                                                                                                                                                                                                     
    'display',                                                                                                                                                                                                                                   
    'height',                                                                                                                                                                                                                                    
    'maxHeight',                                                                                                                                                                                                                                 
    'maxWidth',                                                                                                                                                                                                                                  
    'minHeight',                                                                                                                                                                                                                                 
    'minWidth',                                                                                                                                                                                                                                  
    'size',                                                                                                                                                                                                                                      
    'space',                                                                                                                                                                                                                                     
    'textAlign',                                                                                                                                                                                                                                 
    'borderRadius',                                                                                                                                                                                                                              
    'boxShadow',                                                                                                                                                                                                                                 
    'overflow',                                                                                                                                                                                                                                  
  ]                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                 
  // compose() once per module (setup, not the measured job); each measured call is                                                                                                                                                              
  // a single parse of the maximal props — exactly what Box does per render.                                                                                                                                                                     
  const cache = new WeakMap<object, (p: unknown) => unknown>()                                                                                                                                                                                   
  const boxParser = (mod: Record<string, unknown>) => {                                                                                                                                                                                          
    let parser = cache.get(mod)                                                                                                                                                                                                                  
    if (!parser) {                                                                                                                                                                                                                               
      const fns = BOX_PARSERS.map((n) => mod[n]).filter((f) => typeof f === 'function')                                                                                                                                                          
      parser = (mod.compose as (...f: unknown[]) => (p: unknown) => unknown)(...fns)                                                                                                                                                             
      cache.set(mod, parser)                                                                                                                                                                                                                     
    }                                                                                                                                                                                                                                            
    return parser                                                                                                                                                                                                                                
  }                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                 
  export default {                                                                                                                                                                                                                               
    name: 'pcln-design-system <Box> styling',                                                                                                                                                                                                    
    packages: {                                                                                                                                                                                                                                  
      ours: '@soroush.tech/styled-system@5.6.0',                                                                                                                                                                                                 
      orig: 'styled-system@5.1.5',                                                                                                                                                                                                               
    },                                                                                                                                                                                                                                           
    cases: {                                                                                                                                                                                                                                     
      'ours (fork 5.6.0)': ({ modules }: { modules: Record<string, Record<string, unknown>> }) =>                                                                                                                                                
        boxParser(modules.ours)(props),                                                                                                                                                                                                          
      'orig (jxnblk 5.1.5)': ({ modules }: { modules: Record<string, Record<string, unknown>> }) =>                                                                                                                                              
        boxParser(modules.orig)(props),                                                                                                                                                                                                          
    },                                                                                                                                                                                                                                           
    options: { gc: 'inner', rounds: 3, warmup: 1000 },                                                                                                                                                                                           
  }                   
  ```